### PR TITLE
Add example detected issue fixture

### DIFF
--- a/test/fixtures/gaps/example-detected-issue.json
+++ b/test/fixtures/gaps/example-detected-issue.json
@@ -1,5 +1,6 @@
 {
   "resourceType": "DetectedIssue",
+  "status": "final",
   "code": {
     "coding": [
       {
@@ -11,6 +12,11 @@
   },
   "evidence": [
     {
+      "detail": [
+        {
+          "reference": "MeasureReport/example"
+        }
+      ],
       "extension": [
         {
           "url": "http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-gap-data",
@@ -38,6 +44,11 @@
       ]
     },
     {
+      "detail": [
+        {
+          "reference": "MeasureReport/example"
+        }
+      ],
       "extension": [
         {
           "url": "http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-gap-data",
@@ -65,6 +76,11 @@
       ]
     },
     {
+      "detail": [
+        {
+          "reference": "MeasureReport/example"
+        }
+      ],
       "extension": [
         {
           "url": "http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-gap-data",
@@ -92,6 +108,11 @@
       ]
     },
     {
+      "detail": [
+        {
+          "reference": "MeasureReport/example"
+        }
+      ],
       "extension": [
         {
           "url": "http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-gap-data",
@@ -119,6 +140,11 @@
       ]
     },
     {
+      "detail": [
+        {
+          "reference": "MeasureReport/example"
+        }
+      ],
       "extension": [
         {
           "url": "http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-gap-data",

--- a/test/fixtures/gaps/example-detected-issue.json
+++ b/test/fixtures/gaps/example-detected-issue.json
@@ -1,0 +1,149 @@
+{
+  "resourceType": "DetectedIssue",
+  "code": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/detectedissue-category",
+        "code": "care-gap",
+        "display": "Gap in Care Detected"
+      }
+    ]
+  },
+  "evidence": [
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-gap-data",
+          "valueDataRequirement": {
+            "type": "Procedure",
+            "codeFilter": [
+              {
+                "path": "code",
+                "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1020"
+              }
+            ]
+          }
+        },
+        {
+          "url": "http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-gaps-status",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/us/davinci-deqm/CodeSystem/gaps-status",
+                "code": "open-gap"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-gap-data",
+          "valueDataRequirement": {
+            "type": "Procedure",
+            "codeFilter": [
+              {
+                "path": "code",
+                "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1011"
+              }
+            ]
+          }
+        },
+        {
+          "url": "http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-gaps-status",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/us/davinci-deqm/CodeSystem/gaps-status",
+                "code": "open-gap"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-gap-data",
+          "valueDataRequirement": {
+            "type": "Procedure",
+            "codeFilter": [
+              {
+                "path": "code",
+                "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1010"
+              }
+            ]
+          }
+        },
+        {
+          "url": "http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-gaps-status",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/us/davinci-deqm/CodeSystem/gaps-status",
+                "code": "open-gap"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-gap-data",
+          "valueDataRequirement": {
+            "type": "Procedure",
+            "codeFilter": [
+              {
+                "path": "code",
+                "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1039"
+              }
+            ]
+          }
+        },
+        {
+          "url": "http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-gaps-status",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/us/davinci-deqm/CodeSystem/gaps-status",
+                "code": "open-gap"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-gap-data",
+          "valueDataRequirement": {
+            "type": "Procedure",
+            "codeFilter": [
+              {
+                "path": "code",
+                "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1038"
+              }
+            ]
+          }
+        },
+        {
+          "url": "http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-gaps-status",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/us/davinci-deqm/CodeSystem/gaps-status",
+                "code": "open-gap"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This PR showcases how we plan to model gaps in care using the [DEQM DetectedIssue Profile](http://build.fhir.org/ig/HL7/davinci-deqm/StructureDefinition-gaps-detectedissue-deqm.html). This requires 2 extensions. Neither of which actually exist yet, but can be added to the ballot. The URLs i've included here are just for demonstration.

1) `http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-gap-data`: this extension will contain the dataRequirement for this given query for which data type and code/valueset it is looking for
2) `http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-gaps-status`: this extension will indicate if the gap is due to missing data (open-gap) or present data (closed-gap)

The only review that's required here is visual inspection