### PR TITLE
Set EnableAnnotations and EnableLocators through URL params in Makefile

### DIFF
--- a/test/fixtures/elm/queries/README.md
+++ b/test/fixtures/elm/queries/README.md
@@ -17,6 +17,8 @@ To use the `Makefile` provided in this directory to translate CQL into ELM JSON:
 
 If the translation service returns any errors from translation, the parser will output errors for the first file it comes to with errors. That file, and any after it, will not be written to `output/`
 
+The translation service is called with `EnableAnnotations` and `EnableLocators` set, through URL query parameters.
+
 ## Cleanup
 
 To stop the translation service, run `make clean`. This will not delete any translated JSON in `output/`.

--- a/test/fixtures/elm/queries/cql-translator.ts
+++ b/test/fixtures/elm/queries/cql-translator.ts
@@ -6,7 +6,8 @@ import * as translationService from 'cql-translation-service-client';
 
 const TRANSLATION_SERVICE_URL = 'http://localhost:8080/cql/translator';
 
-const client = new translationService.Client(TRANSLATION_SERVICE_URL);
+// Build the service URL with annotations & locators set to true as query params
+const client = new translationService.Client(`${TRANSLATION_SERVICE_URL}?annotations=true&locators=true`);
 
 // This interface is extended here to add the "annotation" property
 // because the client type sets its value type to "object" rather than "object[]"


### PR DESCRIPTION
# Summary
This PR adds query parameters to the service URL to set `annotations` and `locators` to `true`. This is a _little_ hacky, but the only way to pass these params without updates to `cql-translation-service-client`.

# Testing guidance
run `make` in `test/fixtures/elm/queries` and ensure the resulting JSON files have both `EnableAnnotations` and `EnableLocators` listed as `library.annotation[0].translatorOptions`