### PR TITLE
Debug Refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ const gapsInCare = Calculator.calculateGapsInCare(measureBundle, patientBundles,
 The options that we support for calculation are as follows:
 | option                 |  type   | optional? | description                                                                 |
 | :--------------------- | :-----: | :-------: | :-------------------------------------------------------------------------- |
+| enableDebugOutput      | boolean |    yes    |                 Enable debug output from function calls. Defaults to false. |
 | includeClauseResults   | boolean |    yes    |                        Option to include clause results. Defaults to false. |
 | includePrettyResults   | boolean |    yes    |   Option to include pretty results on statement results. Defaults to false. |
 | includeHighlighting    | boolean |    yes    |         Include highlighting in MeasureReport narrative. Defaults to false. |
@@ -79,6 +80,7 @@ To run the globally installed CLI (see above), use the global `fqm-exeuction com
 Usage: fqm-execution [options]
 
 Options:
+  -d, --debug                                 enable debug output (default: false)
   -o, --output-type <type>                    type of output, "raw", "detailed", "reports", "gaps" (default: "detailed")
   -m, --measure-bundle <measure-bundle>       path to measure bundle
   -p, --patient-bundles <patient-bundles...>  paths to patient bundle
@@ -134,6 +136,10 @@ Or using the built JavaScript:
 npm run build
 node build/cli.js [options]
 ```
+
+### Debug Option
+
+The CLI comes build with a debug option (`-d/--debug`) which will include a `debugOutput` property on the results object containing any CQL, ELM, ValueSets, and engine results processed during execution.
 
 ### Debugging in VS Code
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ node build/cli.js [options]
 
 ### Debug Option
 
-The CLI comes build with a debug option (`-d/--debug`) which will include a `debugOutput` property on the results object containing any CQL, ELM, ValueSets, and engine results processed during execution.
+The CLI comes built with a debug option (`-d/--debug`) which will include a `debugOutput` property on the results object containing any CQL, ELM, ValueSets, and engine results processed during execution.
 
 ### Debugging in VS Code
 

--- a/src/DebugHelper.ts
+++ b/src/DebugHelper.ts
@@ -2,18 +2,20 @@ import { ELM } from './types/ELMTypes';
 import { ValueSetMap } from './types/CQLTypes';
 import fs from 'fs';
 
-export function dumpHTML(htmlString: string, nameInDebugFolder: string): void {
+export function dumpHTMLs(htmls: { name: string; html: string }[]): void {
   // create debug folder if it doesnt exist
-  if (!fs.existsSync('debug')) {
-    fs.mkdirSync('debug', { recursive: true });
+  if (!fs.existsSync('debug/html')) {
+    fs.mkdirSync('debug/html', { recursive: true });
   }
 
-  // delete old copy
-  if (fs.existsSync(`debug/${nameInDebugFolder}`)) {
-    fs.unlinkSync(`debug/${nameInDebugFolder}`);
-  }
+  htmls.forEach(h => {
+    // delete old copy
+    if (fs.existsSync(`debug/html/${h.name}`)) {
+      fs.unlinkSync(`debug/html/${h.name}`);
+    }
 
-  fs.writeFileSync(`debug/${nameInDebugFolder}`, htmlString);
+    fs.writeFileSync(`debug/html/${h.name}`, h.html);
+  });
 }
 
 export function dumpELMJSONs(elmJSONs: ELM[]): void {

--- a/src/DebugHelper.ts
+++ b/src/DebugHelper.ts
@@ -2,6 +2,12 @@ import { ELM } from './types/ELMTypes';
 import { ValueSetMap } from './types/CQLTypes';
 import fs from 'fs';
 
+export function clearDebugFolder(): void {
+  if (fs.existsSync('debug/')) {
+    fs.rmdirSync('debug/', { recursive: true });
+  }
+}
+
 export function dumpHTMLs(htmls: { name: string; html: string }[]): void {
   // create debug folder if it doesnt exist
   if (!fs.existsSync('debug/html')) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,7 +5,7 @@ import { program } from 'commander';
 import fs from 'fs';
 import path from 'path';
 import { calculate, calculateGapsInCare, calculateMeasureReports, calculateRaw } from './Calculator';
-import { dumpCQLs, dumpELMJSONs, dumpHTMLs, dumpObject, dumpVSMap } from './DebugHelper';
+import { clearDebugFolder, dumpCQLs, dumpELMJSONs, dumpHTMLs, dumpObject, dumpVSMap } from './DebugHelper';
 
 program
   .option('-d, --debug', 'enable debug output', false)
@@ -41,6 +41,8 @@ if (program.outputType === 'raw') {
 }
 
 if (program.debug) {
+  clearDebugFolder();
+
   const debugOutput = result?.debugOutput;
 
   // Dump raw, detailed, reports, gapt in care objects

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -23,6 +23,8 @@ export interface CalculationOptions {
   calculateSDEs?: boolean;
   /** Include HTML structure for highlighting */
   calculateHTML?: boolean;
+  /** Enable debug output including CQL, ELM, results */
+  enableDebugOutput?: boolean;
 }
 
 /**
@@ -198,4 +200,18 @@ export interface DataTypeQuery {
   queryLocalId?: string;
   /** name of the library where the statment can be looked up */
   libraryName?: string;
+}
+
+/*
+ * Debug output if enabled
+ */
+export interface DebugOutput {
+  cql?: { name: string; cql: string }[];
+  elm?: ELM[];
+  vs?: cql.ValueSetMap;
+  html?: { name: string; html: string }[];
+  rawResults?: cql.Results | string;
+  detailedResults?: ExecutionResult[];
+  measureReports?: R4.IMeasureReport[];
+  gaps?: DataTypeQuery[];
 }


### PR DESCRIPTION
# Summary

Refactor debug output behavior to be optional, and to not use `fs` in any core pieces of the code

## New behavior

Debug output is now a property on the return result of `calculate`, `calculateRaw`, and `calculateMeasureReports`. the CLI will dump this to a `debug` folder as before when the debug option is specified at runtime of the CLI.

## Code changes

* Modify core functions to return `{ results: CurrentReturnType, debugOutput: DebugOutput }` type motif
* Move debug output writing functionality to purely CLI
* Add `-d/--debug` option to CLI and `enableDebugOutput` calculation option
* update docs

# Testing guidance

* Remove your existing debug folder to start from clean slate
* Run the CLI first without the `-d` option (there should be no debug folder created)
* Run the CLI with the `-d` option. `debugOutput` should be present on the results and all the same debug info will be dumped to the `debug` folder as before