### PR TITLE
Do not calculate gaps for denominator exclusion or exception patients

### DIFF
--- a/src/Calculator.ts
+++ b/src/Calculator.ts
@@ -241,6 +241,7 @@ export function calculateGapsInCare(
 
       const denomResult = dr.populationResults?.find(pr => pr.populationType === PopulationType.DENOM)?.result;
       const numerResult = dr.populationResults?.find(pr => pr.populationType === PopulationType.NUMER)?.result;
+      const numerRelevance = dr.populationRelevance?.find(pr => pr.populationType === PopulationType.NUMER)?.result;
 
       if (!measureResource.improvementNotation?.coding) {
         throw new Error('Measure resource must include improvement notation');
@@ -254,8 +255,10 @@ export function calculateGapsInCare(
 
       // If positive improvement measure, consider patients in denominator but not numerator for gaps
       // If negative improvement measure, consider patients in numerator for gaps
+      // For either case, ignore patient if numerator isn't relevant
       const populationCriteria =
-        improvementNotation === ImprovementNotation.POSITIVE ? denomResult && !numerResult : numerResult;
+        numerRelevance &&
+        (improvementNotation === ImprovementNotation.POSITIVE ? denomResult && !numerResult : numerResult);
 
       if (populationCriteria) {
         const matchingGroup = measureResource.group?.find(g => g.id === dr.groupId);


### PR DESCRIPTION
# Summary
Updates gaps calculation so that gaps are not calculated for patients that fall into the denominator exception or denominator exclusion.
## New behavior
Adds a check of detailed results population relevance. If the numerator is false, then this patient was never even considered for the numerator, so there are no gaps that could have gotten it into the numerator. (Or for negative improvement notation, it can't be in the negatively-associated numerator). Now gaps are not generated for this case of patients for which there are no gaps.
## Code changes
Small changes in Calculator.ts
# Testing guidance
This was tested with connectathon's [EXM124-9.0.000](https://github.com/DBCG/connectathon/blob/master/fhir401/bundles/measure/EXM124-9.0.000/EXM124-9.0.000-bundle.json). [Denex patient](https://github.com/DBCG/connectathon/blob/master/fhir401/bundles/measure/EXM124-9.0.000/EXM124-9.0.000-files/tests-denomexcl-EXM124-bundle.json) now does not generate gaps, but [Denom patient](https://github.com/DBCG/connectathon/blob/master/fhir401/bundles/measure/EXM124-9.0.000/EXM124-9.0.000-files/tests-denom-EXM124-bundle.json) still does generate gaps.
