### PR TITLE
Initial gaps in care functionality: numerator queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,9 @@ npm install -g https://github.com/projecttacoma/fqm-execution.git
 import { Calculator } from 'fqm-execution';
 
 const rawResults = Calculator.calculateRaw(measureBundle, patientBundles, options); // Get raw results from CQL engine for each patient
-const rawResults = Calculator.calculate(measureBundle, patientBundles, options); // Get detailed population results for each patient
-const rawResults = Calculator.calculateMeasureReports(measureBundle, patientBundles, options); // Get individual FHIR MeasureReports for each patient
+const detailedResults = Calculator.calculate(measureBundle, patientBundles, options); // Get detailed population results for each patient
+const measureReports = Calculator.calculateMeasureReports(measureBundle, patientBundles, options); // Get individual FHIR MeasureReports for each patient
+const gapsInCare = Calculator.calculateGapsInCare(measureBundle, patientBundles, options); // Get gaps in care for each patient, if present
 ```
 
 #### Require
@@ -51,8 +52,9 @@ const rawResults = Calculator.calculateMeasureReports(measureBundle, patientBund
 const { Calculator } = require('fqm-execution');
 
 const rawResults = Calculator.calculateRaw(measureBundle, patientBundles, options); // Get raw results from CQL engine for each patient
-const rawResults = Calculator.calculate(measureBundle, patientBundles, options); // Get detailed population results for each patient
-const rawResults = Calculator.calculateMeasureReports(measureBundle, patientBundles, options); // Get individual FHIR MeasureReports for each patient
+const detailedResults = Calculator.calculate(measureBundle, patientBundles, options); // Get detailed population results for each patient
+const measureReports = Calculator.calculateMeasureReports(measureBundle, patientBundles, options); // Get individual FHIR MeasureReports for each patient
+const gapsInCare = Calculator.calculateGapsInCare(measureBundle, patientBundles, options); // Get gaps in care for each patient, if present
 ```
 
 #### Calculation Options
@@ -77,7 +79,7 @@ To run the globally installed CLI (see above), use the global `fqm-exeuction com
 Usage: fqm-execution [options]
 
 Options:
-  -o, --output-type <type>                    type of output, "raw", "detailed", "reports" (default: "detailed")
+  -o, --output-type <type>                    type of output, "raw", "detailed", "reports", "gaps" (default: "detailed")
   -m, --measure-bundle <measure-bundle>       path to measure bundle
   -p, --patient-bundles <patient-bundles...>  paths to patient bundle
   -h, --help                                  display help for command
@@ -159,7 +161,7 @@ Add the following contents to `.vscode/launch.json` in the root of the project d
               "${workspaceFolder}/build/**/*.js"
             ],
             "internalConsoleOptions": "openOnSessionStart",
-            "args": ["-m", "${workspaceFolder}/relative/path/to/measure/bundle.json", "-p", "${workspaceFolder}/relative/path/to/patient/bundle.json", "-o", "<reports | detailed | raw>"]
+            "args": ["-m", "${workspaceFolder}/relative/path/to/measure/bundle.json", "-p", "${workspaceFolder}/relative/path/to/patient/bundle.json", "-o", "<reports | detailed | raw | gaps>"]
           }
     ]
 }

--- a/src/Calculator.ts
+++ b/src/Calculator.ts
@@ -360,6 +360,16 @@ export function calculateGapsInCare(
           throw new Error('Argument measureBundle must include a Measure resource');
         }
         const measureResource = measureEntry.resource as R4.IMeasure;
+
+        // Gaps only supported for proportion/ratio measures
+        const scoringCode = measureResource.scoring?.coding?.find(
+          c => c.system === 'http://hl7.org/fhir/measure-scoring'
+        )?.code;
+
+        if (scoringCode !== MeasureScoreType.PROP) {
+          throw new Error(`Gaps in care not supported for measure scoring type ${scoringCode}`);
+        }
+
         const matchingGroup = measureResource.group?.find(g => g.id === dr.groupId);
 
         if (!matchingGroup) {

--- a/src/Calculator.ts
+++ b/src/Calculator.ts
@@ -386,7 +386,7 @@ export function calculateGapsInCare(
           throw new Error(`Expression ${numerExpressionName} not found in ${mainLibraryName}`);
         }
 
-        result = CalculatorHelpers.findRetrieves(mainLibraryELM, elmLibraries, numerELMExpression.expression);
+        result = CalculatorHelpers.findRetrieves(mainLibraryELM, elmLibraries, numerELMExpression.expression, dr);
       }
     });
   });

--- a/src/CalculatorHelpers.ts
+++ b/src/CalculatorHelpers.ts
@@ -527,7 +527,8 @@ export function findRetrieves(
           parentQuerySatisfied,
           retreiveSatisfied,
           queryLocalId,
-          retrieveLocalId: expr.localId
+          retrieveLocalId: expr.localId,
+          libraryName: elm.library.identifier.id
         });
       }
     } else if (
@@ -547,7 +548,8 @@ export function findRetrieves(
           parentQuerySatisfied,
           retreiveSatisfied,
           queryLocalId,
-          retrieveLocalId: expr.localId
+          retrieveLocalId: expr.localId,
+          libraryName: elm.library.identifier.id
         });
       }
     }

--- a/src/CalculatorHelpers.ts
+++ b/src/CalculatorHelpers.ts
@@ -1,5 +1,11 @@
 import { R4 } from '@ahryman40k/ts-fhir-types';
-import { DetailedPopulationGroupResult, EpisodeResults, PopulationResult, StratifierResult } from './types/Calculator';
+import {
+  DataTypeQuery,
+  DetailedPopulationGroupResult,
+  EpisodeResults,
+  PopulationResult,
+  StratifierResult
+} from './types/Calculator';
 import * as MeasureHelpers from './MeasureHelpers';
 import { getResult, hasResult, setResult, createOrSetResult } from './ResultsHelpers';
 import { ELM, ELMStatement } from './types/ELMTypes';
@@ -480,4 +486,71 @@ export function generateELMJSONFunction(functionName: string, parameter: string)
     }
   };
   return elmFunction;
+}
+
+/**
+ * Get all data types, and codes/valuesets used in Retreive ELM expressions
+ *
+ * @param elm main ELM library with expressions to traverse
+ * @param deps list of any dependent ELM libraries included in the main ELM
+ * @param expr expression to find queries under (usually numerator for gaps in care)
+ */
+export function findRetrieves(elm: ELM, deps: ELM[], expr: ELMStatement) {
+  const results: DataTypeQuery[] = [];
+
+  // Base case, get data type and code/valueset off the expression
+  if (expr.type === 'Retrieve' && expr.dataType) {
+    if (expr.codes?.type === 'ValueSetRef') {
+      const valueSet = elm.library.valueSets?.def.find(v => v.name === expr.codes.name);
+      if (valueSet) {
+        results.push({ dataType: expr.dataType, valueSet: valueSet.id });
+      }
+    } else if (
+      expr.codes.type === 'CodeRef' ||
+      (expr.codes.type === 'ToList' && expr.codes.operand?.type === 'CodeRef')
+    ) {
+      // ToList promotions have the CodeRef on the operand
+      const codeName = expr.codes.type === 'CodeRef' ? expr.codes.name : expr.codes.operand.name;
+      const code = elm.library.codes?.def.find(c => c.name === codeName);
+      if (code) {
+        results.push({
+          dataType: expr.dataType,
+          code: {
+            system: code.codeSystem.name,
+            code: code.id
+          }
+        });
+      }
+    }
+  } else if (expr.type === 'Query') {
+    // Queries have the source array containing the expressions
+    expr.source?.forEach(s => {
+      results.push(...findRetrieves(elm, deps, s.expression));
+    });
+  } else if (expr.type === 'ExpressionRef') {
+    // Find expression in dependent library
+    if (expr.libraryName) {
+      const matchingLib = deps.find(d => d.library.identifier.id === expr.libraryName);
+      const exprRef = matchingLib?.library.statements.def.find(e => e.name === expr.name);
+      if (matchingLib && exprRef) {
+        results.push(...findRetrieves(matchingLib, deps, exprRef.expression));
+      }
+    } else {
+      // Find expression in current library
+      const exprRef = elm.library.statements.def.find(d => d.name === expr.name);
+      if (exprRef) {
+        results.push(...findRetrieves(elm, deps, exprRef.expression));
+      }
+    }
+  } else if (expr.operand) {
+    // Operand can be array or object. Recurse on either
+    if (Array.isArray(expr.operand)) {
+      expr.operand.forEach(e => {
+        results.push(...findRetrieves(elm, deps, e));
+      });
+    } else {
+      results.push(...findRetrieves(elm, deps, expr.operand));
+    }
+  }
+  return results;
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,10 +4,10 @@ import { R4 } from '@ahryman40k/ts-fhir-types';
 import { program } from 'commander';
 import fs from 'fs';
 import path from 'path';
-import { calculate, calculateMeasureReports, calculateRaw } from './Calculator';
+import { calculate, calculateGapsInCare, calculateMeasureReports, calculateRaw } from './Calculator';
 
 program
-  .option('-o, --output-type <type>', 'type of output, "raw", "detailed", "reports"', 'detailed')
+  .option('-o, --output-type <type>', 'type of output, "raw", "detailed", "reports", "gaps"', 'detailed')
   .requiredOption('-m, --measure-bundle <measure-bundle>', 'path to measure bundle')
   .requiredOption('-p, --patient-bundles <patient-bundles...>', 'paths to patient bundle')
   .parse(process.argv);
@@ -22,16 +22,18 @@ const measureBundle = parseBundle(path.resolve(program.measureBundle));
 const patientBundles = program.patientBundles.map((bundlePath: string) => parseBundle(path.resolve(bundlePath)));
 
 let result;
-if (program.outputType == 'raw') {
+if (program.outputType === 'raw') {
   result = calculateRaw(measureBundle, patientBundles, {});
-} else if (program.outputType == 'detailed') {
+} else if (program.outputType === 'detailed') {
   result = calculate(measureBundle, patientBundles, { calculateSDEs: true });
-} else if (program.outputType == 'reports') {
+} else if (program.outputType === 'reports') {
   result = calculateMeasureReports(measureBundle, patientBundles, {
     measurementPeriodStart: '2019-01-01',
     measurementPeriodEnd: '2019-12-31',
     calculateSDEs: true,
     calculateHTML: true
   });
+} else if (program.outputType === 'gaps') {
+  result = calculateGapsInCare(measureBundle, patientBundles, {});
 }
 console.log(JSON.stringify(result, null, 2));

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -185,4 +185,8 @@ export interface DataTypeQuery {
     system: string;
     code: string;
   };
+  retreiveSatisfied?: boolean;
+  parentQuerySatisfied?: boolean;
+  retrieveLocalId?: string;
+  queryLocalId?: string;
 }

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -179,14 +179,23 @@ export interface EpisodeResults {
  * Data type and query used in ELM
  */
 export interface DataTypeQuery {
+  /** FHIR data type of the retrieve */
   dataType: string;
+  /** valueSet used, if applicable */
   valueSet?: string;
+  /** code used, if applicable */
   code?: {
     system: string;
     code: string;
   };
+  /** whether or not the retrieve was truthy */
   retreiveSatisfied?: boolean;
+  /** whether or not the entire query was truthy */
   parentQuerySatisfied?: boolean;
+  /** localId in ELM for the retreive statement */
   retrieveLocalId?: string;
+  /** localId in ELM for the query statement */
   queryLocalId?: string;
+  /** name of the library where the statment can be looked up */
+  libraryName?: string;
 }

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -174,3 +174,15 @@ export interface EpisodeResults {
   /** Stratifier results for this episode. */
   stratifierResults?: StratifierResult[];
 }
+
+/**
+ * Data type and query used in ELM
+ */
+export interface DataTypeQuery {
+  dataType: string;
+  valueSet?: string;
+  code?: {
+    system: string;
+    code: string;
+  };
+}

--- a/src/types/ELMTypes.ts
+++ b/src/types/ELMTypes.ts
@@ -31,7 +31,9 @@ export interface ELMLibrary {
     def: ELMValueSet[];
   };
   /** Direct reference code statements. */
-  codes?: any;
+  codes?: {
+    def: ELMCode[];
+  };
   /** Standard define or define function statements. The actual logic is defined here. */
   statements: {
     /** List of statement definitions. */
@@ -87,7 +89,15 @@ export interface ELMStatement {
   /** Type of this statement. Will be 'FunctionDef' if it is a function. */
   type?: string;
   /** Definition function parameters if this is a function. */
-  operand?: any[];
+  operand?: any;
+  /** Used in query expressions */
+  source?: any[];
+  /** Used in expression refs */
+  libraryName?: string;
+  /** Used in retrieves */
+  dataType?: string;
+  /** Used in retrieves */
+  codes?: any;
 }
 
 /**
@@ -106,6 +116,18 @@ export interface ELMValueSet {
   accessLevel?: string;
   /** Version of the valueset. Should not be used in eCQM land. */
   version?: string;
+}
+
+/**
+ * ELM Code definition
+ */
+export interface ELMCode {
+  id: string;
+  name: string;
+  accessLevel: string;
+  codeSystem: {
+    name: string;
+  };
 }
 
 export interface LibraryDependencyInfo {

--- a/test/CalculatorHelpers.test.ts
+++ b/test/CalculatorHelpers.test.ts
@@ -13,7 +13,8 @@ const EXPECTED_VS_RETRIEVE_RESULTS: DataTypeQuery[] = [
     retreiveSatisfied: false,
     retrieveLocalId: '14',
     parentQuerySatisfied: false,
-    queryLocalId: undefined
+    queryLocalId: undefined,
+    libraryName: 'SimpleQueries'
   }
 ];
 const EXPECTED_VS_QUERY_RESULTS: DataTypeQuery[] = [
@@ -23,7 +24,8 @@ const EXPECTED_VS_QUERY_RESULTS: DataTypeQuery[] = [
     retreiveSatisfied: false,
     retrieveLocalId: '18',
     parentQuerySatisfied: false,
-    queryLocalId: '24'
+    queryLocalId: '24',
+    libraryName: 'SimpleQueries'
   }
 ];
 const EXPECTED_CODE_RESULTS: DataTypeQuery[] = [
@@ -36,7 +38,8 @@ const EXPECTED_CODE_RESULTS: DataTypeQuery[] = [
     retreiveSatisfied: true,
     retrieveLocalId: '16',
     parentQuerySatisfied: false,
-    queryLocalId: undefined
+    queryLocalId: undefined,
+    libraryName: 'SimpleQueries'
   }
 ];
 const EXPECTED_DEPENDENCY_RESULTS: DataTypeQuery[] = [
@@ -46,7 +49,8 @@ const EXPECTED_DEPENDENCY_RESULTS: DataTypeQuery[] = [
     retreiveSatisfied: false,
     retrieveLocalId: '4',
     parentQuerySatisfied: false,
-    queryLocalId: undefined
+    queryLocalId: undefined,
+    libraryName: 'SimpleDep'
   }
 ];
 const EXAMPLE_DETAILED_RESULTS: DetailedPopulationGroupResult = {

--- a/test/CalculatorHelpers.test.ts
+++ b/test/CalculatorHelpers.test.ts
@@ -1,0 +1,54 @@
+import { findRetrieves } from '../src/CalculatorHelpers';
+import { DataTypeQuery } from '../src/types/Calculator';
+import { getELMFixture } from './helpers/testHelpers';
+
+const simpleQueryELM = getELMFixture('elm/queries/SimpleQueries.json');
+const simpleQueryELMDependency = getELMFixture('elm/queries/SimpleQueriesDependency.json');
+
+const EXPECTED_VS_RESULTS: DataTypeQuery[] = [
+  { dataType: '{http://hl7.org/fhir}Condition', valueSet: 'http://example.com/test-vs' }
+];
+const EXPECTED_CODE_RESULTS: DataTypeQuery[] = [
+  {
+    dataType: '{http://hl7.org/fhir}Procedure',
+    code: {
+      system: 'EXAMPLE',
+      code: 'test'
+    }
+  }
+];
+const EXPECTED_DEPENDENCY_RESULTS: DataTypeQuery[] = [
+  { dataType: '{http://hl7.org/fhir}Condition', valueSet: 'http://example.com/test-vs-2' }
+];
+
+describe('Find Numerator Queries', () => {
+  test('simple valueset lookup', () => {
+    const valueSetExpr = simpleQueryELM.library.statements.def[0]; // expression for valueset lookup
+    const results = findRetrieves(simpleQueryELM, [simpleQueryELMDependency], valueSetExpr.expression);
+    expect(results).toEqual(EXPECTED_VS_RESULTS);
+  });
+
+  test('simple code lookup', () => {
+    const codeExpr = simpleQueryELM.library.statements.def[1]; // expression for code lookup
+    const results = findRetrieves(simpleQueryELM, [simpleQueryELMDependency], codeExpr.expression);
+    expect(results).toEqual(EXPECTED_CODE_RESULTS);
+  });
+
+  test('simple aliased query', () => {
+    const queryExpr = simpleQueryELM.library.statements.def[2]; // expression with aliased query
+    const results = findRetrieves(simpleQueryELM, [simpleQueryELMDependency], queryExpr.expression);
+    expect(results).toEqual(EXPECTED_VS_RESULTS);
+  });
+
+  test('simple expression ref', () => {
+    const expressionRef = simpleQueryELM.library.statements.def[3]; // expression with local expression ref
+    const results = findRetrieves(simpleQueryELM, [simpleQueryELMDependency], expressionRef.expression);
+    expect(results).toEqual(EXPECTED_VS_RESULTS);
+  });
+
+  test('dependent library expression ref', () => {
+    const expressionRefDependency = simpleQueryELM.library.statements.def[4]; // expression with expression ref in dependent library
+    const results = findRetrieves(simpleQueryELM, [simpleQueryELMDependency], expressionRefDependency.expression);
+    expect(results).toEqual(EXPECTED_DEPENDENCY_RESULTS);
+  });
+});

--- a/test/CalculatorHelpers.test.ts
+++ b/test/CalculatorHelpers.test.ts
@@ -1,12 +1,30 @@
 import { findRetrieves } from '../src/CalculatorHelpers';
-import { DataTypeQuery } from '../src/types/Calculator';
+import { DataTypeQuery, DetailedPopulationGroupResult } from '../src/types/Calculator';
+import { FinalResult } from '../src/types/Enums';
 import { getELMFixture } from './helpers/testHelpers';
 
 const simpleQueryELM = getELMFixture('elm/queries/SimpleQueries.json');
 const simpleQueryELMDependency = getELMFixture('elm/queries/SimpleQueriesDependency.json');
 
-const EXPECTED_VS_RESULTS: DataTypeQuery[] = [
-  { dataType: '{http://hl7.org/fhir}Condition', valueSet: 'http://example.com/test-vs' }
+const EXPECTED_VS_RETRIEVE_RESULTS: DataTypeQuery[] = [
+  {
+    dataType: '{http://hl7.org/fhir}Condition',
+    valueSet: 'http://example.com/test-vs',
+    retreiveSatisfied: false,
+    retrieveLocalId: '14',
+    parentQuerySatisfied: false,
+    queryLocalId: undefined
+  }
+];
+const EXPECTED_VS_QUERY_RESULTS: DataTypeQuery[] = [
+  {
+    dataType: '{http://hl7.org/fhir}Condition',
+    valueSet: 'http://example.com/test-vs',
+    retreiveSatisfied: false,
+    retrieveLocalId: '18',
+    parentQuerySatisfied: false,
+    queryLocalId: '24'
+  }
 ];
 const EXPECTED_CODE_RESULTS: DataTypeQuery[] = [
   {
@@ -14,41 +32,132 @@ const EXPECTED_CODE_RESULTS: DataTypeQuery[] = [
     code: {
       system: 'EXAMPLE',
       code: 'test'
-    }
+    },
+    retreiveSatisfied: true,
+    retrieveLocalId: '16',
+    parentQuerySatisfied: false,
+    queryLocalId: undefined
   }
 ];
 const EXPECTED_DEPENDENCY_RESULTS: DataTypeQuery[] = [
-  { dataType: '{http://hl7.org/fhir}Condition', valueSet: 'http://example.com/test-vs-2' }
+  {
+    dataType: '{http://hl7.org/fhir}Condition',
+    valueSet: 'http://example.com/test-vs-2',
+    retreiveSatisfied: false,
+    retrieveLocalId: '4',
+    parentQuerySatisfied: false,
+    queryLocalId: undefined
+  }
 ];
+const EXAMPLE_DETAILED_RESULTS: DetailedPopulationGroupResult = {
+  groupId: 'example',
+  statementResults: [],
+  clauseResults: [
+    {
+      libraryName: 'SimpleQueries',
+      statementName: 'SimpleVSRetrieve',
+      final: FinalResult.FALSE,
+      localId: '14',
+      raw: []
+    },
+    {
+      libraryName: 'SimpleQueries',
+      statementName: 'SimpleCodeRetrieve',
+      final: FinalResult.TRUE,
+      localId: '16',
+      raw: true
+    },
+    {
+      libraryName: 'SimpleQueries',
+      statementName: 'SimpleQuery',
+      final: FinalResult.FALSE,
+      localId: '24',
+      raw: []
+    },
+    {
+      libraryName: 'SimpleQueries',
+      statementName: 'SimpleQuery',
+      final: FinalResult.FALSE,
+      localId: '18',
+      raw: []
+    },
+    {
+      libraryName: 'SimpleQueries',
+      statementName: 'SimpleExpressionRef',
+      final: FinalResult.FALSE,
+      localId: '26',
+      raw: []
+    },
+    {
+      libraryName: 'SimpleQueries',
+      statementName: 'DepExpressionRef',
+      final: FinalResult.FALSE,
+      localId: '29',
+      raw: []
+    },
+    {
+      libraryName: 'SimpleDep',
+      statementName: 'SimpleRetrieve',
+      final: FinalResult.FALSE,
+      localId: '4',
+      raw: []
+    }
+  ]
+};
 
 describe('Find Numerator Queries', () => {
   test('simple valueset lookup', () => {
     const valueSetExpr = simpleQueryELM.library.statements.def[0]; // expression for valueset lookup
-    const results = findRetrieves(simpleQueryELM, [simpleQueryELMDependency], valueSetExpr.expression);
-    expect(results).toEqual(EXPECTED_VS_RESULTS);
+    const results = findRetrieves(
+      simpleQueryELM,
+      [simpleQueryELMDependency],
+      valueSetExpr.expression,
+      EXAMPLE_DETAILED_RESULTS
+    );
+    expect(results).toEqual(EXPECTED_VS_RETRIEVE_RESULTS);
   });
 
   test('simple code lookup', () => {
     const codeExpr = simpleQueryELM.library.statements.def[1]; // expression for code lookup
-    const results = findRetrieves(simpleQueryELM, [simpleQueryELMDependency], codeExpr.expression);
+    const results = findRetrieves(
+      simpleQueryELM,
+      [simpleQueryELMDependency],
+      codeExpr.expression,
+      EXAMPLE_DETAILED_RESULTS
+    );
     expect(results).toEqual(EXPECTED_CODE_RESULTS);
   });
 
   test('simple aliased query', () => {
     const queryExpr = simpleQueryELM.library.statements.def[2]; // expression with aliased query
-    const results = findRetrieves(simpleQueryELM, [simpleQueryELMDependency], queryExpr.expression);
-    expect(results).toEqual(EXPECTED_VS_RESULTS);
+    const results = findRetrieves(
+      simpleQueryELM,
+      [simpleQueryELMDependency],
+      queryExpr.expression,
+      EXAMPLE_DETAILED_RESULTS
+    );
+    expect(results).toEqual(EXPECTED_VS_QUERY_RESULTS);
   });
 
   test('simple expression ref', () => {
     const expressionRef = simpleQueryELM.library.statements.def[3]; // expression with local expression ref
-    const results = findRetrieves(simpleQueryELM, [simpleQueryELMDependency], expressionRef.expression);
-    expect(results).toEqual(EXPECTED_VS_RESULTS);
+    const results = findRetrieves(
+      simpleQueryELM,
+      [simpleQueryELMDependency],
+      expressionRef.expression,
+      EXAMPLE_DETAILED_RESULTS
+    );
+    expect(results).toEqual(EXPECTED_VS_RETRIEVE_RESULTS);
   });
 
   test('dependent library expression ref', () => {
     const expressionRefDependency = simpleQueryELM.library.statements.def[4]; // expression with expression ref in dependent library
-    const results = findRetrieves(simpleQueryELM, [simpleQueryELMDependency], expressionRefDependency.expression);
+    const results = findRetrieves(
+      simpleQueryELM,
+      [simpleQueryELMDependency],
+      expressionRefDependency.expression,
+      EXAMPLE_DETAILED_RESULTS
+    );
     expect(results).toEqual(EXPECTED_DEPENDENCY_RESULTS);
   });
 });

--- a/test/fixtures/elm/queries/SimpleQueries.cql
+++ b/test/fixtures/elm/queries/SimpleQueries.cql
@@ -1,0 +1,35 @@
+library SimpleQueries version '0.0.1'
+
+using FHIR version '4.0.1'
+
+include FHIRHelpers version '4.0.1'
+include SimpleDep version '0.0.1'
+
+codesystem "EXAMPLE": 'http://example.com'
+codesystem "EXAMPLE-2": 'http://example.com/2'
+
+valueset "test-vs": 'http://example.com/test-vs'
+
+code "test-code": 'test' from "EXAMPLE"
+code "test-code-2": 'test-2' from "EXAMPLE-2"
+
+concept "test-concept": { "test-code", "test-code-2" } display 'test-concept'
+
+define "SimpleVSRetrieve":
+  [Condition: "test-vs"]
+
+define "SimpleCodeRetrieve":
+  [Procedure: "test-code"]
+
+define "SimpleQuery":
+  [Condition: "test-vs"] C where C.id = 'test'
+
+define "SimpleExpressionRef":
+  "SimpleVSRetrieve"
+
+define "DepExpressionRef":
+  "SimpleDep"."SimpleRetrieve"
+
+define "SimpleConceptRetrieve":
+  [Procedure: "test-concept"]
+

--- a/test/fixtures/elm/queries/SimpleQueries.json
+++ b/test/fixtures/elm/queries/SimpleQueries.json
@@ -1,0 +1,178 @@
+{
+  "library": {
+    "annotation": [
+      {
+        "translatorOptions": "",
+        "type": "CqlToElmInfo"
+      }
+    ],
+    "identifier": {
+      "id": "simpleQueries",
+      "version": "0.0.1"
+    },
+    "schemaIdentifier": {
+      "id": "urn:hl7-org:elm",
+      "version": "r1"
+    },
+    "usings": {
+      "def": [
+        {
+          "localIdentifier": "System",
+          "uri": "urn:hl7-org:elm-types:r1"
+        },
+        {
+          "localIdentifier": "FHIR",
+          "uri": "http://hl7.org/fhir",
+          "version": "4.0.1"
+        }
+      ]
+    },
+    "includes": {
+      "def": [
+        {
+          "localIdentifier": "FHIRHelpers",
+          "path": "FHIRHelpers",
+          "version": "4.0.1"
+        },
+        {
+          "localIdentifier": "SimpleDep",
+          "path": "SimpleDep",
+          "version": "0.0.1"
+        }
+      ]
+    },
+    "codeSystems": {
+      "def": [
+        {
+          "name": "EXAMPLE",
+          "id": "http://example.com",
+          "accessLevel": "Public"
+        }
+      ]
+    },
+    "valueSets": {
+      "def": [
+        {
+          "name": "test-vs",
+          "id": "http://example.com/test-vs",
+          "accessLevel": "Public"
+        }
+      ]
+    },
+    "codes": {
+      "def": [
+        {
+          "name": "test-code",
+          "id": "test",
+          "accessLevel": "Public",
+          "codeSystem": {
+            "name": "EXAMPLE"
+          }
+        }
+      ]
+    },
+    "statements": {
+      "def": [
+        {
+          "name": "SimpleVSRetrieve",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "expression": {
+            "dataType": "{http://hl7.org/fhir}Condition",
+            "templateId": "http://hl7.org/fhir/StructureDefinition/Condition",
+            "codeProperty": "code",
+            "type": "Retrieve",
+            "codes": {
+              "name": "test-vs",
+              "type": "ValueSetRef"
+            }
+          }
+        },
+        {
+          "name": "SimpleCodeRetrieve",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "expression": {
+            "dataType": "{http://hl7.org/fhir}Procedure",
+            "templateId": "http://hl7.org/fhir/StructureDefinition/Procedure",
+            "codeProperty": "code",
+            "type": "Retrieve",
+            "codes": {
+              "type": "ToList",
+              "operand": {
+                "name": "test-code",
+                "type": "CodeRef"
+              }
+            }
+          }
+        },
+        {
+          "name": "SimpleQuery",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "expression": {
+            "type": "Query",
+            "source": [
+              {
+                "alias": "C",
+                "expression": {
+                  "dataType": "{http://hl7.org/fhir}Condition",
+                  "templateId": "http://hl7.org/fhir/StructureDefinition/Condition",
+                  "codeProperty": "code",
+                  "type": "Retrieve",
+                  "codes": {
+                    "name": "test-vs",
+                    "type": "ValueSetRef"
+                  }
+                }
+              }
+            ],
+            "relationship": [
+            ],
+            "where": {
+              "type": "Equal",
+              "operand": [
+                {
+                  "name": "ToString",
+                  "libraryName": "FHIRHelpers",
+                  "type": "FunctionRef",
+                  "operand": [
+                    {
+                      "path": "id",
+                      "scope": "C",
+                      "type": "Property"
+                    }
+                  ]
+                },
+                {
+                  "valueType": "{urn:hl7-org:elm-types:r1}String",
+                  "value": "test",
+                  "type": "Literal"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "SimpleExpressionRef",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "expression": {
+            "name": "SimpleVSRetrieve",
+            "type": "ExpressionRef"
+          }
+        },
+        {
+          "name": "DepExpressionRef",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "expression": {
+            "name": "SimpleRetrieve",
+            "libraryName": "SimpleDep",
+            "type": "ExpressionRef"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/elm/queries/SimpleQueries.json
+++ b/test/fixtures/elm/queries/SimpleQueries.json
@@ -2,12 +2,12 @@
   "library": {
     "annotation": [
       {
-        "translatorOptions": "",
+        "translatorOptions": "EnableAnnotations,EnableLocators",
         "type": "CqlToElmInfo"
       }
     ],
     "identifier": {
-      "id": "simpleQueries",
+      "id": "SimpleQueries",
       "version": "0.0.1"
     },
     "schemaIdentifier": {
@@ -21,6 +21,8 @@
           "uri": "urn:hl7-org:elm-types:r1"
         },
         {
+          "localId": "1",
+          "locator": "3:1-3:26",
           "localIdentifier": "FHIR",
           "uri": "http://hl7.org/fhir",
           "version": "4.0.1"
@@ -30,11 +32,15 @@
     "includes": {
       "def": [
         {
+          "localId": "2",
+          "locator": "5:1-5:35",
           "localIdentifier": "FHIRHelpers",
           "path": "FHIRHelpers",
           "version": "4.0.1"
         },
         {
+          "localId": "3",
+          "locator": "6:1-6:33",
           "localIdentifier": "SimpleDep",
           "path": "SimpleDep",
           "version": "0.0.1"
@@ -44,8 +50,17 @@
     "codeSystems": {
       "def": [
         {
+          "localId": "4",
+          "locator": "8:1-8:42",
           "name": "EXAMPLE",
           "id": "http://example.com",
+          "accessLevel": "Public"
+        },
+        {
+          "localId": "5",
+          "locator": "9:1-9:46",
+          "name": "EXAMPLE-2",
+          "id": "http://example.com/2",
           "accessLevel": "Public"
         }
       ]
@@ -53,6 +68,8 @@
     "valueSets": {
       "def": [
         {
+          "localId": "6",
+          "locator": "11:1-11:48",
           "name": "test-vs",
           "id": "http://example.com/test-vs",
           "accessLevel": "Public"
@@ -62,37 +79,171 @@
     "codes": {
       "def": [
         {
+          "localId": "8",
+          "locator": "13:1-13:39",
           "name": "test-code",
           "id": "test",
           "accessLevel": "Public",
           "codeSystem": {
+            "localId": "7",
+            "locator": "13:31-13:39",
             "name": "EXAMPLE"
           }
+        },
+        {
+          "localId": "10",
+          "locator": "14:1-14:45",
+          "name": "test-code-2",
+          "id": "test-2",
+          "accessLevel": "Public",
+          "codeSystem": {
+            "localId": "9",
+            "locator": "14:35-14:45",
+            "name": "EXAMPLE-2"
+          }
+        }
+      ]
+    },
+    "concepts": {
+      "def": [
+        {
+          "localId": "13",
+          "locator": "16:1-16:77",
+          "name": "test-concept",
+          "display": "test-concept",
+          "accessLevel": "Public",
+          "code": [
+            {
+              "localId": "11",
+              "locator": "16:27-16:37",
+              "name": "test-code"
+            },
+            {
+              "localId": "12",
+              "locator": "16:40-16:52",
+              "name": "test-code-2"
+            }
+          ]
         }
       ]
     },
     "statements": {
       "def": [
         {
+          "localId": "15",
+          "locator": "18:1-19:24",
           "name": "SimpleVSRetrieve",
           "context": "Patient",
           "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "15",
+                "s": [
+                  {
+                    "value": [
+                      "define ",
+                      "\"SimpleVSRetrieve\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "14",
+                    "s": [
+                      {
+                        "value": [
+                          "[",
+                          "Condition",
+                          ": "
+                        ]
+                      },
+                      {
+                        "s": [
+                          {
+                            "value": [
+                              "\"test-vs\""
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "]"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
           "expression": {
+            "localId": "14",
+            "locator": "19:3-19:24",
             "dataType": "{http://hl7.org/fhir}Condition",
             "templateId": "http://hl7.org/fhir/StructureDefinition/Condition",
             "codeProperty": "code",
             "type": "Retrieve",
             "codes": {
+              "locator": "19:15-19:23",
               "name": "test-vs",
               "type": "ValueSetRef"
             }
           }
         },
         {
+          "localId": "17",
+          "locator": "21:1-22:26",
           "name": "SimpleCodeRetrieve",
           "context": "Patient",
           "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "17",
+                "s": [
+                  {
+                    "value": [
+                      "define ",
+                      "\"SimpleCodeRetrieve\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "16",
+                    "s": [
+                      {
+                        "value": [
+                          "[",
+                          "Procedure",
+                          ": "
+                        ]
+                      },
+                      {
+                        "s": [
+                          {
+                            "value": [
+                              "\"test-code\""
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "]"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
           "expression": {
+            "localId": "16",
+            "locator": "22:3-22:26",
             "dataType": "{http://hl7.org/fhir}Procedure",
             "templateId": "http://hl7.org/fhir/StructureDefinition/Procedure",
             "codeProperty": "code",
@@ -100,6 +251,7 @@
             "codes": {
               "type": "ToList",
               "operand": {
+                "locator": "22:15-22:25",
                 "name": "test-code",
                 "type": "CodeRef"
               }
@@ -107,20 +259,164 @@
           }
         },
         {
+          "localId": "25",
+          "locator": "24:1-25:46",
           "name": "SimpleQuery",
           "context": "Patient",
           "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "25",
+                "s": [
+                  {
+                    "value": [
+                      "define ",
+                      "\"SimpleQuery\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "24",
+                    "s": [
+                      {
+                        "s": [
+                          {
+                            "r": "19",
+                            "s": [
+                              {
+                                "r": "18",
+                                "s": [
+                                  {
+                                    "r": "18",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "[",
+                                          "Condition",
+                                          ": "
+                                        ]
+                                      },
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"test-vs\""
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "]"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "C"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          " "
+                        ]
+                      },
+                      {
+                        "r": "23",
+                        "s": [
+                          {
+                            "value": [
+                              "where "
+                            ]
+                          },
+                          {
+                            "r": "23",
+                            "s": [
+                              {
+                                "r": "21",
+                                "s": [
+                                  {
+                                    "r": "20",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "C"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "."
+                                    ]
+                                  },
+                                  {
+                                    "r": "21",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "id"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "=",
+                                  " "
+                                ]
+                              },
+                              {
+                                "r": "22",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "'test'"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
           "expression": {
+            "localId": "24",
+            "locator": "25:3-25:46",
             "type": "Query",
             "source": [
               {
+                "localId": "19",
+                "locator": "25:3-25:26",
                 "alias": "C",
                 "expression": {
+                  "localId": "18",
+                  "locator": "25:3-25:24",
                   "dataType": "{http://hl7.org/fhir}Condition",
                   "templateId": "http://hl7.org/fhir/StructureDefinition/Condition",
                   "codeProperty": "code",
                   "type": "Retrieve",
                   "codes": {
+                    "locator": "25:15-25:23",
                     "name": "test-vs",
                     "type": "ValueSetRef"
                   }
@@ -130,6 +426,8 @@
             "relationship": [
             ],
             "where": {
+              "localId": "23",
+              "locator": "25:28-25:46",
               "type": "Equal",
               "operand": [
                 {
@@ -138,6 +436,8 @@
                   "type": "FunctionRef",
                   "operand": [
                     {
+                      "localId": "21",
+                      "locator": "25:34-25:37",
                       "path": "id",
                       "scope": "C",
                       "type": "Property"
@@ -145,6 +445,8 @@
                   ]
                 },
                 {
+                  "localId": "22",
+                  "locator": "25:41-25:46",
                   "valueType": "{urn:hl7-org:elm-types:r1}String",
                   "value": "test",
                   "type": "Literal"
@@ -154,22 +456,171 @@
           }
         },
         {
+          "localId": "27",
+          "locator": "27:1-28:20",
           "name": "SimpleExpressionRef",
           "context": "Patient",
           "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "27",
+                "s": [
+                  {
+                    "value": [
+                      "define ",
+                      "\"SimpleExpressionRef\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "26",
+                    "s": [
+                      {
+                        "value": [
+                          "\"SimpleVSRetrieve\""
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
           "expression": {
+            "localId": "26",
+            "locator": "28:3-28:20",
             "name": "SimpleVSRetrieve",
             "type": "ExpressionRef"
           }
         },
         {
+          "localId": "30",
+          "locator": "30:1-31:30",
           "name": "DepExpressionRef",
           "context": "Patient",
           "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "30",
+                "s": [
+                  {
+                    "value": [
+                      "define ",
+                      "\"DepExpressionRef\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "29",
+                    "s": [
+                      {
+                        "r": "28",
+                        "s": [
+                          {
+                            "value": [
+                              "\"SimpleDep\""
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "."
+                        ]
+                      },
+                      {
+                        "r": "29",
+                        "s": [
+                          {
+                            "value": [
+                              "\"SimpleRetrieve\""
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
           "expression": {
+            "localId": "29",
+            "locator": "31:3-31:30",
             "name": "SimpleRetrieve",
             "libraryName": "SimpleDep",
             "type": "ExpressionRef"
+          }
+        },
+        {
+          "localId": "32",
+          "locator": "33:1-34:29",
+          "name": "SimpleConceptRetrieve",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "32",
+                "s": [
+                  {
+                    "value": [
+                      "define ",
+                      "\"SimpleConceptRetrieve\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "31",
+                    "s": [
+                      {
+                        "value": [
+                          "[",
+                          "Procedure",
+                          ": "
+                        ]
+                      },
+                      {
+                        "s": [
+                          {
+                            "value": [
+                              "\"test-concept\""
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "]"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "31",
+            "locator": "34:3-34:29",
+            "dataType": "{http://hl7.org/fhir}Procedure",
+            "templateId": "http://hl7.org/fhir/StructureDefinition/Procedure",
+            "codeProperty": "code",
+            "type": "Retrieve",
+            "codes": {
+              "path": "codes",
+              "type": "Property",
+              "source": {
+                "locator": "34:15-34:28",
+                "name": "test-concept",
+                "type": "ConceptRef"
+              }
+            }
           }
         }
       ]

--- a/test/fixtures/elm/queries/SimpleQueriesDependency.cql
+++ b/test/fixtures/elm/queries/SimpleQueriesDependency.cql
@@ -1,0 +1,11 @@
+library SimpleDep version '0.0.1'
+
+using FHIR version '4.0.1'
+
+include FHIRHelpers version '4.0.1'
+
+valueset "test-vs-2": 'http://example.com/test-vs-2'
+
+define "SimpleRetrieve":
+  [Condition: "test-vs-2"]
+

--- a/test/fixtures/elm/queries/SimpleQueriesDependency.json
+++ b/test/fixtures/elm/queries/SimpleQueriesDependency.json
@@ -2,7 +2,7 @@
   "library": {
     "annotation": [
       {
-        "translatorOptions": "",
+        "translatorOptions": "EnableAnnotations,EnableLocators",
         "type": "CqlToElmInfo"
       }
     ],
@@ -21,6 +21,8 @@
           "uri": "urn:hl7-org:elm-types:r1"
         },
         {
+          "localId": "1",
+          "locator": "3:1-3:26",
           "localIdentifier": "FHIR",
           "uri": "http://hl7.org/fhir",
           "version": "4.0.1"
@@ -30,6 +32,8 @@
     "includes": {
       "def": [
         {
+          "localId": "2",
+          "locator": "5:1-5:35",
           "localIdentifier": "FHIRHelpers",
           "path": "FHIRHelpers",
           "version": "4.0.1"
@@ -39,6 +43,8 @@
     "valueSets": {
       "def": [
         {
+          "localId": "3",
+          "locator": "7:1-7:52",
           "name": "test-vs-2",
           "id": "http://example.com/test-vs-2",
           "accessLevel": "Public"
@@ -48,15 +54,63 @@
     "statements": {
       "def": [
         {
+          "localId": "5",
+          "locator": "9:1-10:26",
           "name": "SimpleRetrieve",
           "context": "Patient",
           "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "5",
+                "s": [
+                  {
+                    "value": [
+                      "define ",
+                      "\"SimpleRetrieve\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "4",
+                    "s": [
+                      {
+                        "value": [
+                          "[",
+                          "Condition",
+                          ": "
+                        ]
+                      },
+                      {
+                        "s": [
+                          {
+                            "value": [
+                              "\"test-vs-2\""
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "]"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
           "expression": {
+            "localId": "4",
+            "locator": "10:3-10:26",
             "dataType": "{http://hl7.org/fhir}Condition",
             "templateId": "http://hl7.org/fhir/StructureDefinition/Condition",
             "codeProperty": "code",
             "type": "Retrieve",
             "codes": {
+              "locator": "10:15-10:25",
               "name": "test-vs-2",
               "type": "ValueSetRef"
             }

--- a/test/fixtures/elm/queries/SimpleQueriesDependency.json
+++ b/test/fixtures/elm/queries/SimpleQueriesDependency.json
@@ -1,0 +1,68 @@
+{
+  "library": {
+    "annotation": [
+      {
+        "translatorOptions": "",
+        "type": "CqlToElmInfo"
+      }
+    ],
+    "identifier": {
+      "id": "SimpleDep",
+      "version": "0.0.1"
+    },
+    "schemaIdentifier": {
+      "id": "urn:hl7-org:elm",
+      "version": "r1"
+    },
+    "usings": {
+      "def": [
+        {
+          "localIdentifier": "System",
+          "uri": "urn:hl7-org:elm-types:r1"
+        },
+        {
+          "localIdentifier": "FHIR",
+          "uri": "http://hl7.org/fhir",
+          "version": "4.0.1"
+        }
+      ]
+    },
+    "includes": {
+      "def": [
+        {
+          "localIdentifier": "FHIRHelpers",
+          "path": "FHIRHelpers",
+          "version": "4.0.1"
+        }
+      ]
+    },
+    "valueSets": {
+      "def": [
+        {
+          "name": "test-vs-2",
+          "id": "http://example.com/test-vs-2",
+          "accessLevel": "Public"
+        }
+      ]
+    },
+    "statements": {
+      "def": [
+        {
+          "name": "SimpleRetrieve",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "expression": {
+            "dataType": "{http://hl7.org/fhir}Condition",
+            "templateId": "http://hl7.org/fhir/StructureDefinition/Condition",
+            "codeProperty": "code",
+            "type": "Retrieve",
+            "codes": {
+              "name": "test-vs-2",
+              "type": "ValueSetRef"
+            }
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
# Summary

This PR includes the initial work towards using fqm-execution for gaps in care.

There is a new option in the CLI to run with output type `gaps`. Right now, this will output any queries used by the numerator clause for FHIR resources along with the corresponding code or valueset, IFF the patient in question was in the denominator but not the numerator.

## New behavior

* New CLI output type to output the information

## Code changes

* `calculateGapsInCare` function in `Calculator.ts` that does the processing of the population results to determine if the numerator queries should be parsed (i.e. if the patient is in denom but not numer)
* `findRetrieves` function in `CalculatorHelpers.ts` that recursively traverses the ELM tree for `Retreive` expressions, which are the ones that specify a data type and code/valueset.
* Unit test for the recursive function
* Updated some of the ELM types to have more info

# Testing guidance

Run the CLI with output type `gaps`. To see meaningful results, test with a denominator patient (we have some in our test/fixtures directory for EXM130). There will be a new `gaps.json` file in the debug folder as well as the result output to the console.
