### PR TITLE
Add helper for extracting measurement period from Measure, and set sane defaults in Calculator.ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ Options:
   -o, --output-type <type>                    type of output, "raw", "detailed", "reports", "gaps" (default: "detailed")
   -m, --measure-bundle <measure-bundle>       path to measure bundle
   -p, --patient-bundles <patient-bundles...>  paths to patient bundle
+  -s, --measurement-period-start <date>       start date for the measurement period, in YYYY-MM-DD format (defaults to the start date defined in the Measure, or 2019-01-01 if not set there)
+  -e, --measurement-period-end <date>         end date for the measurement period, in YYYY-MM-DD format (defaults to the end date defined in the Measure, or 2019-12-31 if not set there)
   -h, --help                                  display help for command
 ```
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   globals: {
     'ts-jest': {
-      tsConfig: 'tsconfig.json'
+      tsconfig: 'tsconfig.json'
     }
   },
   moduleFileExtensions: ['ts', 'js', 'd.ts'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fqm-execution",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fqm-execution",
-  "version": "0.2.0",
+  "version": "0.1.0",
   "description": "FHIR Quality Measure Execution",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fqm-execution",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "FHIR Quality Measure Execution",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/Calculator.ts
+++ b/src/Calculator.ts
@@ -4,6 +4,7 @@ import { PopulationType, MeasureScoreType, ImprovementNotation } from './types/E
 import * as cql from './types/CQLTypes';
 import * as Execution from './Execution';
 import * as CalculatorHelpers from './CalculatorHelpers';
+import { extractMeasurementPeriod } from './MeasureHelpers';
 import * as ResultsHelpers from './ResultsHelpers';
 import * as MeasureReportBuilder from './MeasureReportBuilder';
 import * as GapsInCareHelpers from './GapsInCareHelpers';
@@ -24,6 +25,16 @@ export function calculate(
   options: CalculationOptions
 ): { results: ExecutionResult[]; debugOutput?: DebugOutput; elmLibraries?: ELM[]; mainLibraryName?: string } {
   const debugObject: DebugOutput | undefined = options.enableDebugOutput ? <DebugOutput>{} : undefined;
+
+  // Ensure the CalculationOptions have sane defaults, only if they're not set
+  options.calculateHTML = options.calculateHTML ?? true;
+  options.calculateSDEs = options.calculateSDEs ?? true;
+  // Get the default measurement period out of the Measure object
+  const measureMPs = extractMeasurementPeriod(measureBundle);
+  // Set the measurement period start/end, but only if the caller didn't specify one
+  options.measurementPeriodStart = options.measurementPeriodStart ?? measureMPs.measurementPeriodStart;
+  options.measurementPeriodEnd = options.measurementPeriodEnd ?? measureMPs.measurementPeriodEnd;
+
   const measureEntry = measureBundle.entry?.find(e => e.resource?.resourceType === 'Measure');
   if (!measureEntry || !measureEntry.resource) {
     throw new Error('Measure resource was not found in provided measure bundle');

--- a/src/Calculator.ts
+++ b/src/Calculator.ts
@@ -30,10 +30,10 @@ export function calculate(
   options.calculateHTML = options.calculateHTML ?? true;
   options.calculateSDEs = options.calculateSDEs ?? true;
   // Get the default measurement period out of the Measure object
-  const measureMPs = extractMeasurementPeriod(measureBundle);
+  const measurementPeriod = extractMeasurementPeriod(measureBundle);
   // Set the measurement period start/end, but only if the caller didn't specify one
-  options.measurementPeriodStart = options.measurementPeriodStart ?? measureMPs.measurementPeriodStart;
-  options.measurementPeriodEnd = options.measurementPeriodEnd ?? measureMPs.measurementPeriodEnd;
+  options.measurementPeriodStart = options.measurementPeriodStart ?? measurementPeriod.measurementPeriodStart;
+  options.measurementPeriodEnd = options.measurementPeriodEnd ?? measurementPeriod.measurementPeriodEnd;
 
   const measureEntry = measureBundle.entry?.find(e => e.resource?.resourceType === 'Measure');
   if (!measureEntry || !measureEntry.resource) {

--- a/src/MeasureHelpers.ts
+++ b/src/MeasureHelpers.ts
@@ -1,6 +1,7 @@
 import { ELM, ELMStatement } from './types/ELMTypes';
 import { R4 } from '@ahryman40k/ts-fhir-types';
 import { PopulationType } from './types/Enums';
+import { CalculationOptions } from './types/Calculator';
 
 /**
  * Finds all localIds in a statement by it's library and statement name.
@@ -376,6 +377,27 @@ export function codeableConceptToPopulationType(concept: R4.ICodeableConcept | u
   }
 
   return null;
+}
+
+/**
+ * Pulls the measurement period out of the Measure resource in the provided bundle, assuming one is set.
+ * NOTE: the default start/end values are also set in Execution.ts
+ * so if this date is changed from 2019 it must also be changed there
+ *
+ * @param {R4.IBundle} measureBundle the FHIR Bundle object containing the Measure resource.
+ * @returns {CalculationOptions} object with only the measurement period start/end fields filled out,
+ * or the year 2019 set as the calculation period if not set in the Measure.
+ */
+export function extractMeasurementPeriod(measureBundle: R4.IBundle): CalculationOptions {
+  const measureEntry = measureBundle.entry?.find(e => e.resource?.resourceType === 'Measure');
+  if (!measureEntry || !measureEntry.resource) {
+    throw new Error('Measure resource was not found in provided measure bundle');
+  }
+  const measure = measureEntry.resource as R4.IMeasure;
+  return {
+    measurementPeriodStart: measure.effectivePeriod?.start || '2019-01-01',
+    measurementPeriodEnd: measure.effectivePeriod?.end || '2019-12-31'
+  };
 }
 
 function __guard__(value: any, transform: any) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,12 +6,24 @@ import fs from 'fs';
 import path from 'path';
 import { calculate, calculateGapsInCare, calculateMeasureReports, calculateRaw } from './Calculator';
 import { clearDebugFolder, dumpCQLs, dumpELMJSONs, dumpHTMLs, dumpObject, dumpVSMap } from './DebugHelper';
+import { extractMeasurementPeriod } from './MeasureHelpers';
+import { CalculationOptions } from './types/Calculator';
 
 program
   .option('-d, --debug', 'enable debug output', false)
   .option('-o, --output-type <type>', 'type of output, "raw", "detailed", "reports", "gaps"', 'detailed')
   .requiredOption('-m, --measure-bundle <measure-bundle>', 'path to measure bundle')
   .requiredOption('-p, --patient-bundles <patient-bundles...>', 'paths to patient bundle')
+  .option(
+    '-s, --measurement-period-start <date>',
+    'start date for the measurement period, in YYYY-MM-DD format (defaults to the start date defined in the Measure, or 2019-01-01 if not set there)',
+    undefined
+  )
+  .option(
+    '-e, --measurement-period-end <date>',
+    'end date for the measurement period, in YYYY-MM-DD format (defaults to the end date defined in the Measure, or 2019-12-31 if not set there)',
+    undefined
+  )
   .parse(process.argv);
 
 function parseBundle(filePath: string): R4.IBundle {
@@ -24,20 +36,24 @@ const measureBundle = parseBundle(path.resolve(program.measureBundle));
 const patientBundles = program.patientBundles.map((bundlePath: string) => parseBundle(path.resolve(bundlePath)));
 
 let result;
+
+const calcOptions: CalculationOptions = { enableDebugOutput: program.debug };
+// Override the measurement period start/end in the options only if the user specfied them
+if (program.measurementPeriodStart) {
+  calcOptions.measurementPeriodStart = program.measurementPeriodStart;
+}
+if (program.measurementPeriodEnd) {
+  calcOptions.measurementPeriodEnd = program.measurementPeriodEnd;
+}
+
 if (program.outputType === 'raw') {
-  result = calculateRaw(measureBundle, patientBundles, { enableDebugOutput: program.debug });
+  result = calculateRaw(measureBundle, patientBundles, calcOptions);
 } else if (program.outputType === 'detailed') {
-  result = calculate(measureBundle, patientBundles, { calculateSDEs: true, enableDebugOutput: program.debug });
+  result = calculate(measureBundle, patientBundles, calcOptions);
 } else if (program.outputType === 'reports') {
-  result = calculateMeasureReports(measureBundle, patientBundles, {
-    measurementPeriodStart: '2019-01-01',
-    measurementPeriodEnd: '2019-12-31',
-    calculateSDEs: true,
-    calculateHTML: true,
-    enableDebugOutput: program.debug
-  });
+  result = calculateMeasureReports(measureBundle, patientBundles, calcOptions);
 } else if (program.outputType === 'gaps') {
-  result = calculateGapsInCare(measureBundle, patientBundles, { enableDebugOutput: program.debug });
+  result = calculateGapsInCare(measureBundle, patientBundles, calcOptions);
 }
 
 if (program.debug) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,7 +6,6 @@ import fs from 'fs';
 import path from 'path';
 import { calculate, calculateGapsInCare, calculateMeasureReports, calculateRaw } from './Calculator';
 import { clearDebugFolder, dumpCQLs, dumpELMJSONs, dumpHTMLs, dumpObject, dumpVSMap } from './DebugHelper';
-import { extractMeasurementPeriod } from './MeasureHelpers';
 import { CalculationOptions } from './types/Calculator';
 
 program

--- a/test/MeasureHelpers.test.ts
+++ b/test/MeasureHelpers.test.ts
@@ -196,4 +196,92 @@ describe('MeasureHelpers', () => {
       expect(MeasureHelpers.codeableConceptToPopulationType(codeableConcept)).toBe(null);
     });
   });
+
+  describe('extractMeasurementPeriod', () => {
+    test('Measurement period start set on measure', () => {
+      const measureBundleFixture: R4.IBundle = {
+        resourceType: 'Bundle',
+        entry: [
+          {
+            resource: {
+              resourceType: 'Measure',
+              effectivePeriod: {
+                start: '2000-01-01'
+              }
+            }
+          }
+        ]
+      };
+
+      const mpConfig = MeasureHelpers.extractMeasurementPeriod(measureBundleFixture);
+
+      expect(mpConfig.measurementPeriodStart).toBe('2000-01-01');
+      expect(mpConfig.measurementPeriodEnd).toBe('2019-12-31');
+    });
+
+    test('Measurement period end set on measure', () => {
+      const measureBundleFixture: R4.IBundle = {
+        resourceType: 'Bundle',
+        entry: [
+          {
+            resource: {
+              resourceType: 'Measure',
+              effectivePeriod: {
+                end: '2000-12-31'
+              }
+            }
+          }
+        ]
+      };
+
+      const mpConfig = MeasureHelpers.extractMeasurementPeriod(measureBundleFixture);
+
+      expect(mpConfig.measurementPeriodStart).toBe('2019-01-01');
+      expect(mpConfig.measurementPeriodEnd).toBe('2000-12-31');
+    });
+
+    test('Measurement period start and end set on measure', () => {
+      const measureBundleFixture: R4.IBundle = {
+        resourceType: 'Bundle',
+        entry: [
+          {
+            resource: {
+              resourceType: 'Measure',
+              effectivePeriod: {
+                start: '2000-01-01',
+                end: '2000-12-31'
+              }
+            }
+          }
+        ]
+      };
+
+      const mpConfig = MeasureHelpers.extractMeasurementPeriod(measureBundleFixture);
+
+      expect(mpConfig.measurementPeriodStart).toBe('2000-01-01');
+      expect(mpConfig.measurementPeriodEnd).toBe('2000-12-31');
+    });
+
+    test('Neither set on measure', () => {
+      const measureBundleFixture: R4.IBundle = {
+        resourceType: 'Bundle',
+        entry: [
+          {
+            resource: {
+              resourceType: 'Measure',
+              effectivePeriod: {
+                start: '',
+                end: ''
+              }
+            }
+          }
+        ]
+      };
+
+      const mpConfig = MeasureHelpers.extractMeasurementPeriod(measureBundleFixture);
+
+      expect(mpConfig.measurementPeriodStart).toBe('2019-01-01');
+      expect(mpConfig.measurementPeriodEnd).toBe('2019-12-31');
+    });
+  });
 });


### PR DESCRIPTION
# Summary
This PR adds "sane" defaults for:

* `calculateHTML`: `true`
*  `calculateSDEs`: `true`
* `measurementPeriodStart`/`measurementPeriodEnd`: Whatever the measure sets it to, or `2019-01-01`/`2019-12-31` respectively, if not set in the measure `effectivePeriod` object.
 
 to `Calculator.ts`. It also adds the ability to pass in measurement period strings on the command line, to override the measure.

## New behavior
See above, regarding measurement period default changes.

## Code changes
Added `extractMeasurementPeriod` to `MeasureHelpers.ts` to pull the `effectivePeriod.start`/`.end` out of the `Measure` object, and use that to set defaults in `Calculator.ts`

# Testing guidance
Use the command line `-s` and `-e` flags to test changing the measurement period when calling `fqm-execution`. Using a VS Code debug session, drop a breakpoint in `Calculator.ts` to check the measurement period in `options`.
