### PR TITLE
Improve CQL translation in fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ build/
 debug/
 .vscode
 **/.DS_Store
-test/fixtures/elm/queries/translation-output
+test/fixtures/elm/queries/output/*
 test/fixtures/elm/queries/.start-translator
 connectathon/
 fhir-patient-generator/

--- a/package-lock.json
+++ b/package-lock.json
@@ -2193,6 +2193,15 @@
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
       "dev": true
     },
+    "axios": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "dev": true,
+      "requires": {
+        "follow-redirects": "1.5.10"
+      }
+    },
     "babel-jest": {
       "version": "26.6.3",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.6.3.tgz",
@@ -2817,6 +2826,29 @@
       "requires": {
         "@lhncbc/ucum-lhc": "^4.1.3",
         "luxon": "^1.25.0"
+      }
+    },
+    "cql-translation-service-client": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cql-translation-service-client/-/cql-translation-service-client-0.6.0.tgz",
+      "integrity": "sha512-YpHG84d0wweGxCjem232WPTsCz6nIUaoxk8QksQjJge9p8kdXajA81Aya4PHD1R4NG0kEY6bxjwVxmabxbL9sQ==",
+      "dev": true,
+      "requires": {
+        "axios": "^0.19.2",
+        "form-data": "3.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+          "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
       }
     },
     "create-require": {
@@ -3717,6 +3749,26 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
       "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
       "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "dev": true,
+      "requires": {
+        "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
     },
     "for-in": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@types/uuid": "^8.3.0",
     "@typescript-eslint/eslint-plugin": "^3.2.0",
     "@typescript-eslint/parser": "^3.2.0",
+    "cql-translation-service-client": "^0.6.0",
     "eslint": "^7.5.0",
     "eslint-config-prettier": "^6.11.0",
     "jest": "^26.1.0",

--- a/test/fixtures/elm/queries/Makefile
+++ b/test/fixtures/elm/queries/Makefile
@@ -8,17 +8,11 @@ all: .start-translator translate
 
 FILES := $(shell find *.cql)
 
-define get_file_args
-	$(eval FILE_ARGS += -F $(basename $1)=@$1)
-endef
-
 translate:
-	$(info $$FILES is [${FILES}])
-	$(foreach f, $(FILES),$(call get_file_args,$(f)))
-	$(info $$FILE_ARGS is [${FILE_ARGS}])
-	curl $(FILE_ARGS) "http://localhost:8080/cql/translator?locators=true&annotations=true" > translation-output
+	$(info translating [${FILES}])
+	rm -f ./output/*.json
+	ts-node ./cql-translator.ts
 
 clean:
 	-docker stop cql-translation-service
 	-rm .start-translator
-	-rm translation-output

--- a/test/fixtures/elm/queries/README.md
+++ b/test/fixtures/elm/queries/README.md
@@ -1,0 +1,22 @@
+## Prerequisites
+
+* `node` version `12.x` or greater, with `ts-node` installed globally
+    * `npm install -g ts-node`
+* `Docker`
+
+## Use
+
+To use the `Makefile` provided in this directory to translate CQL into ELM JSON:
+
+* Navigate to the `test/fixtures/elm/queries` directory in the command line
+* Put your CQL in a file (or multiple files) in the `queries` directory, with the `.cql` extension
+* run `make` in this directory. `make` will:
+    * Start the translation service in Docker (if not already started)
+    * Translate all files in the `queries` directory into ELM JSON
+    * Place the translated JSON files into `output/`
+
+If the translation service returns any errors from translation, the parser will output errors for the first file it comes to with errors. That file, and any after it, will not be written to `output/`
+
+## Cleanup
+
+To stop the translation service, run `make clean`. This will not delete any translated JSON in `output/`.

--- a/test/fixtures/elm/queries/cql-translator.ts
+++ b/test/fixtures/elm/queries/cql-translator.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/ban-types */
+
 import fs from 'fs';
 import path from 'path';
 import * as translationService from 'cql-translation-service-client';

--- a/test/fixtures/elm/queries/cql-translator.ts
+++ b/test/fixtures/elm/queries/cql-translator.ts
@@ -1,0 +1,108 @@
+import fs from 'fs';
+import path from 'path';
+import * as translationService from 'cql-translation-service-client';
+
+const TRANSLATION_SERVICE_URL = 'http://localhost:8080/cql/translator';
+
+const client = new translationService.Client(TRANSLATION_SERVICE_URL);
+
+// This interface is extended here to add the "annotation" property
+// because the client type sets its value type to "object" rather than "object[]"
+interface ElmLibrary extends translationService.ElmLibrary {
+  library: {
+    identifier: {
+      id: string;
+      version: string;
+    };
+    schemaIdentifier: {
+      id: string;
+      version: string;
+    };
+    usings?: {
+      def: translationService.ElmUsing[];
+    };
+    includes?: {
+      def: translationService.ElmIncludes[];
+    };
+    valueSets?: {
+      def: translationService.ElmValueSet[];
+    };
+    codes?: {
+      def: translationService.ElmCode[];
+    };
+    codeSystems?: {
+      def: translationService.ElmCodeSystem[];
+    };
+    concepts?: {
+      def: object[];
+    };
+    statements: {
+      def: translationService.ElmStatement[];
+    };
+    annotation: object[];
+    [x: string]: object | undefined;
+  };
+}
+
+/**
+ * Translate all cql
+ *
+ * @returns {translationService.ElmLibraries} ELM from translator
+ */
+async function translateCQL():Promise<translationService.ElmLibraries> {
+  const cqlPath = path.resolve(path.join(__dirname), './');
+  const cqlFiles = fs.readdirSync(cqlPath).filter((f) => path.extname(f) === '.cql');
+  const cqlRequestBody:translationService.CqlLibraries = {};
+
+  cqlFiles.forEach((f) => {
+    cqlRequestBody[path.basename(f, '.cql')] = {
+      cql: fs.readFileSync(path.join(cqlPath, f), 'utf8'),
+    };
+  });
+
+  const elm = await client.convertCQL(cqlRequestBody);
+  return elm;
+}
+
+/**
+ * Find any errors found in the ELM annotation
+ *
+ * @param {ElmLibrary} elm ELM JSON to look for errors in
+ * @returns {object[]} annotations with severity error
+ */
+function processErrors(elm:ElmLibrary):object[] {
+  const errors:object[] = [];
+
+  // Check annotations for errors. If no annotations, no errors
+  if (elm.library.annotation) {
+    elm.library.annotation.forEach((a: any) => {
+      if (a.errorSeverity === 'error') {
+        errors.push(a as object);
+      }
+    });
+  }
+
+  return errors;
+}
+
+translateCQL()
+  .then((libraries) => {
+    const buildPath = path.join(__dirname, './output');
+    Object.entries(libraries).forEach(([libName, elm]) => {
+      const errors = processErrors(elm as ElmLibrary);
+      if (errors.length === 0) {
+        const elmPath = path.join(buildPath, `${libName}.json`);
+        fs.writeFileSync(elmPath, JSON.stringify(elm), 'utf8');
+        console.log(`Wrote ELM to ${elmPath}`);
+      } else {
+        console.error('Error translating to ELM');
+        console.error(errors);
+        process.exit(1);
+      }
+    });
+  })
+  .catch((e) => {
+    console.error(`HTTP error translating CQL: ${e.message}`);
+    console.error(e.stack);
+    process.exit(1);
+  });

--- a/test/fixtures/elm/queries/cql-translator.ts
+++ b/test/fixtures/elm/queries/cql-translator.ts
@@ -51,14 +51,14 @@ interface ElmLibrary extends translationService.ElmLibrary {
  *
  * @returns {translationService.ElmLibraries} ELM from translator
  */
-async function translateCQL():Promise<translationService.ElmLibraries> {
+async function translateCQL(): Promise<translationService.ElmLibraries> {
   const cqlPath = path.resolve(path.join(__dirname), './');
-  const cqlFiles = fs.readdirSync(cqlPath).filter((f) => path.extname(f) === '.cql');
-  const cqlRequestBody:translationService.CqlLibraries = {};
+  const cqlFiles = fs.readdirSync(cqlPath).filter(f => path.extname(f) === '.cql');
+  const cqlRequestBody: translationService.CqlLibraries = {};
 
-  cqlFiles.forEach((f) => {
+  cqlFiles.forEach(f => {
     cqlRequestBody[path.basename(f, '.cql')] = {
-      cql: fs.readFileSync(path.join(cqlPath, f), 'utf8'),
+      cql: fs.readFileSync(path.join(cqlPath, f), 'utf8')
     };
   });
 
@@ -72,8 +72,8 @@ async function translateCQL():Promise<translationService.ElmLibraries> {
  * @param {ElmLibrary} elm ELM JSON to look for errors in
  * @returns {object[]} annotations with severity error
  */
-function processErrors(elm:ElmLibrary):object[] {
-  const errors:object[] = [];
+function processErrors(elm: ElmLibrary): object[] {
+  const errors: object[] = [];
 
   // Check annotations for errors. If no annotations, no errors
   if (elm.library.annotation) {
@@ -88,7 +88,7 @@ function processErrors(elm:ElmLibrary):object[] {
 }
 
 translateCQL()
-  .then((libraries) => {
+  .then(libraries => {
     const buildPath = path.join(__dirname, './output');
     Object.entries(libraries).forEach(([libName, elm]) => {
       const errors = processErrors(elm as ElmLibrary);
@@ -103,7 +103,7 @@ translateCQL()
       }
     });
   })
-  .catch((e) => {
+  .catch(e => {
     console.error(`HTTP error translating CQL: ${e.message}`);
     console.error(e.stack);
     process.exit(1);

--- a/test/fixtures/elm/queries/cql-translator.ts
+++ b/test/fixtures/elm/queries/cql-translator.ts
@@ -94,7 +94,7 @@ translateCQL()
       const errors = processErrors(elm as ElmLibrary);
       if (errors.length === 0) {
         const elmPath = path.join(buildPath, `${libName}.json`);
-        fs.writeFileSync(elmPath, JSON.stringify(elm), 'utf8');
+        fs.writeFileSync(elmPath, JSON.stringify(elm, undefined, 2), 'utf8');
         console.log(`Wrote ELM to ${elmPath}`);
       } else {
         console.error('Error translating to ELM');


### PR DESCRIPTION
# Summary
Adds a Typescript script for running CQL through the translation service, and splitting out the resulting ELM JSON into separate files in `test/fixtures/elm/queries/output`. Makes use of https://github.com/mcode/cql-translation-service-client to do the heavy lifting.

## New behavior
* `Makefile` now calls `cql-translator.ts` to do the CQL translation using `ts-node`
* ELM JSON is now written to `test/fixtures/elm/queries/output` as individual files
* `make clean` no longer deletes the output JSON
* `make` _will_ delete old output JSON, prior to re-translating.

## Code changes
* Added `cql-translator.ts`, which uses the `cql-translation-service-client` to translate every `.cql` file in `test/fixtures/elm/queries/output`

# Testing guidance

## Happy path
* `cd` to `test/fixtures/elm/queries`
* run `make`
* Ensure the two `.cql` files that are already in that dir properly translate, and the translated ELM for both shows up in the `output/` folder

## Sad path
* `cd` to `test/fixtures/elm/queries`
* Break one of the `.cql` files (easy way to do this: delete a `:` after any of the `define` statements)
* run `make`
* Ensure the broken file is _not_ output to the `output/` directory, and that an error is spit out on the command line

## Extra credit
Run some of your own CQL files through the `make` process.
