### PR TITLE
Added guidance response fixtures for modeling enhancements

### DIFF
--- a/test/fixtures/gaps/guidanceResponse/guidance-combination.json
+++ b/test/fixtures/gaps/guidanceResponse/guidance-combination.json
@@ -1,0 +1,51 @@
+{
+  "resourceType": "GuidanceResponse",
+  "id": "e3505055-e235-401d-9487-e9e250cc16dd",
+  "dataRequirement": [
+    {
+      "type": "Observation",
+      "codeFilter": [
+        {
+          "path": "code",
+          "valueSet": "http://example.com/test-vs"
+        },
+        {
+          "path": "status",
+          "code": [
+            {
+              "system": "http://hl7.org/fhir/observation-status",
+              "code": "final"
+            }
+          ]
+        }
+      ],
+      "dateFilter": [
+        {
+          "path": "effectivePeriod",
+          "valuePeriod": {
+            "start": "2019-01-01",
+            "end": "2019-12-31"
+          }
+        }
+      ]
+    }
+  ],
+  "reasonCode": [
+    {
+      "coding": [
+        {
+          "system": "CareGapReasonCodeSystem",
+          "code": "DateOutOfRange",
+          "display": "Data element was found, date was out of range"
+        },
+        {
+          "system": "CareGapReasonCodeSystem",
+          "code": "IncorectAttribute",
+          "display": "Data element had an incorrect attribute value"
+        }
+      ]
+    }
+  ],
+  "status": "data-required",
+  "moduleUri": "http://hl7.org/fhir/us/cqfmeasures/Measure/EXM130"
+}

--- a/test/fixtures/gaps/guidanceResponse/guidance-date-out-of-range.json
+++ b/test/fixtures/gaps/guidanceResponse/guidance-date-out-of-range.json
@@ -1,0 +1,37 @@
+{
+  "resourceType": "GuidanceResponse",
+  "id": "e3505055-e235-401d-9487-e9e250cc16dd",
+  "dataRequirement": [
+    {
+      "type": "Observation",
+      "codeFilter": [
+        {
+          "path": "code",
+          "valueSet": "http://example.com/test-vs"
+        }
+      ],
+      "dateFilter": [
+        {
+          "path": "effectivePeriod",
+          "valuePeriod": {
+            "start": "2019-01-01",
+            "end": "2019-12-31"
+          }
+        }
+      ]
+    }
+  ],
+  "reasonCode": [
+    {
+      "coding": [
+        {
+          "system": "CareGapReasonCodeSystem",
+          "code": "DateOutOfRange",
+          "display": "Date of required data was out of range"
+        }
+      ]
+    }
+  ],
+  "status": "data-required",
+  "moduleUri": "http://hl7.org/fhir/us/cqfmeasures/Measure/EXM130"
+}

--- a/test/fixtures/gaps/guidanceResponse/guidance-incorrect-attribute.json
+++ b/test/fixtures/gaps/guidanceResponse/guidance-incorrect-attribute.json
@@ -1,0 +1,35 @@
+{
+  "resourceType": "GuidanceResponse",
+  "id": "e3505055-e235-401d-9487-e9e250cc16dd",
+  "dataRequirement": [
+    {
+      "type": "Observation",
+      "codeFilter": [
+        {
+          "path": "code",
+          "valueSet": "http://example.com/test-vs"
+        },
+        {
+          "path": "status",
+          "code": [{
+            "system": "http://hl7.org/fhir/observation-status",
+            "code": "final"
+          }]
+        }
+      ]
+    }
+  ],
+  "reasonCode": [
+    {
+      "coding": [
+        {
+          "system": "CareGapReasonCodeSystem",
+          "code": "IncorectAttribute",
+          "display": "Data element had an incorrect attribute value"
+        }
+      ]
+    }
+  ],
+  "status": "data-required",
+  "moduleUri": "http://hl7.org/fhir/us/cqfmeasures/Measure/EXM130"
+}

--- a/test/fixtures/gaps/guidanceResponse/guidance-invalid-duration.json
+++ b/test/fixtures/gaps/guidanceResponse/guidance-invalid-duration.json
@@ -1,0 +1,38 @@
+{
+  "resourceType": "GuidanceResponse",
+  "id": "e3505055-e235-401d-9487-e9e250cc16dd",
+  "dataRequirement": [
+    {
+      "type": "Encounter",
+      "codeFilter": [
+        {
+          "path": "code",
+          "valueSet": "http://example.com/test-vs"
+        }
+      ],
+      "dateFilter": [
+        {
+          "path": "length",
+          "valueDuration": {
+            "value": 14,
+            "unit": "d",
+            "system": "http://unitsofmeasure.org"
+          }
+        }
+      ]
+    }
+  ],
+  "reasonCode": [
+    {
+      "coding": [
+        {
+          "system": "CareGapReasonCodeSystem",
+          "code": "InvalidDuration",
+          "display": "Data element was found, but duration was invalid"
+        }
+      ]
+    }
+  ],
+  "status": "data-required",
+  "moduleUri": "http://hl7.org/fhir/us/cqfmeasures/Measure/EXM130"
+}

--- a/test/fixtures/gaps/guidanceResponse/guidance-missing-retrieve.json
+++ b/test/fixtures/gaps/guidanceResponse/guidance-missing-retrieve.json
@@ -1,0 +1,28 @@
+{
+  "resourceType": "GuidanceResponse",
+  "id": "e3505055-e235-401d-9487-e9e250cc16dd",
+  "dataRequirement": [
+    {
+      "type": "Observation",
+      "codeFilter": [
+        {
+          "path": "code",
+          "valueSet": "http://example.com/test-vs"
+        }
+      ]
+    }
+  ],
+  "reasonCode": [
+    {
+      "coding": [
+        {
+          "system": "CareGapReasonCodeSystem",
+          "code": "Missing",
+          "display": "No Data Element found from Value Set"
+        }
+      ]
+    }
+  ],
+  "status": "data-required",
+  "moduleUri": "http://hl7.org/fhir/us/cqfmeasures/Measure/EXM130"
+}

--- a/test/fixtures/gaps/guidanceResponse/guidance-missing-value-extension.json
+++ b/test/fixtures/gaps/guidanceResponse/guidance-missing-value-extension.json
@@ -15,11 +15,11 @@
           "url": "http://example.com/dr-value",
           "extension": [
             {
-              "url": "http://example.com/dr-value-attribute",
+              "url": "dr-value-attribute",
               "valueString": "result"
             },
             {
-              "url": "http://example.com/dr-value-filter",
+              "url": "dr-value-filter",
               "valueRange": {
                 "high": {
                   "value": 9,

--- a/test/fixtures/gaps/guidanceResponse/guidance-missing-value-extension.json
+++ b/test/fixtures/gaps/guidanceResponse/guidance-missing-value-extension.json
@@ -12,9 +12,12 @@
       ],
       "extension": [
         {
-          "url": "http://example.com/dr-value-attribute",
-          "valueString": "result",
+          "url": "http://example.com/dr-value",
           "extension": [
+            {
+              "url": "http://example.com/dr-value-attribute",
+              "valueString": "result"
+            },
             {
               "url": "http://example.com/dr-value-filter",
               "valueRange": {

--- a/test/fixtures/gaps/guidanceResponse/guidance-missing-value-extension.json
+++ b/test/fixtures/gaps/guidanceResponse/guidance-missing-value-extension.json
@@ -1,0 +1,45 @@
+{
+  "resourceType": "GuidanceResponse",
+  "id": "e3505055-e235-401d-9487-e9e250cc16dd",
+  "dataRequirement": [
+    {
+      "type": "Observation",
+      "codeFilter": [
+        {
+          "path": "code",
+          "valueSet": "http://example.com/test-vs"
+        }
+      ],
+      "extension": [
+        {
+          "url": "http://example.com/dr-value-attribute",
+          "valueString": "result",
+          "extension": [
+            {
+              "url": "http://example.com/dr-value-filter",
+              "valueRange": {
+                "high": {
+                  "value": 9,
+                  "unit": "%"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "reasonCode": [
+    {
+      "coding": [
+        {
+          "system": "CareGapReasonCodeSystem",
+          "code": "MissingValue",
+          "display": "Data element was found, but value was missing"
+        }
+      ]
+    }
+  ],
+  "status": "data-required",
+  "moduleUri": "http://hl7.org/fhir/us/cqfmeasures/Measure/EXM130"
+}

--- a/test/fixtures/gaps/guidanceResponse/guidance-missing-value-reference.json
+++ b/test/fixtures/gaps/guidanceResponse/guidance-missing-value-reference.json
@@ -1,0 +1,43 @@
+[
+  {
+    "resourceType": "GuidanceResponse",
+    "id": "e3505055-e235-401d-9487-e9e250cc16dd",
+    "dataRequirement": [
+      {
+        "type": "Observation",
+        "codeFilter": [
+          {
+            "path": "code",
+            "valueSet": "http://example.com/test-vs"
+          }
+        ]
+      }
+    ],
+    "reasonReference": {
+      "reference": "Observation/example"
+    },
+    "status": "data-required",
+    "moduleUri": "http://hl7.org/fhir/us/cqfmeasures/Measure/EXM130"
+  },
+  {
+    "resourceType": "Observation",
+    "id": "example",
+    "code": {
+      "coding": [
+        {
+          "system": "CareGapReasonCodeSystem",
+          "code": "MissingValue",
+          "display": "Data element was found, but value was missing"
+        }
+      ]
+    },
+    "referenceRange": [
+      {
+        "high": {
+          "value": 9,
+          "unit": "%"
+        }
+      }
+    ]
+  }
+]

--- a/test/fixtures/gaps/guidanceResponse/guidance-value-out-of-range-extension.json
+++ b/test/fixtures/gaps/guidanceResponse/guidance-value-out-of-range-extension.json
@@ -15,11 +15,11 @@
           "url": "http://example.com/dr-value",
           "extension": [
             {
-              "url": "http://example.com/dr-value-attribute",
+              "url": "dr-value-attribute",
               "valueString": "result"
             },
             {
-              "url": "http://example.com/dr-value-filter",
+              "url": "dr-value-filter",
               "valueRange": {
                 "high": {
                   "value": 9,

--- a/test/fixtures/gaps/guidanceResponse/guidance-value-out-of-range-extension.json
+++ b/test/fixtures/gaps/guidanceResponse/guidance-value-out-of-range-extension.json
@@ -12,9 +12,12 @@
       ],
       "extension": [
         {
-          "url": "http://example.com/dr-value-attribute",
-          "valueString": "result",
+          "url": "http://example.com/dr-value",
           "extension": [
+            {
+              "url": "http://example.com/dr-value-attribute",
+              "valueString": "result"
+            },
             {
               "url": "http://example.com/dr-value-filter",
               "valueRange": {

--- a/test/fixtures/gaps/guidanceResponse/guidance-value-out-of-range-extension.json
+++ b/test/fixtures/gaps/guidanceResponse/guidance-value-out-of-range-extension.json
@@ -1,0 +1,45 @@
+{
+  "resourceType": "GuidanceResponse",
+  "id": "e3505055-e235-401d-9487-e9e250cc16dd",
+  "dataRequirement": [
+    {
+      "type": "Observation",
+      "codeFilter": [
+        {
+          "path": "code",
+          "valueSet": "http://example.com/test-vs"
+        }
+      ],
+      "extension": [
+        {
+          "url": "http://example.com/dr-value-attribute",
+          "valueString": "result",
+          "extension": [
+            {
+              "url": "http://example.com/dr-value-filter",
+              "valueRange": {
+                "high": {
+                  "value": 9,
+                  "unit": "%"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "reasonCode": [
+    {
+      "coding": [
+        {
+          "system": "CareGapReasonCodeSystem",
+          "code": "ValueOutOfRange",
+          "display": "Data element was found, but value was out of range"
+        }
+      ]
+    }
+  ],
+  "status": "data-required",
+  "moduleUri": "http://hl7.org/fhir/us/cqfmeasures/Measure/EXM130"
+}

--- a/test/fixtures/gaps/guidanceResponse/guidance-value-out-of-range-reference.json
+++ b/test/fixtures/gaps/guidanceResponse/guidance-value-out-of-range-reference.json
@@ -1,0 +1,43 @@
+[
+  {
+    "resourceType": "GuidanceResponse",
+    "id": "e3505055-e235-401d-9487-e9e250cc16dd",
+    "dataRequirement": [
+      {
+        "type": "Observation",
+        "codeFilter": [
+          {
+            "path": "code",
+            "valueSet": "http://example.com/test-vs"
+          }
+        ]
+      }
+    ],
+    "reasonReference": {
+      "reference": "Observation/example"
+    },
+    "status": "data-required",
+    "moduleUri": "http://hl7.org/fhir/us/cqfmeasures/Measure/EXM130"
+  },
+  {
+    "resourceType": "Observation",
+    "id": "example",
+    "code": {
+      "coding": [
+          {
+            "system": "CareGapReasonCodeSystem",
+            "code": "ValueOutOfRange",
+            "display": "Data element was found, but value was out of range"
+          }
+      ]
+    },
+    "referenceRange": [
+      {
+        "high": {
+          "value": 9,
+          "unit": "%"
+        }
+      }
+    ]
+  }
+]


### PR DESCRIPTION
No changes, just having our example guidances responses controlled somewhere so we can use for unit tests later once we implement more gaps parsing.