### PR TITLE
Add makefile for translating cql test fixtures in gaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ build/
 debug/
 .vscode
 **/.DS_Store
+test/fixtures/elm/queries/translation-output
+test/fixtures/elm/queries/.start-translator

--- a/test/fixtures/elm/queries/Makefile
+++ b/test/fixtures/elm/queries/Makefile
@@ -1,0 +1,24 @@
+all: .start-translator translate
+
+.start-translator:
+	docker pull cqframework/cql-translation-service:latest
+	docker run --name cql-translation-service --rm -dit -p 8080:8080 cqframework/cql-translation-service:latest
+	sleep 5
+	touch .start-translator
+
+FILES := $(shell find *.cql)
+
+define get_file_args
+	$(eval FILE_ARGS += -F $(basename $1)=@$1)
+endef
+
+translate:
+	$(info $$FILES is [${FILES}])
+	$(foreach f, $(FILES),$(call get_file_args,$(f)))
+	$(info $$FILE_ARGS is [${FILE_ARGS}])
+	curl $(FILE_ARGS) "http://localhost:8080/cql/translator?locators=true&annotations=true" > translation-output
+
+clean:
+	-docker stop cql-translation-service
+	-rm .start-translator
+	-rm translation-output


### PR DESCRIPTION
Add Makefile for translating all cql files in the fixtures/elm/queries folder.

User will have to manually copy over the outputted elm json for now because I'm not in the business of parsing out each piece of the multipart form response especially not via bash/makefile.

`make` to translate everything
`make clean` to clean