### PR TITLE
Update evaluatedResource support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1670,6 +1670,22 @@
         }
       }
     },
+    "@lhncbc/ucum-lhc": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@lhncbc/ucum-lhc/-/ucum-lhc-4.1.4.tgz",
+      "integrity": "sha512-ErlXJv6lrerZbthxc33SWTKrZv4KjMIaCN2lNxsNrGZW4PqyVFEKDie6lok//SvC6QeEoAC1mWN8xD87r72qPQ==",
+      "requires": {
+        "csv-parse": "^4.4.6",
+        "csv-stringify": "^1.0.4",
+        "escape-html": "^1.0.3",
+        "is-integer": "^1.0.6",
+        "jsonfile": "^2.2.3",
+        "stream": "0.0.2",
+        "stream-transform": "^0.1.1",
+        "string-to-stream": "^1.1.0",
+        "xmldoc": "^0.4.0"
+      }
+    },
     "@nicolo-ribaudo/chokidar-2": {
       "version": "2.1.8",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8.tgz",
@@ -2795,12 +2811,12 @@
       }
     },
     "cql-execution": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-2.1.0.tgz",
-      "integrity": "sha512-k/6Vm60SCqH+1/RWOrRYNx9DYK9slJAc+wsTZx5Flpu/vRW7rAmRwGRwPalCldDcSvRpdYoAmrWkXu65o32T3A==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-2.2.0.tgz",
+      "integrity": "sha512-arbfPCwl+ZrJQC+QEmYYXGlShMOTNSzIkQFKva11WYUCl+NHvHU1zvyEWPixUF5dw0m5rPn1nATdZp21oAbudg==",
       "requires": {
-        "moment": "^2.27.0",
-        "ucum": "^0.0.7"
+        "@lhncbc/ucum-lhc": "^4.1.3",
+        "luxon": "^1.25.0"
       }
     },
     "create-require": {
@@ -2840,6 +2856,19 @@
           "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
           "dev": true
         }
+      }
+    },
+    "csv-parse": {
+      "version": "4.15.3",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.15.3.tgz",
+      "integrity": "sha512-jlTqDvLdHnYMSr08ynNfk4IAUSJgJjTKy2U5CQBSu4cN9vQOJonLVZP4Qo4gKKrIgIQ5dr07UwOJdi+lRqT12w=="
+    },
+    "csv-stringify": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-1.1.2.tgz",
+      "integrity": "sha1-d6QVJlgbzjOA8SsA18W7rHDIK1g=",
+      "requires": {
+        "lodash.get": "~4.4.2"
       }
     },
     "dashdash": {
@@ -3008,6 +3037,11 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.595.tgz",
       "integrity": "sha512-JpaBIhdBkF9FLG7x06ONfe0f5bxPrxRcq0X+Sc8vsCt+OPWIzxOD+qM71NEHLGbDfN9Q6hbtHRv4/dnvcOxo6g=="
     },
+    "emitter-component": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/emitter-component/-/emitter-component-1.1.1.tgz",
+      "integrity": "sha1-Bl4tvtaVm/RwZ57avq95gdEAOrY="
+    },
     "emittery": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.7.2.tgz",
@@ -3051,6 +3085,11 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -4151,6 +4190,11 @@
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
     },
+    "is-finite": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
+      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w=="
+    },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -4169,6 +4213,14 @@
       "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
       "requires": {
         "is-extglob": "^2.1.1"
+      }
+    },
+    "is-integer": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.7.tgz",
+      "integrity": "sha1-a96Bqs3feLZZtmKdYpytxRqIbVw=",
+      "requires": {
+        "is-finite": "^1.0.0"
       }
     },
     "is-number": {
@@ -5883,6 +5935,14 @@
         "minimist": "^1.2.5"
       }
     },
+    "jsonfile": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -5942,6 +6002,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
       "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -5963,6 +6028,11 @@
       "requires": {
         "yallist": "^4.0.0"
       }
+    },
+    "luxon": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.26.0.tgz",
+      "integrity": "sha512-+V5QIQ5f6CDXQpWNICELwjwuHdqeJM1UenlZWx5ujcRMc9venvluCjFb4t5NYLhb6IhkbMVOxzVuOqkgMxee2A=="
     },
     "make-dir": {
       "version": "2.1.0",
@@ -6505,8 +6575,7 @@
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "optional": true
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "progress": {
       "version": "2.0.3",
@@ -6593,7 +6662,6 @@
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "optional": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -7266,6 +7334,19 @@
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
     },
+    "stream": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stream/-/stream-0.0.2.tgz",
+      "integrity": "sha1-f1Nj8Ff2WSxVlfALyAon9c7B8O8=",
+      "requires": {
+        "emitter-component": "^1.1.1"
+      }
+    },
+    "stream-transform": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-0.1.2.tgz",
+      "integrity": "sha1-fY5rTgOsR4F3j4x5UXUBv7B2Kp8="
+    },
     "string-length": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.1.tgz",
@@ -7274,6 +7355,15 @@
       "requires": {
         "char-regex": "^1.0.2",
         "strip-ansi": "^6.0.0"
+      }
+    },
+    "string-to-stream": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string-to-stream/-/string-to-stream-1.1.1.tgz",
+      "integrity": "sha512-QySF2+3Rwq0SdO3s7BAp4x+c3qsClpPQ6abAmb0DGViiSBAkT5kL6JT2iyzEVP+T1SmzHrQD1TwlP9QAHCc+Sw==",
+      "requires": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.1.0"
       }
     },
     "string-width": {
@@ -7291,7 +7381,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "optional": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -7636,11 +7725,6 @@
       "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
       "dev": true
     },
-    "ucum": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/ucum/-/ucum-0.0.7.tgz",
-      "integrity": "sha1-zQfv5VmaF+9/syd3i/g46DLf0aQ="
-    },
     "uglify-js": {
       "version": "3.11.5",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.11.5.tgz",
@@ -7746,8 +7830,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "optional": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
       "version": "8.3.1",
@@ -7990,6 +8073,21 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
+    },
+    "xmldoc": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/xmldoc/-/xmldoc-0.4.0.tgz",
+      "integrity": "sha1-0lciS+g5PqrL+DfvIn/Y7CWzaIg=",
+      "requires": {
+        "sax": "~1.1.1"
+      },
+      "dependencies": {
+        "sax": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.6.tgz",
+          "integrity": "sha1-XWFr6KXmB9VOEUr65Vt+ry/MMkA="
+        }
+      }
     },
     "y18n": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -11,15 +11,15 @@
     "build/*"
   ],
   "dependencies": {
+    "@ahryman40k/ts-fhir-types": "^4.0.32",
     "atob": "^2.1.2",
     "commander": "^6.1.0",
     "cql-exec-fhir": "1.5.0-beta.1",
-    "cql-execution": "2.1.0",
+    "cql-execution": "^2.2.0",
     "handlebars": "^4.7.6",
     "moment": "^2.29.0",
-    "uuid": "^8.3.1",
-    "@ahryman40k/ts-fhir-types": "^4.0.32",
-    "ts-node": "9.1.1"
+    "ts-node": "9.1.1",
+    "uuid": "^8.3.1"
   },
   "devDependencies": {
     "@types/handlebars": "^4.1.0",

--- a/src/Calculator.ts
+++ b/src/Calculator.ts
@@ -69,7 +69,7 @@ export function calculate(
     const patientExecutionResult: ExecutionResult = {
       patientId: patient.id,
       detailedResults: [],
-      evaluatedResources: rawResults.evaluatedRecords
+      evaluatedResource: rawResults.patientEvaluatedRecords[patient.id]
     };
 
     // Grab statement results for the patient

--- a/src/Execution.ts
+++ b/src/Execution.ts
@@ -129,7 +129,9 @@ export function execute(
   const results = executor.exec(patientSource, executionDateTime);
 
   // Map evaluated resource from engine to the raw FHIR json
-  results.evaluatedRecords = results.evaluatedRecords.map((r: any) => r._json);
+  Object.keys(results.patientEvaluatedRecords).forEach(patientId => {
+    results.patientEvaluatedRecords[patientId] = results.patientEvaluatedRecords[patientId].map((r: any) => r._json);
+  });
 
   if (debugObject && options.enableDebugOutput) {
     debugObject.elm = elmJSONs;

--- a/src/MeasureReportBuilder.ts
+++ b/src/MeasureReportBuilder.ts
@@ -148,8 +148,8 @@ export function buildMeasureReports(
       report.group?.push(group);
     });
 
-    if (result.evaluatedResources) {
-      result.evaluatedResources.forEach(resource => {
+    if (result.evaluatedResource) {
+      result.evaluatedResource.forEach(resource => {
         const reference: R4.IReference = {
           reference: `${resource.resourceType}/${resource.id}`
         };

--- a/src/types/CQLTypes.ts
+++ b/src/types/CQLTypes.ts
@@ -19,7 +19,9 @@ export interface Results {
   localIdPatientResultsMap: {
     [patientId: string]: LocalIdResults;
   };
-  evaluatedRecords: any[];
+  patientEvaluatedRecords: {
+    [patientId: string]: any[];
+  };
 }
 
 export interface StatementResults {

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -56,7 +56,7 @@ export interface ExecutionResult {
   /** SDE values, if specified for calculation */
   supplementalData?: SDEResult[];
   /** Resources evaluated during execution */
-  evaluatedResources?: R4.IResourceList[];
+  evaluatedResource?: R4.IResourceList[];
 }
 
 /**


### PR DESCRIPTION
# Summary

Update cql-execution and use new patientEvaluatedRecords object. See https://github.com/cqframework/cql-execution/pull/232

## New behavior

Bug fix: evaluatedResource no longer duplicates across MeasureReports when multiple patients are passed in

## Code changes

* Rename `evaluatedResources -> evaluatedResource` for consistency
* Update to cql-execution 2.2.0
* Update Executor and Calculator to key the evaluatedResource array by patient ID

# Testing guidance

Run execution with output type `reports`, and pass in more than 1 patient at runtime. E.g.

`./src/cli.ts -m ../connectathon/fhir401/bundles/EXM124-9.0.000/EXM124-9.0.000-bundle.json -p ../connectathon/fhir401/bundles/EXM124-9.0.000/EXM124-9.0.000-files/tests-denom-EXM124-bundle.json ../connectathon/fhir401/bundles/EXM124-9.0.000/EXM124-9.0.000-files/tests-numer-EXM124-bundle.json -o reports -d`

MeasureReport for denom patient only contains evaluatedResource for that patient
![image](https://user-images.githubusercontent.com/16297930/110019063-01448980-7cf6-11eb-9a18-0c5fd2e89ca1.png)


MeasureReport for numer patient only contains evaluatedResource for that patient 
![image](https://user-images.githubusercontent.com/16297930/110019036-f689f480-7cf5-11eb-86d4-05bfdf7342bf.png)


