### PR TITLE
Browser friendly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "version": "4.0.34",
       "resolved": "https://registry.npmjs.org/@ahryman40k/ts-fhir-types/-/ts-fhir-types-4.0.34.tgz",
       "integrity": "sha512-G/o0wmYoqOfvgSids46U6ge767OjQfNkr8lUcqblZsLpOZF/xiXE46eXmfmnxzjYD2FvlpUQM4LxmK4f0feWkA==",
-      "dev": true,
       "requires": {
         "fp-ts": "^2.8.3",
         "io-ts": "^2.0.0",
@@ -3691,8 +3690,7 @@
     "fp-ts": {
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.8.5.tgz",
-      "integrity": "sha512-g6do+Q/IQsxgsd2qU6+QnAbZaPR533seIbFyLGqWSxhNX4+F+cY37QdaYmMUOzekLOv/yg/2f15tc26tzDatgw==",
-      "dev": true
+      "integrity": "sha512-g6do+Q/IQsxgsd2qU6+QnAbZaPR533seIbFyLGqWSxhNX4+F+cY37QdaYmMUOzekLOv/yg/2f15tc26tzDatgw=="
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -4018,8 +4016,7 @@
     "io-ts": {
       "version": "2.2.12",
       "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-2.2.12.tgz",
-      "integrity": "sha512-pZh43E3xs1RUmv3voC58Mbb6Ihjo3UdDU6WWi578Zpe2BxVue1SlSQCioSymZxk9HoXa370nSfFzp5LrLA2F8g==",
-      "dev": true
+      "integrity": "sha512-pZh43E3xs1RUmv3voC58Mbb6Ihjo3UdDU6WWi578Zpe2BxVue1SlSQCioSymZxk9HoXa370nSfFzp5LrLA2F8g=="
     },
     "ip-regex": {
       "version": "2.1.0",
@@ -6589,8 +6586,7 @@
     "reflect-metadata": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
-      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==",
-      "dev": true
+      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
     },
     "regenerate": {
       "version": "1.4.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2759,21 +2759,6 @@
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
-    "copyfiles": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/copyfiles/-/copyfiles-2.4.0.tgz",
-      "integrity": "sha512-yGjpR3yjQdxccW8EcJ4a7ZCA6wGER6/Q2Y+b7bXbVxGeSHBf93i9d7MzTsx+VV1CpMKQa3v4ThZfXBcltMzl0w==",
-      "dev": true,
-      "requires": {
-        "glob": "^7.0.5",
-        "minimatch": "^3.0.3",
-        "mkdirp": "^1.0.4",
-        "noms": "0.0.0",
-        "through2": "^2.0.1",
-        "untildify": "^4.0.0",
-        "yargs": "^15.3.1"
-      }
-    },
     "core-js-compat": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.7.0.tgz",
@@ -6166,42 +6151,6 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.66.tgz",
       "integrity": "sha512-JHEQ1iWPGK+38VLB2H9ef2otU4l8s3yAMt9Xf934r6+ojCYDMHPMqvCc9TnzfeFSP1QEOeU6YZEd3+De0LTCgg=="
     },
-    "noms": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/noms/-/noms-0.0.0.tgz",
-      "integrity": "sha1-2o69nzr51nYJGbJ9nNyAkqczKFk=",
-      "dev": true,
-      "requires": {
-        "inherits": "^2.0.1",
-        "readable-stream": "~1.0.31"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        }
-      }
-    },
     "normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -6527,7 +6476,8 @@
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "optional": true
     },
     "progress": {
       "version": "2.0.3",
@@ -6614,6 +6564,7 @@
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "optional": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -7284,6 +7235,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "optional": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -7446,16 +7398,6 @@
       "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
       "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
       "dev": true
-    },
-    "through2": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-      "dev": true,
-      "requires": {
-        "readable-stream": "~2.3.6",
-        "xtend": "~4.0.1"
-      }
     },
     "tmpl": {
       "version": "1.0.4",
@@ -7707,12 +7649,6 @@
         }
       }
     },
-    "untildify": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
-      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
-      "dev": true
-    },
     "upath": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
@@ -7741,7 +7677,8 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "optional": true
     },
     "uuid": {
       "version": "8.3.1",
@@ -7983,12 +7920,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "dev": true
-    },
-    "xtend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "dev": true
     },
     "y18n": {

--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
     "cql-execution": "2.1.0",
     "handlebars": "^4.7.6",
     "moment": "^2.29.0",
-    "uuid": "^8.3.1"
+    "uuid": "^8.3.1",
+    "@ahryman40k/ts-fhir-types": "^4.0.32"
   },
   "devDependencies": {
-    "@ahryman40k/ts-fhir-types": "^4.0.32",
     "@types/handlebars": "^4.1.0",
     "@types/jest": "^26.0.5",
     "@types/node": "^14.0.23",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@types/uuid": "^8.3.0",
     "@typescript-eslint/eslint-plugin": "^3.2.0",
     "@typescript-eslint/parser": "^3.2.0",
-    "copyfiles": "^2.4.0",
     "eslint": "^7.5.0",
     "eslint-config-prettier": "^6.11.0",
     "jest": "^26.1.0",
@@ -36,7 +35,7 @@
     "typescript": "^3.9.7"
   },
   "scripts": {
-    "build": "rm -rf ./build && tsc && npm run copy-templates",
+    "build": "rm -rf ./build && tsc",
     "build:watch": "rm -rf ./build && tsc -w",
     "lint": "tsc && eslint \"**/*.{js,ts}\"",
     "lint:fix": "tsc --noEmit && eslint \"**/*.{js,ts}\" --quiet --fix",
@@ -45,8 +44,7 @@
     "test": "jest",
     "test:watch": "jest --watchAll",
     "check": "npm run test && npm run lint && npm run prettier",
-    "prepare": "npm run build",
-    "copy-templates": "copyfiles -u 1 ./src/templates/*.hbs ./build/"
+    "prepare": "npm run build"
   },
   "repository": {
     "type": "git",

--- a/src/Calculator.ts
+++ b/src/Calculator.ts
@@ -123,7 +123,7 @@ export function calculate(
             name: `clauses-${detailedGroupResult.groupId}.html`,
             html
           };
-          if (debugObject.html?.length !== 0) {
+          if (Array.isArray(debugObject.html) && debugObject.html?.length !== 0) {
             debugObject.html?.push(debugHtml);
           } else {
             debugObject.html = [debugHtml];

--- a/src/HTMLGenerator.ts
+++ b/src/HTMLGenerator.ts
@@ -1,12 +1,9 @@
 import { Annotation, ELM } from './types/ELMTypes';
 import Handlebars from 'handlebars';
-import fs from 'fs';
-import path from 'path';
 import { ClauseResult, StatementResult } from './types/Calculator';
 import { FinalResult, Relevance } from './types/Enums';
-
-const mainTemplate = fs.readFileSync(path.join(__dirname, './templates/main.hbs'), 'utf8');
-const clauseTemplate = fs.readFileSync(path.join(__dirname, './templates/clause.hbs'), 'utf8');
+import mainTemplate from './templates/main';
+import clauseTemplate from './templates/clause';
 
 export const cqlLogicClauseTrueStyle = {
   'background-color': '#ccebe0',

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -28,7 +28,7 @@ if (program.outputType === 'raw') {
   result = calculateRaw(measureBundle, patientBundles, { enableDebugOutput: program.debug });
 } else if (program.outputType === 'detailed') {
   result = calculate(measureBundle, patientBundles, { calculateSDEs: true, enableDebugOutput: program.debug });
-} else if (program.outputType == 'reports') {
+} else if (program.outputType === 'reports') {
   result = calculateMeasureReports(measureBundle, patientBundles, {
     measurementPeriodStart: '2019-01-01',
     measurementPeriodEnd: '2019-12-31',

--- a/src/templates/clause.ts
+++ b/src/templates/clause.ts
@@ -8,4 +8,3 @@ export default `<span{{#if r}} data-ref-id="{{r}}" style="{{highlightClause r}}"
 {{~/each ~}}
 {{~/if~}}
 </span>`;
-

--- a/src/templates/clause.ts
+++ b/src/templates/clause.ts
@@ -1,4 +1,4 @@
-<span{{#if r}} data-ref-id="{{r}}" style="{{highlightClause r}}"{{/if}}>
+export default `<span{{#if r}} data-ref-id="{{r}}" style="{{highlightClause r}}"{{/if}}>
 {{~#if value ~}}
 {{ concat value }}
 {{~/if ~}}
@@ -7,4 +7,5 @@
 {{> clause ~}}
 {{~/each ~}}
 {{~/if~}}
-</span>
+</span>`;
+

--- a/src/templates/main.hbs
+++ b/src/templates/main.hbs
@@ -1,5 +1,0 @@
-<pre style="tab-size: 2; border-bottom-width: 4px; line-height: 1.4">
-<code>
-{{> clause}}
-</code>
-</pre>

--- a/src/templates/main.ts
+++ b/src/templates/main.ts
@@ -1,0 +1,6 @@
+export default `<pre style="tab-size: 2; border-bottom-width: 4px; line-height: 1.4">
+<code>
+{{> clause}}
+</code>
+</pre>`;
+

--- a/src/templates/main.ts
+++ b/src/templates/main.ts
@@ -3,4 +3,3 @@ export default `<pre style="tab-size: 2; border-bottom-width: 4px; line-height: 
 {{> clause}}
 </code>
 </pre>`;
-


### PR DESCRIPTION
# Summary

DRAFT: Review #27 first.

This PR removes non-browser-friendly code from the library. Namely, the usage of `fs` in the HTMLGenerator. Everything else is fair game. Webpack/other bundlers were not needed.

## New behavior

Nothing really. Build script no longer copies over handlebars files as there are none now.

## Code changes

* Add the fhir types library to regular dependencies: we require it directly into the app.
* Change handlebars templates to be strings exported by ts files

# Testing guidance

* Clone [this repo](https://github.com/mgramigna/fqm-example-browser-usage)
* npm install
* npm start

Note that this example app that I made uses fqm-execution as a dependency. An app will load in the browser with a button that will call fqm-execution's `calculate` function directly in the browser. Calculation results will be rendered on the screen.

Also worth testing that html generation still works by running with output type `reports` and confirming that html output is as expected.
