### PR TITLE
Fix some typedef issues and comments. Move enums out of d.ts

### DIFF
--- a/src/Calculator.ts
+++ b/src/Calculator.ts
@@ -1,5 +1,6 @@
 import { R4 } from '@ahryman40k/ts-fhir-types';
-import { ExecutionResult, CalculationOptions, FinalResult, Relevance, PopulationType } from './types/Calculator';
+import { ExecutionResult, CalculationOptions } from './types/Calculator';
+import { FinalResult, Relevance, PopulationType } from './types/Enums';
 
 /**
  * Calculate measure against a set of patients. Returning detailed results for each patient and population group.

--- a/src/types/Calculator.d.ts
+++ b/src/types/Calculator.d.ts
@@ -1,4 +1,5 @@
 import { R4 } from '@ahryman40k/ts-fhir-types';
+import { PopulationType, FinalResult, Relevance } from './Enums';
 
 /**
  * Options for calculation.
@@ -38,9 +39,15 @@ interface DetailedPopulationGroupResult {
   groupId: string;
   /** Index of this stratifier if it is a stratified result. */
   strataId?: string;
-  /** Clause results for every CQL clause. */
+  /**
+   * Clause results for every CQL/ELM logic clause.
+   * Each piece of logic (ex. `and`, `retrieve`, `before`, etc.) will have a result.
+   */
   clauseResults?: ClauseResult[];
-  /** Statement results for every CQL define statement. */
+  /**
+   * Statement results for every CQL define statement. Each `define "StatementName":`
+   * in the CQL logic will have a result.
+   */
   statementResults: StatementResult[];
   /** Results for each population in this group. */
   populationResults?: PopulationResult[];
@@ -49,7 +56,8 @@ interface DetailedPopulationGroupResult {
 }
 
 /**
- * Detailed results for an individual CQL clause.
+ * Detailed results for an individual CQL/ELM clause. A clause is an individual piece of logic.
+ * For example: `and`, `before`, `or`.
  */
 interface ClauseResult {
   /** Name of library this clause resides in */
@@ -65,14 +73,15 @@ interface ClauseResult {
 }
 
 /**
- * Detailed result for a CQL define statement.
+ * Detailed result for a CQL define statement. This is any `define "StatementName":` in the
+ * calculated CQL.
  */
 interface StatementResult {
-  /** Name of library this clause resides in */
+  /** Name of library this statement resides in */
   libraryName: string;
-  /** Name of statement this clause resides in */
+  /** Name of statement */
   statementName: string;
-  /** LocalId of clause */
+  /** LocalId of the root CQL/ELM clause for this statement*/
   localId: string;
   /** Final, processed result of raw calculation */
   final: FinalResult;
@@ -104,55 +113,4 @@ interface EpisodeResults {
   episodeId: string;
   /** Results for each population. */
   populationResults: PopulationResult[];
-}
-
-/**
- * Enum for population types. Matching http://hl7.org/fhir/valueset-measure-population.html
- */
-export enum PopulationType {
-  IPP = 'initial-population',
-  DENOM = 'denominator',
-  DENEX = 'denominator-exclusion',
-  DENEXCP = 'denominator-exception',
-  NUMER = 'numerator',
-  NUMEX = 'numerator-exclusion',
-  MSRPOPL = 'measure-population',
-  MSRPOPLEX = 'measure-population-exclusion',
-  OBSERV = 'measure-observation'
-}
-
-/**
- * Final result for a clause or statement.
- *
- * 'NA' - Not applicable. This statement is not relevant to any population calculation in this population_set. Common
- *   for unused library statements or statements only used for other population sets.
- *   !!!IMPORTANT NOTE!!! All define function statements are marked 'NA' since we don't have a strategy for
- *        highlighting or coverage when it comes to functions.
- *
- * 'UNHIT' - This statement wasn't hit. This is most likely because the statement was not relevant to population
- *     calculation for this patient. i.e. 'FALSE' in the the `statement_relevance` map.
- *
- * 'TRUE' - This statement is relevant and has a truthy result.
- *
- * 'FALSE' - This statement is relevant and has a falsey result.
- */
-export enum FinalResult {
-  NA = 'NA',
-  UNHIT = 'UNHIT',
-  TRUE = 'TRUE',
-  FALSE = 'FALSE'
-}
-
-/**
- * 'NA' - Not applicable. This statement is not relevant to any population calculation in this population_set. Common
- *   for unused library statements or statements only used for other population sets.
- *
- * 'FALSE' - This statement is not relevant to any of this patient's population inclusion calculations.
- *
- * 'TRUE' - This statement is relevant for one or more of the population inclusion calculations.
- */
-export enum Relevance {
-  NA = 'NA',
-  TRUE = 'TRUE',
-  FALSE = 'FALSE'
 }

--- a/src/types/ELMTypes.d.ts
+++ b/src/types/ELMTypes.d.ts
@@ -68,6 +68,8 @@ export interface ELMStatement {
   /** Clause id. This is used to reference logic to the annotation structure. */
   localId?: string;
   /** Locator in the original CQL file. Only exists if compiled with this info. */
+  locator?: string;
+  /** Name of the statement. */
   name: string;
   /** The context of this statement. Usually 'Patient'. */
   context: string;

--- a/src/types/Enums.ts
+++ b/src/types/Enums.ts
@@ -1,0 +1,50 @@
+/**
+ * Enum for population types. Matching http://hl7.org/fhir/valueset-measure-population.html
+ */
+export enum PopulationType {
+  IPP = 'initial-population',
+  DENOM = 'denominator',
+  DENEX = 'denominator-exclusion',
+  DENEXCP = 'denominator-exception',
+  NUMER = 'numerator',
+  NUMEX = 'numerator-exclusion',
+  MSRPOPL = 'measure-population',
+  MSRPOPLEX = 'measure-population-exclusion',
+  OBSERV = 'measure-observation'
+}
+
+/**
+ * Final result for a clause or statement.
+ *
+ * 'NA' - Not applicable. This statement is not relevant to any population calculation in this population_set. Common
+ *   for unused library statements or statements only used for other population sets.
+ *   !!!IMPORTANT NOTE!!! All define function statements are marked 'NA' since we don't have a strategy for
+ *        highlighting or coverage when it comes to functions.
+ *
+ * 'UNHIT' - This statement wasn't hit. This is most likely because the statement was not relevant to population
+ *     calculation for this patient. i.e. 'FALSE' in the the `statement_relevance` map.
+ *
+ * 'TRUE' - This statement is relevant and has a truthy result.
+ *
+ * 'FALSE' - This statement is relevant and has a falsey result.
+ */
+export enum FinalResult {
+  NA = 'NA',
+  UNHIT = 'UNHIT',
+  TRUE = 'TRUE',
+  FALSE = 'FALSE'
+}
+
+/**
+ * 'NA' - Not applicable. This statement is not relevant to any population calculation in this population_set. Common
+ *   for unused library statements or statements only used for other population sets.
+ *
+ * 'FALSE' - This statement is not relevant to any of this patient's population inclusion calculations.
+ *
+ * 'TRUE' - This statement is relevant for one or more of the population inclusion calculations.
+ */
+export enum Relevance {
+  NA = 'NA',
+  TRUE = 'TRUE',
+  FALSE = 'FALSE'
+}


### PR DESCRIPTION
- A few comments have added clarification.
- Added a missing item from an ELM structure definition.
- Moved Enums to their own file that is not a d.ts file. They need to be in a .ts to be compiled and used.