### PR TITLE
Html annotation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,4 @@
+# Summary
+## New behavior
+## Code changes
+# Testing guidance

--- a/package-lock.json
+++ b/package-lock.json
@@ -1776,6 +1776,15 @@
         "@types/node": "*"
       }
     },
+    "@types/handlebars": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@types/handlebars/-/handlebars-4.1.0.tgz",
+      "integrity": "sha512-gq9YweFKNNB1uFK71eRqsd4niVkXrxHugqWFQkeLRJvGjnxsLr16bYtcsG4tOFwmYi0Bax+wCkbf1reUfdl4kA==",
+      "dev": true,
+      "requires": {
+        "handlebars": "*"
+      }
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
@@ -2752,6 +2761,29 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+    },
+    "copyfiles": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/copyfiles/-/copyfiles-2.4.0.tgz",
+      "integrity": "sha512-yGjpR3yjQdxccW8EcJ4a7ZCA6wGER6/Q2Y+b7bXbVxGeSHBf93i9d7MzTsx+VV1CpMKQa3v4ThZfXBcltMzl0w==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.5",
+        "minimatch": "^3.0.3",
+        "mkdirp": "^1.0.4",
+        "noms": "0.0.0",
+        "through2": "^2.0.1",
+        "untildify": "^4.0.0",
+        "yargs": "^15.3.1"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
+        }
+      }
     },
     "core-js-compat": {
       "version": "3.6.5",
@@ -3852,6 +3884,25 @@
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "dev": true,
       "optional": true
+    },
+    "handlebars": {
+      "version": "4.7.6",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
+      "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
+      "requires": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
+        "wordwrap": "^1.0.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
+      }
     },
     "har-schema": {
       "version": "2.0.0",
@@ -6125,6 +6176,11 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
+    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -6171,6 +6227,42 @@
       "version": "1.1.64",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.64.tgz",
       "integrity": "sha512-Iec8O9166/x2HRMJyLLLWkd0sFFLrFNy+Xf+JQfSQsdBJzPcHpNl3JQ9gD4j+aJxmCa25jNsIbM4bmACtSbkSg=="
+    },
+    "noms": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/noms/-/noms-0.0.0.tgz",
+      "integrity": "sha1-2o69nzr51nYJGbJ9nNyAkqczKFk=",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "readable-stream": "~1.0.31"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
+      }
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -6502,8 +6594,7 @@
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "optional": true
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "progress": {
       "version": "2.0.3",
@@ -6590,7 +6681,6 @@
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "optional": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -7288,7 +7378,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "optional": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -7411,6 +7500,16 @@
       "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
       "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
       "dev": true
+    },
+    "through2": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "dev": true,
+      "requires": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
     },
     "tmpl": {
       "version": "1.0.4",
@@ -7591,6 +7690,12 @@
       "resolved": "https://registry.npmjs.org/ucum/-/ucum-0.0.7.tgz",
       "integrity": "sha1-zQfv5VmaF+9/syd3i/g46DLf0aQ="
     },
+    "uglify-js": {
+      "version": "3.11.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.11.3.tgz",
+      "integrity": "sha512-wDRziHG94mNj2n3R864CvYw/+pc9y/RNImiTyrrf8BzgWn75JgFSwYvXrtZQMnMnOp/4UTrf3iCSQxSStPiByA==",
+      "optional": true
+    },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
@@ -7662,6 +7767,12 @@
         }
       }
     },
+    "untildify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
+      "dev": true
+    },
     "upath": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
@@ -7690,8 +7801,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "optional": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
       "version": "8.3.1",
@@ -7824,6 +7934,11 @@
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
     },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+    },
     "wrap-ansi": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
@@ -7940,6 +8055,12 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "dev": true
     },
     "y18n": {

--- a/package.json
+++ b/package.json
@@ -12,16 +12,19 @@
     "commander": "^6.1.0",
     "cql-exec-fhir": "1.5.0-beta.1",
     "cql-execution": "2.0.0-beta.1",
+    "handlebars": "^4.7.6",
     "moment": "^2.29.0",
     "uuid": "^8.3.1"
   },
   "devDependencies": {
     "@ahryman40k/ts-fhir-types": "^4.0.32",
+    "@types/handlebars": "^4.1.0",
     "@types/jest": "^26.0.5",
     "@types/node": "^14.0.23",
     "@types/uuid": "^8.3.0",
     "@typescript-eslint/eslint-plugin": "^3.2.0",
     "@typescript-eslint/parser": "^3.2.0",
+    "copyfiles": "^2.4.0",
     "eslint": "^7.5.0",
     "eslint-config-prettier": "^6.11.0",
     "jest": "^26.1.0",
@@ -30,15 +33,17 @@
     "typescript": "^3.9.7"
   },
   "scripts": {
-    "build": "rm -rf ./build && tsc",
+    "build": "rm -rf ./build && tsc && npm run copy-templates",
     "build:watch": "rm -rf ./build && tsc -w",
     "lint": "tsc && eslint \"**/*.{js,ts}\"",
     "lint:fix": "tsc --noEmit && eslint \"**/*.{js,ts}\" --quiet --fix",
     "prettier": "prettier --check \"**/*.{js,ts}\"",
     "prettier:fix": "prettier --write \"**/*.{js,ts}\"",
     "test": "jest",
+    "test:watch": "jest --watchAll",
     "check": "npm run test && npm run lint && npm run prettier",
-    "prepare": "npm run build"
+    "prepare": "npm run build",
+    "copy-templates": "copyfiles -u 1 ./src/templates/*.hbs ./build/"
   },
   "repository": {
     "type": "git",

--- a/src/Calculator.ts
+++ b/src/Calculator.ts
@@ -162,6 +162,7 @@ export function calculateMeasureReports(
       // add narrative for relevant clauses
       if (detail.html) {
         report.text = {
+          status: R4.NarrativeStatusKind._generated,
           div: detail.html
         };
       }

--- a/src/Calculator.ts
+++ b/src/Calculator.ts
@@ -2,14 +2,12 @@ import { R4 } from '@ahryman40k/ts-fhir-types';
 import { ExecutionResult, CalculationOptions } from './types/Calculator';
 import { PopulationType } from './types/Enums';
 import { v4 as uuidv4 } from 'uuid';
-
-// import { PatientSource } from 'cql-exec-fhir';
 import * as cql from './types/CQLTypes';
 import * as Execution from './Execution';
-import { dumpObject } from './DebugHelper';
-
+import { dumpHTML, dumpObject } from './DebugHelper';
 import * as CalculatorHelpers from './CalculatorHelpers';
 import * as ResultsHelpers from './ResultsHelpers';
+import { generateHTML } from './HTMLGenerator';
 
 /**
  * Calculate measure against a set of patients. Returning detailed results for each patient and population group.
@@ -104,6 +102,12 @@ export function calculate(
         true
       );
 
+      if (options.calculateHTML) {
+        const html = generateHTML(elmLibraries, detailedGroupResult.statementResults, detailedGroupResult.groupId);
+        detailedGroupResult.html = html;
+        dumpHTML(html, `clauses-${detailedGroupResult.groupId}.html`);
+      }
+
       // add this group result to the patient results
       patientExecutionResult.detailedResults?.push(detailedGroupResult);
     });
@@ -155,6 +159,13 @@ export function calculateMeasureReports(
     // create group population counts from result's detailedResults (yes/no->1/0)
     report.group = [];
     result?.detailedResults?.forEach(detail => {
+      // add narrative for relevant clauses
+      if (detail.html) {
+        report.text = {
+          div: detail.html
+        };
+      }
+
       // TODO: check the measure definition for stratification to determine whether to add group.stratiier
       // if yes, add stratifier with population copied into. Set counts to 0 if the result for the stratifier is false
       const group = <R4.IMeasureReport_Group>{};
@@ -263,7 +274,7 @@ export function calculateRaw(
   }
 }
 
-// // Code->Display https://terminology.hl7.org/1.0.0/CodeSystem-measure-population.html
+// Code->Display https://terminology.hl7.org/1.0.0/CodeSystem-measure-population.html
 const POPULATION_DISPLAY_MAP = {
   [PopulationType.IPP]: 'Initial Population',
   [PopulationType.DENOM]: 'Denominator',

--- a/src/Calculator.ts
+++ b/src/Calculator.ts
@@ -156,15 +156,20 @@ export function calculateMeasureReports(
     const measure = measureEntry?.resource as R4.IMeasure;
     report.measure = measure.url || 'UnknownMeasure'; // or some other default?
 
+    // add narrative if specified
+    if (options.calculateHTML) {
+      report.text = {
+        status: R4.NarrativeStatusKind._generated,
+        div: ''
+      };
+    }
+
     // create group population counts from result's detailedResults (yes/no->1/0)
     report.group = [];
     result?.detailedResults?.forEach(detail => {
       // add narrative for relevant clauses
-      if (detail.html) {
-        report.text = {
-          status: R4.NarrativeStatusKind._generated,
-          div: detail.html
-        };
+      if (report.text && detail.html) {
+        report.text.div += detail.html;
       }
 
       // TODO: check the measure definition for stratification to determine whether to add group.stratiier

--- a/src/DebugHelper.ts
+++ b/src/DebugHelper.ts
@@ -2,6 +2,20 @@ import { ELM } from './types/ELMTypes';
 import { ValueSetMap } from './types/CQLTypes';
 import fs from 'fs';
 
+export function dumpHTML(htmlString: string, nameInDebugFolder: string): void {
+  // create debug folder if it doesnt exist
+  if (!fs.existsSync('debug')) {
+    fs.mkdirSync('debug', { recursive: true });
+  }
+
+  // delete old copy
+  if (fs.existsSync(`debug/${nameInDebugFolder}`)) {
+    fs.unlinkSync(`debug/${nameInDebugFolder}`);
+  }
+
+  fs.writeFileSync(`debug/${nameInDebugFolder}`, htmlString);
+}
+
 export function dumpELMJSONs(elmJSONs: ELM[]): void {
   // create folder if it doesn't exist
   if (!fs.existsSync('debug/elm')) {

--- a/src/HTMLGenerator.ts
+++ b/src/HTMLGenerator.ts
@@ -1,0 +1,55 @@
+import { Annotation, ELM } from './types/ELMTypes';
+import Handlebars from 'handlebars';
+import fs from 'fs';
+import path from 'path';
+import { StatementResult } from './types/Calculator';
+import { Relevance } from './types/Enums';
+
+const mainTemplate = fs.readFileSync(path.join(__dirname, './templates/main.hbs'), 'utf8');
+const clauseTemplate = fs.readFileSync(path.join(__dirname, './templates/clause.hbs'), 'utf8');
+
+const main = Handlebars.compile(mainTemplate);
+Handlebars.registerPartial('clause', clauseTemplate);
+
+// text values in annotations show up as an array of strings
+Handlebars.registerHelper('concat', s => s.join(''));
+
+/**
+ * Generate HTML structure based on ELM annotations in relevant statements
+ *
+ * @param elmLibraries main ELM and dependencies to lookup statements
+ * @param statementResults StatementResult array from calculation
+ * @param groupId ID of population group
+ */
+export function generateHTML(elmLibraries: ELM[], statementResults: StatementResult[], groupId: string): string {
+  const relevantStatements = statementResults.filter(s => s.relevance === Relevance.TRUE);
+
+  // assemble array of annotations to be templated to HTML
+  let annotations: Annotation[] = [];
+  relevantStatements.forEach(s => {
+    const matchingLibrary = elmLibraries.find(e => e.library.identifier.id === s.libraryName);
+    if (!matchingLibrary) {
+      throw new Error(`Could not find library ${s.libraryName} for statement ${s.statementName}`);
+    }
+
+    const matchingExpression = matchingLibrary.library.statements.def.find(e => e.name === s.statementName);
+    if (!matchingExpression) {
+      throw new Error(`No statement ${s.statementName} found in library ${s.libraryName}`);
+    }
+
+    if (matchingExpression.annotation) {
+      annotations = annotations.concat(matchingExpression.annotation);
+    }
+  });
+
+  let result = `<div><h2>Population Group: ${groupId}</h2>`;
+
+  // generate HTML clauses using hbs template for each annotation
+  annotations.forEach(a => {
+    const res = main({ groupId, ...a.s });
+    result += res;
+  });
+
+  result += '</div>';
+  return result;
+}

--- a/src/HTMLGenerator.ts
+++ b/src/HTMLGenerator.ts
@@ -25,7 +25,7 @@ export function generateHTML(elmLibraries: ELM[], statementResults: StatementRes
   const relevantStatements = statementResults.filter(s => s.relevance === Relevance.TRUE);
 
   // assemble array of annotations to be templated to HTML
-  let annotations: Annotation[] = [];
+  const annotations: Annotation[] = [];
   relevantStatements.forEach(s => {
     const matchingLibrary = elmLibraries.find(e => e.library.identifier.id === s.libraryName);
     if (!matchingLibrary) {
@@ -38,7 +38,7 @@ export function generateHTML(elmLibraries: ELM[], statementResults: StatementRes
     }
 
     if (matchingExpression.annotation) {
-      annotations = annotations.concat(matchingExpression.annotation);
+      annotations.push(...matchingExpression.annotation);
     }
   });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,7 +30,8 @@ if (program.outputType == 'raw') {
   result = calculateMeasureReports(measureBundle, patientBundles, {
     measurementPeriodStart: '2019-01-01',
     measurementPeriodEnd: '2019-12-31',
-    calculateSDEs: true
+    calculateSDEs: true,
+    calculateHTML: true
   });
 }
 console.log(JSON.stringify(result, null, 2));

--- a/src/templates/clause.hbs
+++ b/src/templates/clause.hbs
@@ -1,0 +1,10 @@
+<span{{#if r}} data-ref-id="{{r}}"{{/if}}>
+{{~#if value ~}}
+{{ concat value }}
+{{~/if ~}}
+{{~#if s~}}
+{{~#each s~}}
+{{> clause ~}}
+{{~/each ~}}
+{{~/if~}}
+</span>

--- a/src/templates/main.hbs
+++ b/src/templates/main.hbs
@@ -1,0 +1,5 @@
+<pre style='tab-size: 2'>
+<code>
+{{> clause}}
+</code>
+</pre>

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -21,6 +21,8 @@ export interface CalculationOptions {
   patientSource?: any;
   /** Include SDEs in calculation */
   calculateSDEs?: boolean;
+  /** Include HTML structure for highlighting */
+  calculateHTML?: boolean;
 }
 
 /**
@@ -91,6 +93,8 @@ export interface DetailedPopulationGroupResult {
   populationResults?: PopulationResult[];
   /** If this is an episode of care measure. Each episode found in IPP will have results. */
   episodeResults?: EpisodeResults[];
+  /** HTML markup of the clauses */
+  html?: string;
 }
 
 /**

--- a/src/types/ELMTypes.ts
+++ b/src/types/ELMTypes.ts
@@ -9,6 +9,7 @@ export interface ELM {
  * this level of the ELM tree.
  */
 export interface ELMLibrary {
+  annotation?: any;
   /** Identifier for this library. */
   identifier: ELMIdentifier;
   /** Identifier for the version of ELM. */
@@ -42,6 +43,7 @@ export interface ELMLibrary {
 export interface ELMIdentifier {
   id: string;
   version: string;
+  system?: string;
 }
 
 /**
@@ -79,7 +81,7 @@ export interface ELMStatement {
    * Annotation structure for this statement. Can be used to build the CQL file with
    * reference indicators to the corresponding logic for each clause.
    */
-  annotation?: any[];
+  annotation?: Annotation[];
   /** The executable expression for this statement. */
   expression?: any;
   /** Type of this statement. Will be 'FunctionDef' if it is a function. */
@@ -123,4 +125,21 @@ export interface StatementDependency {
 export interface StatementReference {
   libraryId: string;
   statementName: string;
+}
+
+/**
+ * Annotation on an ELM expression
+ */
+export interface Annotation {
+  type: string;
+  s: AnnotationStatement;
+}
+
+/**
+ * Recursive statement object for an ELM Annotation
+ */
+export interface AnnotationStatement {
+  r?: string;
+  s?: AnnotationStatement[];
+  value?: string[];
 }

--- a/test/ELMDependencyHelper.test.ts
+++ b/test/ELMDependencyHelper.test.ts
@@ -1,10 +1,5 @@
 import * as ELMDependencyHelper from '../src/ELMDependencyHelper';
-import { readFileSync } from 'fs';
-import { ELM } from '../src/types/ELMTypes';
-
-function getELMFixture(path: string): ELM {
-  return JSON.parse(readFileSync(`test/fixtures/${path}`).toString());
-}
+import { getELMFixture } from './helpers/testHelpers';
 
 describe('ELMDependencyHelper', () => {
   describe('buildStatementDependencyMaps', () => {

--- a/test/HTMLGenerator.test.ts
+++ b/test/HTMLGenerator.test.ts
@@ -1,0 +1,55 @@
+import { generateHTML } from '../src/HTMLGenerator';
+import { StatementResult } from '../src/types/Calculator';
+import { ELM, ELMStatement } from '../src/types/ELMTypes';
+import { FinalResult, Relevance } from '../src/types/Enums';
+import { getELMFixture, getHTMLFixture } from './helpers/testHelpers';
+
+describe('HTMLGenerator', () => {
+  let elm = <ELM>{};
+  let simpleExpression: ELMStatement | undefined;
+  let statementResults: StatementResult[];
+  beforeEach(() => {
+    elm = getELMFixture('elm/CMS723v0.json');
+    simpleExpression = elm.library.statements.def.find(d => d.localId === '119'); // Simple expression for Denominator
+
+    statementResults = [
+      {
+        statementName: simpleExpression?.name ?? '',
+        libraryName: elm.library.identifier.id,
+        final: FinalResult.TRUE,
+        relevance: Relevance.TRUE
+      }
+    ];
+  });
+
+  test('simple HTML generation', () => {
+    // Ignore tabs and new lines
+    const expectedHTML = getHTMLFixture('simpleAnnotation.html').replace(/\s/g, '');
+    const res = generateHTML([elm], statementResults, 'test');
+
+    expect(res.replace(/\s/g, '')).toEqual(expectedHTML);
+  });
+
+  test('no library found should error', () => {
+    elm.library.identifier.id = 'NOT REAL';
+
+    expect(() => {
+      generateHTML([elm], statementResults, 'test');
+    }).toThrowError();
+  });
+
+  test('no statement found should error', () => {
+    const badStatementResults = [
+      {
+        statementName: 'NOT REAL',
+        libraryName: elm.library.identifier.id,
+        final: FinalResult.TRUE,
+        relevance: Relevance.TRUE
+      }
+    ];
+
+    expect(() => {
+      generateHTML([elm], badStatementResults, 'test');
+    }).toThrowError();
+  });
+});

--- a/test/MeasureHelpers.test.ts
+++ b/test/MeasureHelpers.test.ts
@@ -1,12 +1,8 @@
 import * as MeasureHelpers from '../src/MeasureHelpers';
-import { readFileSync } from 'fs';
 import { ELM } from '../src/types/ELMTypes';
 import { R4 } from '@ahryman40k/ts-fhir-types';
 import { PopulationType } from '../src/types/Enums';
-
-function getJSONFixture(path: string): any {
-  return JSON.parse(readFileSync(`test/fixtures/${path}`).toString());
-}
+import { getJSONFixture } from './helpers/testHelpers';
 
 describe('MeasureHelpers', () => {
   describe('findAllLocalIdsInStatementByName', () => {

--- a/test/fixtures/html/simpleAnnotation.html
+++ b/test/fixtures/html/simpleAnnotation.html
@@ -1,0 +1,25 @@
+<div>
+  <h2>Population Group: test</h2>
+  <pre style='tab-size: 2'>
+    <code>
+      <span data-ref-id="119">
+        <span>define &quot;Denominator&quot;: </span>
+        <span data-ref-id="118">
+          <span data-ref-id="116">
+            <span data-ref-id="101">
+              <span>&quot;Encounter with Atrial Ablation Procedure&quot;</span>
+            </span>
+            <span>union</span>
+            <span data-ref-id="115">
+              <span>&quot;History of Atrial FibrillationFlutter&quot;</span>
+            </span>
+          </span>
+          <span>union</span>
+          <span data-ref-id="117">
+            <span>&quot;Current Diagnosis Atrial FibrillationFlutter&quot;</span>
+          </span>
+        </span>
+      </span>
+    </code>
+  </pre>
+</div>

--- a/test/helpers/testHelpers.ts
+++ b/test/helpers/testHelpers.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'fs';
+import { ELM } from '../../src/types/ELMTypes';
+
+export function getELMFixture(path: string): ELM {
+  return JSON.parse(readFileSync(`test/fixtures/${path}`).toString());
+}
+
+export function getJSONFixture(path: string): any {
+  return JSON.parse(readFileSync(`test/fixtures/${path}`).toString());
+}
+
+export function getHTMLFixture(path: string): string {
+  return readFileSync(`test/fixtures/html/${path}`, 'utf8');
+}


### PR DESCRIPTION
# Summary

Uses the statementResults processed in #13 to assemble the HTML tree structure that mirrors the ELM annotations for a given statement. Uses the [handlebars](https://handlebarsjs.com/) library to make a recursive template for the annotation. The resulting HTML is put onto the text narrative of the `MeasureReport` resource(s) generated when the `calculateMeasureReports` function is called.

The HTML string is also added to the detailed results for each group and can be calculated using the `calculateHTML` calculation option.

## HTML Example

An annotation on an ELM statement can have 3 relevant properties for this: `r` (reference id), `s` (sub-clause(?), can be recursive), and `value` (array of strings that compose the CQL statement). The algorithm goes roughly as follows:

1) If the object has `value`, then it is a leaf node, and concatenate the contents of `value` into a `<span>`
2) Else, the object should have `r` and `s`. Create a `<span>` with `data-ref-id` equal to the value of `r`
3) Iterate through every child node in `s` and recurse back to 1)

Take the following CQL snippet for example:

``` cql
define "SDE Ethnicity":
  SDE."SDE Ethnicity"
```

The following is the ELM annotation for this statement;

``` JSON
{
  "type": "Annotation",
  "s": {
    "r": "26",
    "s": [
      {
        "value": [
          "define ",
          "\"SDE Ethnicity\"",
          ":\r\n  "
        ]
      },
      {
        "r": "25",
        "s": [
          {
            "r": "24",
            "s": [
              {
                "value": [
                  "SDE"
                ]
              }
            ]
          },
          {
            "value": [
              "."
            ]
          },
          {
            "r": "25",
            "s": [
              {
                "value": [
                  "\"SDE Ethnicity\""
                ]
              }
            ]
          }
        ]
      }
    ]
  }
}
```

Following the above algorithm, this is the desired result:

``` HTML
<span data-ref-id="26">
	<span>define "SDE Ethnicity":
  </span>
	<span data-ref-id="25">
		<span data-ref-id="24">
			<span>SDE</span>
		</span>
		<span>.</span>
		<span data-ref-id="25">
			<span>"SDE Ethnicity"</span>
		</span>
	</span>
</span>
```

## New behavior

* For detailed results, each result can now optionally have an `html` property which is the HTML string of the clause results for that group
* For measure reports, it will optionally attach the html string for the results to the text.div property
* HTML files that are generated are written to the debug folder

## Code changes

* New dependencies and scripts in package.json. Added the `copy-templates` script which moves the `.hbs` templates into the build directory since they won't be picked up by `tsc`
* `HTMLGenerator.ts`: New helper file that generates html structure for a given group/set of statement results
* `calculate` function calls html generator if the calculateHTML calculationOption is provided
* HTML is added to measure report narrative in `calculateMeasureReports` if the option is provided
* `templates` directory containing handlebars templates for the HTML structure
* Added more granular ELM types for annotations 
* Created a testHelpers file for re-usable functionality across all tests
* Added PR template cause why not

# Testing guidance

Run the cli with the output type "reports". This will generate HTML on the MeasureReport narrative as well as dump the html file to the `debug` inspect the contents of both. (I recommend opening the HTML in the actual browser and using the chrome console to look at the structure).

Run the tests with `npm test`

**NOTE**: If you use the VS Code launch debugger to run the CLI, the configuration needs to be updated, since we need the `npm run copy-templates` script to be run. Update the following in your `launch.json`:

```
            "preLaunchTask": "npm: build",
```

The build script will both run`tsc` and copy the template files necessary at runtime

