### PR TITLE
Add stack of expressions traversed during gaps in care to output

### DIFF
--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -202,6 +202,20 @@ export interface DataTypeQuery {
   queryLocalId?: string;
   /** name of the library where the statment can be looked up */
   libraryName?: string;
+  /** stack of expressions traversed during calculation */
+  expressionStack?: ExpressionStackEntry[];
+}
+
+/**
+ * Expression stack tracked during gaps in care
+ */
+export interface ExpressionStackEntry {
+  /** type of expression (e.g. 'Query') */
+  type: string;
+  /** localId of the expression */
+  localId: string;
+  /** library name where the expression lives */
+  libraryName: string;
 }
 
 /*

--- a/test/GapsInCareHelpers.test.ts
+++ b/test/GapsInCareHelpers.test.ts
@@ -15,9 +15,17 @@ const EXPECTED_VS_RETRIEVE_RESULTS: DataTypeQuery[] = [
     retrieveLocalId: '14',
     parentQueryHasResult: false,
     queryLocalId: undefined,
-    libraryName: 'SimpleQueries'
+    libraryName: 'SimpleQueries',
+    expressionStack: [
+      {
+        localId: '14',
+        libraryName: 'SimpleQueries',
+        type: 'Retrieve'
+      }
+    ]
   }
 ];
+
 const EXPECTED_VS_QUERY_RESULTS: DataTypeQuery[] = [
   {
     dataType: 'Condition',
@@ -26,9 +34,22 @@ const EXPECTED_VS_QUERY_RESULTS: DataTypeQuery[] = [
     retrieveLocalId: '18',
     parentQueryHasResult: false,
     queryLocalId: '24',
-    libraryName: 'SimpleQueries'
+    libraryName: 'SimpleQueries',
+    expressionStack: [
+      {
+        localId: '24',
+        libraryName: 'SimpleQueries',
+        type: 'Query'
+      },
+      {
+        localId: '18',
+        libraryName: 'SimpleQueries',
+        type: 'Retrieve'
+      }
+    ]
   }
 ];
+
 const EXPECTED_CODE_RESULTS: DataTypeQuery[] = [
   {
     dataType: 'Procedure',
@@ -40,9 +61,41 @@ const EXPECTED_CODE_RESULTS: DataTypeQuery[] = [
     retrieveLocalId: '16',
     parentQueryHasResult: false,
     queryLocalId: undefined,
-    libraryName: 'SimpleQueries'
+    libraryName: 'SimpleQueries',
+    expressionStack: [
+      {
+        localId: '16',
+        libraryName: 'SimpleQueries',
+        type: 'Retrieve'
+      }
+    ]
   }
 ];
+
+const EXPECTED_EXPRESSIONREF_RESULTS: DataTypeQuery[] = [
+  {
+    dataType: 'Condition',
+    valueSet: 'http://example.com/test-vs',
+    retrieveHasResult: false,
+    retrieveLocalId: '14',
+    parentQueryHasResult: false,
+    queryLocalId: undefined,
+    libraryName: 'SimpleQueries',
+    expressionStack: [
+      {
+        localId: '26',
+        libraryName: 'SimpleQueries',
+        type: 'ExpressionRef'
+      },
+      {
+        localId: '14',
+        libraryName: 'SimpleQueries',
+        type: 'Retrieve'
+      }
+    ]
+  }
+];
+
 const EXPECTED_DEPENDENCY_RESULTS: DataTypeQuery[] = [
   {
     dataType: 'Condition',
@@ -51,9 +104,22 @@ const EXPECTED_DEPENDENCY_RESULTS: DataTypeQuery[] = [
     retrieveLocalId: '4',
     parentQueryHasResult: false,
     queryLocalId: undefined,
-    libraryName: 'SimpleDep'
+    libraryName: 'SimpleDep',
+    expressionStack: [
+      {
+        localId: '29',
+        libraryName: 'SimpleQueries',
+        type: 'ExpressionRef'
+      },
+      {
+        localId: '4',
+        libraryName: 'SimpleDep',
+        type: 'Retrieve'
+      }
+    ]
   }
 ];
+
 const EXAMPLE_DETAILED_RESULTS: DetailedPopulationGroupResult = {
   groupId: 'example',
   statementResults: [],
@@ -162,7 +228,7 @@ describe('Find Numerator Queries', () => {
       expressionRef.expression,
       EXAMPLE_DETAILED_RESULTS
     );
-    expect(results).toEqual(EXPECTED_VS_RETRIEVE_RESULTS);
+    expect(results).toEqual(EXPECTED_EXPRESSIONREF_RESULTS);
   });
 
   test('dependent library expression ref', () => {


### PR DESCRIPTION
# Summary

Adds a property to the external data model for GiC that tracks each expression traversed during the calculation. Each entry on the stack indicate the expression type, and the local ID/library for lookup later.

This is not used right now, but will be useful when we eventually start to handle more logic like `Or`s and `Not`s

## New behavior

N/A. Just another property that will exist on the debug output for now. Will be used later.

## Code changes

* Add new property to `DataTypeQuery` interface for the stack of expressions
* Push to stack during recursion of gaps in care traversal
* Add unit test cases

# Testing guidance

* Run usual checks
* Inspect the debug output when running gaps to confirm the presence/format of the expression stack (`debug/gaps.json`)
