### PR TITLE
Initial near miss

### DIFF
--- a/src/Calculator.ts
+++ b/src/Calculator.ts
@@ -294,6 +294,8 @@ export function calculateGapsInCare(
           dr
         );
 
+        GapsInCareHelpers.calculateNearMisses(retrieves, improvementNotation);
+
         const detectedIssue = GapsInCareHelpers.generateDetectedIssueResource(
           retrieves,
           matchingMeasureReport,

--- a/src/Calculator.ts
+++ b/src/Calculator.ts
@@ -287,14 +287,14 @@ export function calculateGapsInCare(
           throw new Error(`Expression ${numerExpressionName} not found in ${mainLibraryName}`);
         }
 
-        const retrieves = GapsInCareHelpers.findRetrieves(
+        let retrieves = GapsInCareHelpers.findRetrieves(
           mainLibraryELM,
           elmLibraries,
           numerELMExpression.expression,
           dr
         );
 
-        GapsInCareHelpers.calculateNearMisses(retrieves, improvementNotation);
+        retrieves = GapsInCareHelpers.calculateNearMisses(retrieves, improvementNotation);
 
         const detectedIssue = GapsInCareHelpers.generateDetectedIssueResource(
           retrieves,

--- a/src/GapsInCareHelpers.ts
+++ b/src/GapsInCareHelpers.ts
@@ -280,17 +280,20 @@ export function generateGapsInCareBundle(
 }
 
 /**
- * Silently add near miss data to each DataTypeQuery passed in
+ * Add near miss data to each DataTypeQuery passed in
  *
  * @param retrieves numerator queries from a call to findRetrieves
  * @param improvementNotation string indicating positive or negative improvement notation for the measure being used
  */
 export function calculateNearMisses(retrieves: DataTypeQuery[], improvementNotation: string) {
-  retrieves.forEach(r => {
+  return retrieves.map(r => {
+    let isNearMiss;
     if (improvementNotation === ImprovementNotation.POSITIVE) {
-      r.isNearMiss = r.retrieveHasResult && !r.parentQueryHasResult;
+      isNearMiss = r.retrieveHasResult && !r.parentQueryHasResult;
     } else {
-      r.isNearMiss = !r.retrieveHasResult && r.parentQueryHasResult;
+      // TODO: this can probably be expanded to address negative improvement cases, but it will be a bit more complicated
+      isNearMiss = false;
     }
+    return { ...r, isNearMiss };
   });
 }

--- a/src/GapsInCareHelpers.ts
+++ b/src/GapsInCareHelpers.ts
@@ -278,3 +278,19 @@ export function generateGapsInCareBundle(
     ]
   };
 }
+
+/**
+ * Silently add near miss data to each DataTypeQuery passed in
+ *
+ * @param retrieves numerator queries from a call to findRetrieves
+ * @param improvementNotation string indicating positive or negative improvement notation for the measure being used
+ */
+export function calculateNearMisses(retrieves: DataTypeQuery[], improvementNotation: string) {
+  retrieves.forEach(r => {
+    if (improvementNotation === ImprovementNotation.POSITIVE) {
+      r.isNearMiss = r.retrieveHasResult && !r.parentQueryHasResult;
+    } else {
+      r.isNearMiss = !r.retrieveHasResult && r.parentQueryHasResult;
+    }
+  });
+}

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -204,6 +204,8 @@ export interface DataTypeQuery {
   libraryName?: string;
   /** stack of expressions traversed during calculation */
   expressionStack?: ExpressionStackEntry[];
+  /** whether or not the gap was close to being closed */
+  isNearMiss?: boolean;
 }
 
 /**

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -204,8 +204,6 @@ export interface DataTypeQuery {
   libraryName?: string;
   /** stack of expressions traversed during calculation */
   expressionStack?: ExpressionStackEntry[];
-  /** whether or not the gap was close to being closed */
-  isNearMiss?: boolean;
 }
 
 /**

--- a/test/GapsInCareHelpers.test.ts
+++ b/test/GapsInCareHelpers.test.ts
@@ -1,5 +1,10 @@
 import { R4 } from '@ahryman40k/ts-fhir-types';
-import { findRetrieves, generateDetectedIssueResource, generateGapsInCareBundle } from '../src/GapsInCareHelpers';
+import {
+  findRetrieves,
+  generateDetectedIssueResource,
+  generateGapsInCareBundle,
+  calculateNearMisses
+} from '../src/GapsInCareHelpers';
 import { DataTypeQuery, DetailedPopulationGroupResult } from '../src/types/Calculator';
 import { FinalResult, ImprovementNotation } from '../src/types/Enums';
 import { getELMFixture, getJSONFixture } from './helpers/testHelpers';
@@ -304,6 +309,17 @@ describe('Generate DetectedIssue Resource', () => {
 
     // above query should be present since queries with results are gaps
     expect(resource.evidence).toHaveLength(1);
+  });
+});
+
+describe('Find Near misses', () => {
+  test('simple query/retrieve discrepancy near misses', () => {
+    const retrieves = calculateNearMisses(EXPECTED_CODE_RESULTS, ImprovementNotation.POSITIVE);
+    console.log('retrieves:', retrieves);
+    retrieves.forEach(r => {
+      console.log('near miss:', r.isNearMiss);
+      expect(r.isNearMiss).toBeTruthy();
+    });
   });
 });
 

--- a/test/GapsInCareHelpers.test.ts
+++ b/test/GapsInCareHelpers.test.ts
@@ -315,7 +315,6 @@ describe('Generate DetectedIssue Resource', () => {
 describe('Find Near misses', () => {
   test('simple query/retrieve discrepancy near misses', () => {
     const retrieves = calculateNearMisses(EXPECTED_CODE_RESULTS, ImprovementNotation.POSITIVE);
-    console.log('retrieves:', retrieves);
     retrieves.forEach(r => {
       console.log('near miss:', r.isNearMiss);
       expect(r.isNearMiss).toBeTruthy();

--- a/test/GapsInCareHelpers.test.ts
+++ b/test/GapsInCareHelpers.test.ts
@@ -313,11 +313,17 @@ describe('Generate DetectedIssue Resource', () => {
 });
 
 describe('Find Near misses', () => {
-  test('simple query/retrieve discrepancy near misses', () => {
+  test('simple query/retrieve discrepancy near miss', () => {
     const retrieves = calculateNearMisses(EXPECTED_CODE_RESULTS, ImprovementNotation.POSITIVE);
     retrieves.forEach(r => {
-      console.log('near miss:', r.isNearMiss);
       expect(r.isNearMiss).toBeTruthy();
+    });
+  });
+
+  test('retrieve false, not a near miss', () => {
+    const retrieves = calculateNearMisses(EXPECTED_VS_RETRIEVE_RESULTS, ImprovementNotation.POSITIVE);
+    retrieves.forEach(r => {
+      expect(r.isNearMiss).toBeFalsy();
     });
   });
 });


### PR DESCRIPTION
# Summary
Establishes an initial approach for finding certain near miss gaps. This identifies gaps where the data criteria required by the retrieve was found, but the query it belongs to was not satisfied.
## New behavior
For positive improvement, identifies all data queries where the retrieve is true, but the query is false and marks these as near misses such that they may eventually be identified in the gaps report, dependent on desired formatting.
## Code changes
Adds calculateNearMisses function. Calls `GapsInCareHelpers.calculateNearMisses` on all retrieves found in the calculator. 
# Testing guidance
This was tested with connectathon's [EXM124-9.0.000](https://github.com/DBCG/connectathon/blob/master/fhir401/bundles/measure/EXM124-9.0.000/EXM124-9.0.000-bundle.json) and adjusted [numerator patient](https://github.com/DBCG/connectathon/blob/master/fhir401/bundles/measure/EXM124-9.0.000/EXM124-9.0.000-files/tests-numer-EXM124-bundle.json) with observation time shifted several years earlier. Additionally, a test has been added which can be run with `npm test`
