### PR TITLE
Add documentation and global installation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,181 @@
-# FHIR Quality Measure Execution and Highliting
+# FHIR Quality Measure Execution and Highlighting
+
+Library for executing FHIR-based Electronic Clinical Quality Measures (eCQMs) written in Clinical Quality Language (CQL)
+
+* [Installation](#installation)
+* [Usage](#usage)
+  * [Module](#module)
+  * [CLI](#cli)
+  * [TypeScript](#typescript)
+* [Local Development](#local-development)
+  * [Prerequisites](#prerequisites)
+  * [Local Installation/Usage](#local-installation%2Fusage)
+  * [Debugging in VS Code](#debugging-in-vs-code)
+  * [Testing](#testing)
+  * [Checks](#checks)
+* [License](#license)
+
+## Installation
+
+`fqm-execution` can be installed into your project with npm:
+
+```
+$ npm install --save https://github.com/projecttacoma/fqm-execution.git
+```
+
+To install the global command line interface (CLI), use npm global installation:
+
+```
+$ npm install -g https://github.com/projecttacoma/fqm-execution.git
+```
+
+## Usage
+
+### Module
+
+#### ES6
+``` JavaScript
+import { Calculator } from 'fqm-execution';
+
+const rawResults = Calculator.calculateRaw(measureBundle, patientBundles, options); // Get raw results from CQL engine for each patient
+const rawResults = Calculator.calculate(measureBundle, patientBundles, options); // Get detailed population results for each patient
+const rawResults = Calculator.calculateMeasureReports(measureBundle, patientBundles, options); // Get individual FHIR MeasureReports for each patient
+```
+
+#### Require
+``` JavaScript
+const { Calculator } = require('fqm-execution');
+
+const rawResults = Calculator.calculateRaw(measureBundle, patientBundles, options); // Get raw results from CQL engine for each patient
+const rawResults = Calculator.calculate(measureBundle, patientBundles, options); // Get detailed population results for each patient
+const rawResults = Calculator.calculateMeasureReports(measureBundle, patientBundles, options); // Get individual FHIR MeasureReports for each patient
+```
+
+### CLI
+
+To run the globally installed CLI (see above), use the global `fqm-exeuction command`
+
+```
+Usage: fqm-execution [options]
+
+Options:
+  -o, --output-type <type>                    type of output, "raw", "detailed", "reports" (default: "detailed")
+  -m, --measure-bundle <measure-bundle>       path to measure bundle
+  -p, --patient-bundles <patient-bundles...>  paths to patient bundle
+  -h, --help                                  display help for command
+```
+
+E.g.
+
+```
+$ fqm-execution -o reports -m /path/to/measure/bundle.json -p /path/to/patient1/bundle.json > reports.json
+```
+
+### TypeScript
+
+`fqm-execution` exports custom-defined TypeScript interfaces used within the code to allow for easy integration into other TypeScript projects. The TypeScript files defining these interfaces can be found [here](https://github.com/projecttacoma/fqm-execution/tree/master/src/types)
+
+## Local Development
+
+### Prerequisites
+
+* [Node.js >=10.15.1](https://nodejs.org/en/)
+* [Git](https://git-scm.com/)
+
+### Local Installation/Usage
+
+Clone the source code:
+
+```
+$ git clone https://github.com/projecttacoma/fqm-execution.git
+```
+
+Install dependencies:
+
+```
+$ npm install
+```
+
+Optionally, you can install the `ts-node` utility globally to execute the TypeScript files directly instead of running the build script:
+
+```
+$ npm install -g ts-node
+```
+
+Run the CLI with ts-node:
+
+```
+$ ts-node src/cli.ts [options]
+```
+
+Or using the built JavaScript:
+
+```
+$ npm run build
+$ node build/cli.js [options]
+```
+
+
+### Debugging in VS Code
+
+To attach a debugger to the TypeScript files for deeper inspection of the tool's functionality, we recommend using the [VS Code text editor](https://code.visualstudio.com/) to be able to provide easy debugger configuration.
+
+Add the following contents to `.vscode/launch.json` in the root of the project directory:
+
+```JSON
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch Program",
+            "skipFiles": [
+              "<node_internals>/**"
+            ],
+            "preLaunchTask": "npm: build",
+            "program": "${workspaceFolder}/src/cli.ts",
+            "outFiles": [
+              "${workspaceFolder}/build/**/*.js"
+            ],
+            "internalConsoleOptions": "openOnSessionStart",
+            "args": ["-m", "${workspaceFolder}/relative/path/to/measure/bundle.json", "-p", "${workspaceFolder}/relative/path/to/patient/bundle.json", "-o", "<reports | detailed | raw>"]
+          }
+    ]
+}
+
+```
+
+This will allow you to run the CLI from the `Run` tab in VS Code, and will halt execution of the program at any breakpoints or `debugger` statements in the code, to allow for debugging of the functionality.
+
+### Testing
+
+We use [Jest](https://jestjs.io/en/) for unit-testing `fqm-execution`. Tests can be running using the `test` script in package.json:
+
+```
+$ npm test
+```
+
+### Checks
+
+When contributing new code, ensure that all tests, lint, and prettier checks pass with the following command:
+
+```
+$ npm run check
+```
+
+
+## License
+
+Copyright 2020 The MITRE Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+
+```
+http://www.apache.org/licenses/LICENSE-2.0
+```
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.

--- a/README.md
+++ b/README.md
@@ -2,32 +2,34 @@
 
 Library for executing FHIR-based Electronic Clinical Quality Measures (eCQMs) written in Clinical Quality Language (CQL)
 
-* [Installation](#installation)
-* [Usage](#usage)
-  * [Module](#module)
-  * [Calculation Options](#calculation-options)
-  * [CLI](#cli)
-  * [TypeScript](#typescript)
-* [Local Development](#local-development)
-  * [Prerequisites](#prerequisites)
-  * [Local Installation/Usage](#local-installation%2Fusage)
-  * [Debugging in VS Code](#debugging-in-vs-code)
-  * [Testing](#testing)
-  * [Checks](#checks)
-* [License](#license)
+*   [Installation](#installation)
+*   [Usage](#usage)
+    *   [Module](#module)
+    *   [Calculation Options](#calculation-options)
+    *   [CLI](#cli)
+    *   [TypeScript](#typescript)
+
+*   [Local Development](#local-development)
+    *   [Prerequisites](#prerequisites)
+    *   [Local Installation/Usage](#local-installation%2Fusage)
+    *   [Debugging in VS Code](#debugging-in-vs-code)
+    *   [Testing](#testing)
+    *   [Checks](#checks)
+
+*   [License](#license)
 
 ## Installation
 
 `fqm-execution` can be installed into your project with npm:
 
-```
-$ npm install --save https://github.com/projecttacoma/fqm-execution.git
+``` bash
+npm install --save https://github.com/projecttacoma/fqm-execution.git
 ```
 
 To install the global command line interface (CLI), use npm global installation:
 
-```
-$ npm install -g https://github.com/projecttacoma/fqm-execution.git
+``` bash
+npm install -g https://github.com/projecttacoma/fqm-execution.git
 ```
 
 ## Usage
@@ -70,7 +72,7 @@ The options that we support for calculation are as follows:
 
 To run the globally installed CLI (see above), use the global `fqm-exeuction command`
 
-```
+``` bash
 Usage: fqm-execution [options]
 
 Options:
@@ -82,8 +84,8 @@ Options:
 
 E.g.
 
-```
-$ fqm-execution -o reports -m /path/to/measure/bundle.json -p /path/to/patient1/bundle.json > reports.json
+``` bash
+fqm-execution -o reports -m /path/to/measure/bundle.json -p /path/to/patient1/bundle.json > reports.json
 ```
 
 ### TypeScript
@@ -94,42 +96,41 @@ $ fqm-execution -o reports -m /path/to/measure/bundle.json -p /path/to/patient1/
 
 ### Prerequisites
 
-* [Node.js >=10.15.1](https://nodejs.org/en/)
-* [Git](https://git-scm.com/)
+*   [Node.js >=10.15.1](https://nodejs.org/en/)
+*   [Git](https://git-scm.com/)
 
 ### Local Installation/Usage
 
 Clone the source code:
 
-```
-$ git clone https://github.com/projecttacoma/fqm-execution.git
+``` bash
+git clone https://github.com/projecttacoma/fqm-execution.git
 ```
 
 Install dependencies:
 
-```
-$ npm install
+``` bash
+npm install
 ```
 
 Optionally, you can install the `ts-node` utility globally to execute the TypeScript files directly instead of running the build script:
 
-```
-$ npm install -g ts-node
+``` bash
+npm install -g ts-node
 ```
 
 Run the CLI with ts-node:
 
-```
-$ ts-node src/cli.ts [options]
+``` bash
+ts-node src/cli.ts [options]
 ```
 
 Or using the built JavaScript:
 
+``` bash
+npm run build
+node build/cli.js [options]
 ```
-$ npm run build
-$ node build/cli.js [options]
-```
-
 
 ### Debugging in VS Code
 
@@ -137,7 +138,7 @@ To attach a debugger to the TypeScript files for deeper inspection of the tool's
 
 Add the following contents to `.vscode/launch.json` in the root of the project directory:
 
-```JSON
+``` JavaScript
 {
     // Use IntelliSense to learn about possible attributes.
     // Hover to view descriptions of existing attributes.
@@ -170,18 +171,17 @@ This will allow you to run the CLI from the `Run` tab in VS Code, and will halt 
 
 We use [Jest](https://jestjs.io/en/) for unit-testing `fqm-execution`. Tests can be running using the `test` script in package.json:
 
-```
-$ npm test
+``` bash
+npm test
 ```
 
 ### Checks
 
 When contributing new code, ensure that all tests, lint, and prettier checks pass with the following command:
 
+``` bash
+npm run check
 ```
-$ npm run check
-```
-
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Library for executing FHIR-based Electronic Clinical Quality Measures (eCQMs) written in Clinical Quality Language (CQL)
 
 *   [Installation](#installation)
+
 *   [Usage](#usage)
     *   [Module](#module)
     *   [Calculation Options](#calculation-options)
@@ -189,7 +190,7 @@ Copyright 2020 The MITRE Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 
-```
+``` bash
 http://www.apache.org/licenses/LICENSE-2.0
 ```
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ npm install -g ts-node
 Run the CLI with ts-node:
 
 ``` bash
-ts-node src/cli.ts [options]
+ts-node --files src/cli.ts [options]
 ```
 
 Or using the built JavaScript:

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Library for executing FHIR-based Electronic Clinical Quality Measures (eCQMs) wr
 * [Installation](#installation)
 * [Usage](#usage)
   * [Module](#module)
+  * [Calculation Options](#calculation-options)
   * [CLI](#cli)
   * [TypeScript](#typescript)
 * [Local Development](#local-development)
@@ -50,6 +51,20 @@ const rawResults = Calculator.calculateRaw(measureBundle, patientBundles, option
 const rawResults = Calculator.calculate(measureBundle, patientBundles, options); // Get detailed population results for each patient
 const rawResults = Calculator.calculateMeasureReports(measureBundle, patientBundles, options); // Get individual FHIR MeasureReports for each patient
 ```
+
+#### Calculation Options
+
+The options that we support for calculation are as follows:
+| option                 |  type   | optional? | description                                                                 |
+| :--------------------- | :-----: | :-------: | :-------------------------------------------------------------------------- |
+| includeClauseResults   | boolean |    yes    |                        Option to include clause results. Defaults to false. |
+| includePrettyResults   | boolean |    yes    |   Option to include pretty results on statement results. Defaults to false. |
+| includeHighlighting    | boolean |    yes    |         Include highlighting in MeasureReport narrative. Defaults to false. |
+| measurementPeriodStart | string  |    yes    |                                                Start of measurement period. |
+| measurementPeriodEnd   | string  |    yes    |                                                  End of measurement period. |
+| patientSource          |   any   |    yes    | PatientSource to use. If provided, the patientBundles will not be required. |
+| calculateSDEs          | boolean |    yes    |                             Include SDEs in calculation. Defaults to false. |
+| calculateHTML          | boolean |    yes    |                 Include HTML structure for highlighting. Defaults to false. |
 
 ### CLI
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "FHIR Quality Measure Execution",
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "bin": {
+    "fqm-execution": "build/cli.js"
+  },
   "files": [
     "build/*"
   ],


### PR DESCRIPTION
# Summary

Updates the README of the library, and adds an option in package.json to install the CLI globally

## New behavior

* Docs!
* When this branch is merged, the command `npm install -g https://github.com/projecttacoma/fqm-execution.git` will add the a global command in your terminal called `fqm-execution` which will run the CLI. It will not work right now since we need this PR to be merged first to include the `bin` property on the package

## Code changes

README updated plus new `bin` property in package.json (see [here](https://docs.npmjs.com/cli/v6/configuring-npm/package-json#bin)).

# Testing guidance

Run through the README and try to get set up with everything. It's probably worthwhile to test both the library-based installation as well as the local development installation

Rendered version of the README available [here](https://github.com/projecttacoma/fqm-execution/blob/readme/README.md)

