### PR TITLE
Add support for evaluated resources coming from CQL engine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2807,9 +2807,9 @@
       }
     },
     "cql-execution": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-2.0.0-beta.1.tgz",
-      "integrity": "sha512-GscZH2MTNmJ4ySO5AHR/TDe60mCkdf9l5Hj2LwtjBw36kuiAxGEYh0Yz51LSpMFLu9GOdhdLLf2MASXuEfAqdA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-2.1.0.tgz",
+      "integrity": "sha512-k/6Vm60SCqH+1/RWOrRYNx9DYK9slJAc+wsTZx5Flpu/vRW7rAmRwGRwPalCldDcSvRpdYoAmrWkXu65o32T3A==",
       "requires": {
         "moment": "^2.27.0",
         "ucum": "^0.0.7"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "atob": "^2.1.2",
     "commander": "^6.1.0",
     "cql-exec-fhir": "1.5.0-beta.1",
-    "cql-execution": "2.0.0-beta.1",
+    "cql-execution": "2.1.0",
     "handlebars": "^4.7.6",
     "moment": "^2.29.0",
     "uuid": "^8.3.1"

--- a/src/Calculator.ts
+++ b/src/Calculator.ts
@@ -60,7 +60,8 @@ export function calculate(
     }
     const patientExecutionResult: ExecutionResult = {
       patientId: patient.id,
-      detailedResults: []
+      detailedResults: [],
+      evaluatedResources: rawResults.evaluatedRecords
     };
 
     // Grab statement results for the patient
@@ -273,15 +274,16 @@ export function calculateMeasureReports(
       report.group?.push(group);
     });
 
-    // TODO: create contained evaluatuated resource (contains patient... and population and entity information?)
-    // may eventually need the other bits (all pieces of information that were used in calculation), but we might be able to ignore for now
-    const evalId = uuidv4();
-    const contained: R4.IBundle = {
-      resourceType: 'Bundle',
-      id: evalId,
-      type: R4.BundleTypeKind._collection,
-      entry: []
-    };
+    if (result.evaluatedResources) {
+      result.evaluatedResources.forEach(resource => {
+        const reference: R4.IReference = {
+          reference: `${resource.resourceType}/${resource.id}`
+        };
+        if (!report.evaluatedResource?.find(r => r.reference === reference.reference)) {
+          report.evaluatedResource?.push(reference);
+        }
+      });
+    }
 
     // find this patient's bundle
     const patientBundle = patientBundles.find(patientBundle => {
@@ -295,28 +297,15 @@ export function calculateMeasureReports(
       }
     });
 
-    // if the patient bundle was found add their information to the evaluated resources
+    // if the patient bundle was found add their information to the subject
     if (patientBundle) {
       // grab the measure resource
       const patient = patientBundle.entry?.find(bundleEntry => {
         return bundleEntry.resource?.resourceType === 'Patient';
       })?.resource as R4.IPatient;
 
-      // TODO: (related to above) do we need other entries... List, Encounter, Procedure?
-      const patId = `Patient/${patient?.id}`;
-      contained.entry?.push({
-        fullUrl: patId,
-        resource: patient
-      });
-      report.contained.push(contained);
-
-      // create reference to contained evaluated resource and match ID
-      const evalResourceReference: R4.IReference = {
-        reference: evalId
-      };
-      report.evaluatedResource.push(evalResourceReference);
-
       // create reference to contained patient/subject and match ID
+      const patId = `Patient/${patient?.id}`;
       const subjectReference: R4.IReference = {
         reference: patId
       };
@@ -395,7 +384,7 @@ function addSDE(report: R4.IMeasureReport, measureURL: string, result: Execution
     // add as evaluated resource reference
     report.contained?.push(observation);
     report.evaluatedResource?.push({
-      reference: observation.id
+      reference: `#${observation.id}`
     });
   });
 }

--- a/src/Calculator.ts
+++ b/src/Calculator.ts
@@ -580,6 +580,6 @@ function addScoreObservation(score: R4.IQuantity, measure: R4.IMeasure, report: 
   ];
   report.contained?.push(observationResource);
   report.evaluatedResource?.push({
-    reference: observationResource.id
+    reference: `#${observationResource.id}`
   });
 }

--- a/src/Execution.ts
+++ b/src/Execution.ts
@@ -133,6 +133,9 @@ export function execute(
   const executor = new cql.Executor(lib, codeService, parameters);
   const results = executor.exec(patientSource, executionDateTime);
 
+  // Map evaluated resource from engine to the raw FHIR json
+  results.evaluatedRecords = results.evaluatedRecords.map((r: any) => r._json);
+
   dumpObject(results, 'rawResults.json');
   return { rawResults: results, elmLibraries: elmJSONs, mainLibraryName: rootLibIdentifer.id };
 }

--- a/src/types/CQLTypes.ts
+++ b/src/types/CQLTypes.ts
@@ -19,6 +19,7 @@ export interface Results {
   localIdPatientResultsMap: {
     [patientId: string]: LocalIdResults;
   };
+  evaluatedRecords: any[];
 }
 
 export interface StatementResults {

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -51,6 +51,8 @@ export interface ExecutionResult {
   detailedResults?: DetailedPopulationGroupResult[];
   /** SDE values, if specified for calculation */
   supplementalData?: SDEResult[];
+  /** Resources evaluated during execution */
+  evaluatedResources?: R4.IResourceList[];
 }
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "declaration": true
+    "declaration": true,
+    "sourceMap": true
   }
 }


### PR DESCRIPTION
# Summary

See https://github.com/cqframework/cql-execution/pull/151 for the companion pull request that adds the concept of evaluatedResources to the cql engine.

~DRAFT: We should wait for a new release of cql execution that incorporates the changes in the above PR. Then we can update the dependencies and merge.~

Support for evaluatedResources to the returned MeasureReports. Behavior is modeled after cqf-ruler as a reference. Each resource processed by `cql-execution` is referenced in the `evaluatedResource` array of the MeasureReport using the `ResourceType/id` format.

## New behavior

MeasureReport output type now references evaluated resources

## Code changes

* Assembles list of references in `caluclateMeasureReports` based on the `evaluatedResources` from the engine.
* Cleaned up some code in `calculateMeasureReports`
  * i don't think we need to put anything in the contained resources besides the SDEs/Measure Observation. At least cqf-ruler doesn't. If we reference the resources properly in the evaluatedResource array, I don't think we need to include them in contained.
  * References for the SDEs need to be prefixed with a `#` since they are contained resources, per the FHIR spec.
* Add `sourceMap` to tsconfig to allow for easier debugging in VS code.

# Testing guidance

For the meantime, you will need to link a local clone of [this branch](https://github.com/mgramigna/cql-execution/tree/evaluated-records) to get the proper engine code. Easiest way is to probably change the `cql-execution` dependency in `package.json` to use `file:` and point to a local repo with the `evaluated-records` branch checked out, and re-run npm install.

Run MeasureReport calculation for any measure. You will see additional references in the `evaluatedResource` array, not just the ones for the SDEs if they are calculated. You can cross-reference these with resources in the patient bundle to see what resources they actually are, or use a debugger if that's your thing.

E.g.: EXM130 should have a Patient, Procedure, and Encounter. Below is an example MeasureReport from cqf-ruler. Ours should look similar:

```
{
  "resourceType": "MeasureReport",
  "contained": [
    {
      "resourceType": "Observation",
      "id": "09c4dc68-d1a3-4608-a008-c9ba3feb3998",
      "extension": [
        {
          "url": "http://hl7.org/fhir/StructureDefinition/cqf-measureInfo",
          "extension": [
            {
              "url": "measure",
              "valueCanonical": "http://hl7.org/fhir/us/cqfmeasures/Measure/measure-EXM130-7.3.000"
            },
            {
              "url": "populationId",
              "valueString": "sde-race"
            }
          ]
        }
      ],
      "status": "final",
      "code": {
        "text": "sde-race"
      },
      "valueCodeableConcept": {
        "coding": [
          {
            "system": "urn:oid:2.16.840.1.113883.6.238",
            "code": "2028-9",
            "display": "Asian"
          }
        ]
      }
    },
    {
      "resourceType": "Observation",
      "id": "85be0977-c7cc-4320-af5c-0129ce7b69c4",
      "extension": [
        {
          "url": "http://hl7.org/fhir/StructureDefinition/cqf-measureInfo",
          "extension": [
            {
              "url": "measure",
              "valueCanonical": "http://hl7.org/fhir/us/cqfmeasures/Measure/measure-EXM130-7.3.000"
            },
            {
              "url": "populationId",
              "valueString": "sde-ethnicity"
            }
          ]
        }
      ],
      "status": "final",
      "code": {
        "text": "sde-ethnicity"
      },
      "valueCodeableConcept": {
        "coding": [
          {
            "system": "urn:oid:2.16.840.1.113883.6.238",
            "code": "2135-2",
            "display": "Hispanic or Latino"
          }
        ]
      }
    },
    {
      "resourceType": "Observation",
      "id": "5b7295ce-2482-4b69-8343-f63a57cbda44",
      "extension": [
        {
          "url": "http://hl7.org/fhir/StructureDefinition/cqf-measureInfo",
          "extension": [
            {
              "url": "measure",
              "valueCanonical": "http://hl7.org/fhir/us/cqfmeasures/Measure/measure-EXM130-7.3.000"
            },
            {
              "url": "populationId",
              "valueString": "sde-sex"
            }
          ]
        }
      ],
      "status": "final",
      "code": {
        "text": "sde-sex"
      },
      "valueCodeableConcept": {
        "coding": [
          {
            "code": "M"
          }
        ]
      }
    }
  ],
  "status": "complete",
  "type": "individual",
  "measure": "Measure/measure-EXM130-7.3.000",
  "subject": {
    "reference": "Patient/numer-EXM130"
  },
  "period": {
    "start": "2019-01-01T00:00:00-05:00",
    "end": "2019-12-31T00:00:00-05:00"
  },
  "group": [
    {
      "id": "group-1",
      "population": [
        {
          "code": {
            "coding": [
              {
                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
                "code": "initial-population",
                "display": "Initial Population"
              }
            ]
          },
          "count": 1
        },
        {
          "code": {
            "coding": [
              {
                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
                "code": "numerator",
                "display": "Numerator"
              }
            ]
          },
          "count": 1
        },
        {
          "code": {
            "coding": [
              {
                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
                "code": "denominator",
                "display": "Denominator"
              }
            ]
          },
          "count": 1
        },
        {
          "code": {
            "coding": [
              {
                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
                "code": "denominator-exclusion",
                "display": "Denominator Exclusion"
              }
            ]
          },
          "count": 0
        }
      ],
      "measureScore": {
        "value": 1.0
      }
    }
  ],
  "evaluatedResource": [
    {
      "reference": "#09c4dc68-d1a3-4608-a008-c9ba3feb3998"
    },
    {
      "reference": "#85be0977-c7cc-4320-af5c-0129ce7b69c4"
    },
    {
      "reference": "#5b7295ce-2482-4b69-8343-f63a57cbda44"
    },
    {
      "reference": "#Encounter/numer-EXM130-4"
    },
    {
      "reference": "#Patient/numer-EXM130"
    },
    {
      "reference": "#Procedure/numer-EXM130-1"
    }
  ]
}
```
