### PR TITLE
Add basic CLI to call calculate functions with command line args

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1600,6 +1600,11 @@
         "delayed-stream": "~1.0.0"
       }
     },
+    "commander": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.1.0.tgz",
+      "integrity": "sha512-wl7PNrYWd2y5mp1OK/LhTlv8Ff4kQJQRXXAvF+uU/TPNiVJUxZLRYGj/B0y/lPGAVcSbJqH2Za/cvHmrPMC8mA=="
+    },
     "component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build/*"
   ],
   "dependencies": {
+    "commander": "^6.1.0",
     "cql-exec-fhir": "^1.3.1",
     "cql-execution": "^1.4.3"
   },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,21 @@
+import { R4 } from '@ahryman40k/ts-fhir-types';
+import { program } from 'commander';
+import fs from 'fs';
+import path from 'path';
+import { calculate } from './Calculator';
+
+program
+  .requiredOption('-m, --measure-bundle <measure-bundle>', 'path to measure bundle')
+  .requiredOption('-p, --patient-bundle <patient-bundle>', 'path to  patient bundle')
+  .parse(process.argv);
+
+function parseBundle(filePath: string): R4.IBundle {
+  const contents = fs.readFileSync(filePath, 'utf8');
+  return JSON.parse(contents) as R4.IBundle;
+}
+
+const measureBundle = parseBundle(path.resolve(program.measureBundle));
+const patientBundle = parseBundle(path.resolve(program.patientBundle));
+
+const result = calculate(measureBundle, [patientBundle], {});
+console.log(JSON.stringify(result, null, 2));


### PR DESCRIPTION
Usage: `ts-node src/cli.ts -m path/to/measure/bundle -p path/to/patient/bundle`

Output is just the return result of the `calculate` function stringified to the console. To write it to a file, add `> output.json` or something to the end of the above command.