### PR TITLE
Add plethora of unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: artiomtr/jest-coverage-report-action@v1.1
         with:
           github_token: ${{ secrets.ACCESS_TOKEN_CI }}
-          #threshold: 60
+          threshold: 60
 
   integration_test:
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 node_modules
 build
+coverage

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,12 @@
 module.exports = {
+  collectCoverageFrom: ['src/**/*.ts'],
+  coveragePathIgnorePatterns: [
+    'src/_tests_',
+    'src/cli.ts',
+    'src/Calculator.ts',
+    'src/DebugHelper.ts',
+    'src/Execution.ts'
+  ],
   globals: {
     'ts-jest': {
       tsconfig: 'tsconfig.json'

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "test": "jest",
     "test:coverage": "jest --collectCoverage",
     "test:watch": "jest --watchAll",
+    "test:watch:coverage": "jest --watchAll --collectCoverage",
     "test:integration": "ts-node --files ./src/_tests_/run_tests.ts",
     "check": "npm run test && npm run lint && npm run prettier",
     "prepare": "npm run build"

--- a/test/CalculatorHelpers.test.ts
+++ b/test/CalculatorHelpers.test.ts
@@ -1,6 +1,18 @@
 import * as CalculatorHelpers from '../src/CalculatorHelpers';
 import { R4 } from '@ahryman40k/ts-fhir-types';
 import { getJSONFixture } from './helpers/testHelpers';
+import { PopulationType } from '../src/types/Enums';
+import { StatementResults } from '../src/types/CQLTypes';
+import { PopulationResult } from '../src/types/Calculator';
+
+type MeasureWithGroup = R4.IMeasure & {
+  group: R4.IMeasure_Group[];
+};
+
+const simpleMeasure = getJSONFixture('measure/simple-measure.json') as MeasureWithGroup;
+const cvMeasure = getJSONFixture('measure/cv-measure.json') as MeasureWithGroup;
+const simpleMeasureGroup = simpleMeasure.group[0];
+const cvMeasureGroup = cvMeasure.group[0];
 
 describe('CalculatorHelpers', () => {
   describe('getAllDependentValuesets', () => {
@@ -14,6 +26,202 @@ describe('CalculatorHelpers', () => {
       const vs = CalculatorHelpers.getMissingDependentValuesets(measureBundle);
       expect(vs.length).toEqual(1);
       expect(vs[0]).toEqual('http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016');
+    });
+  });
+
+  describe('Population Values', () => {
+    test('NUMER population not modified by inclusion in NUMEX', () => {
+      const statementResults: StatementResults = {
+        'Initial Population': true,
+        Denominator: true,
+        'Denominator Exclusion': false,
+        Numerator: true,
+        'Numerator Exclusion': true
+      };
+
+      const expectedPopulationResults: PopulationResult[] = [
+        { populationType: PopulationType.IPP, result: true },
+        { populationType: PopulationType.DENOM, result: true },
+        { populationType: PopulationType.DENEX, result: false },
+        { populationType: PopulationType.NUMER, result: true },
+        { populationType: PopulationType.NUMEX, result: true }
+      ];
+
+      const results = CalculatorHelpers.createPopulationValues(simpleMeasure, simpleMeasureGroup, statementResults);
+
+      expect(results.populationResults).toBeDefined();
+      expect(results.populationResults).toHaveLength(expectedPopulationResults.length);
+      expect(results.populationResults).toEqual(expect.arrayContaining(expectedPopulationResults));
+    });
+
+    test('NUMEX membership removed when not a member of NUMER', () => {
+      const statementResults: StatementResults = {
+        'Initial Population': true,
+        Denominator: true,
+        'Denominator Exclusion': false,
+        Numerator: false,
+        'Numerator Exclusion': true
+      };
+
+      const expectedPopulationResults: PopulationResult[] = [
+        { populationType: PopulationType.IPP, result: true },
+        { populationType: PopulationType.DENOM, result: true },
+        { populationType: PopulationType.DENEX, result: false },
+        { populationType: PopulationType.NUMER, result: false },
+        { populationType: PopulationType.NUMEX, result: false }
+      ];
+
+      const results = CalculatorHelpers.createPopulationValues(simpleMeasure, simpleMeasureGroup, statementResults);
+
+      expect(results.populationResults).toBeDefined();
+      expect(results.populationResults).toHaveLength(expectedPopulationResults.length);
+      expect(results.populationResults).toEqual(expect.arrayContaining(expectedPopulationResults));
+    });
+
+    test('NUMEX membership removed when not a member of DENOM', () => {
+      const statementResults: StatementResults = {
+        'Initial Population': true,
+        Denominator: false,
+        'Denominator Exclusion': false,
+        Numerator: false,
+        'Numerator Exclusion': true
+      };
+
+      const expectedPopulationResults: PopulationResult[] = [
+        { populationType: PopulationType.IPP, result: true },
+        { populationType: PopulationType.DENOM, result: false },
+        { populationType: PopulationType.DENEX, result: false },
+        { populationType: PopulationType.NUMER, result: false },
+        { populationType: PopulationType.NUMEX, result: false }
+      ];
+
+      const results = CalculatorHelpers.createPopulationValues(simpleMeasure, simpleMeasureGroup, statementResults);
+
+      expect(results.populationResults).toBeDefined();
+      expect(results.populationResults).toHaveLength(expectedPopulationResults.length);
+      expect(results.populationResults).toEqual(expect.arrayContaining(expectedPopulationResults));
+    });
+
+    test('DENOM population not modified by inclusion in DENEX', () => {
+      const statementResults: StatementResults = {
+        'Initial Population': true,
+        Denominator: true,
+        'Denominator Exclusion': true,
+        Numerator: false,
+        'Numerator Exclusion': false
+      };
+
+      const expectedPopulationResults: PopulationResult[] = [
+        { populationType: PopulationType.IPP, result: true },
+        { populationType: PopulationType.DENOM, result: true },
+        { populationType: PopulationType.DENEX, result: true },
+        { populationType: PopulationType.NUMER, result: false },
+        { populationType: PopulationType.NUMEX, result: false }
+      ];
+
+      const results = CalculatorHelpers.createPopulationValues(simpleMeasure, simpleMeasureGroup, statementResults);
+
+      expect(results.populationResults).toBeDefined();
+      expect(results.populationResults).toHaveLength(expectedPopulationResults.length);
+      expect(results.populationResults).toEqual(expect.arrayContaining(expectedPopulationResults));
+    });
+
+    test('DENEX membership removed when not a member of DENOM', () => {
+      const statementResults: StatementResults = {
+        'Initial Population': true,
+        Denominator: false,
+        'Denominator Exclusion': true,
+        Numerator: false,
+        'Numerator Exclusion': false
+      };
+
+      const expectedPopulationResults: PopulationResult[] = [
+        { populationType: PopulationType.IPP, result: true },
+        { populationType: PopulationType.DENOM, result: false },
+        { populationType: PopulationType.DENEX, result: false },
+        { populationType: PopulationType.NUMER, result: false },
+        { populationType: PopulationType.NUMEX, result: false }
+      ];
+
+      const results = CalculatorHelpers.createPopulationValues(simpleMeasure, simpleMeasureGroup, statementResults);
+
+      expect(results.populationResults).toBeDefined();
+      expect(results.populationResults).toHaveLength(expectedPopulationResults.length);
+      expect(results.populationResults).toEqual(expect.arrayContaining(expectedPopulationResults));
+    });
+
+    test('MSRPOPLEX should be 0 if MSRPOPL not satisfied', () => {
+      const statementResults: StatementResults = {
+        'Initial Population': true,
+        'Measure Population': false,
+        'Measure Population Exclusion': true,
+        'Measure Observation': false
+      };
+
+      const expectedPopulationResults: PopulationResult[] = [
+        { populationType: PopulationType.IPP, result: true },
+        { populationType: PopulationType.MSRPOPL, result: false },
+        { populationType: PopulationType.MSRPOPLEX, result: false },
+        { populationType: PopulationType.OBSERV, result: false }
+      ];
+
+      const results = CalculatorHelpers.createPopulationValues(cvMeasure, cvMeasureGroup, statementResults);
+
+      expect(results.populationResults).toBeDefined();
+      expect(results.populationResults).toHaveLength(expectedPopulationResults.length);
+      expect(results.populationResults).toEqual(expect.arrayContaining(expectedPopulationResults));
+    });
+
+    test.skip('MSRPOPLEX should be unchanged if MSRPOPL satisfied', () => {
+      const statementResults: StatementResults = {
+        'Initial Population': true,
+        'Measure Population': true,
+        'Measure Population Exclusion': true,
+        'Measure Observation': false
+      };
+
+      const expectedPopulationResults: PopulationResult[] = [
+        { populationType: PopulationType.IPP, result: true },
+        { populationType: PopulationType.MSRPOPL, result: true },
+        { populationType: PopulationType.MSRPOPLEX, result: true },
+        { populationType: PopulationType.OBSERV, result: false }
+      ];
+
+      const results = CalculatorHelpers.createPopulationValues(cvMeasure, cvMeasureGroup, statementResults);
+
+      expect(results.populationResults).toBeDefined();
+      expect(results.populationResults).toHaveLength(expectedPopulationResults.length);
+      expect(results.populationResults).toEqual(expect.arrayContaining(expectedPopulationResults));
+    });
+  });
+
+  describe('ELM JSON Function', () => {
+    test('should properly generate ELM JSON given name and parameter', () => {
+      const exampleFunctionName = 'exampleFunction';
+      const exampleParameterName = 'exampleParameter';
+      const fn = CalculatorHelpers.generateELMJSONFunction(exampleFunctionName, exampleParameterName);
+
+      expect(fn.name).toEqual(`obs_func_${exampleFunctionName}_${exampleParameterName}`);
+      expect(fn.expression.source[0].expression.name).toEqual(exampleParameterName);
+      expect(fn.expression.return).toBeDefined();
+      expect(fn.expression.return.expression.type).toEqual('Tuple');
+      expect(fn.expression.return.expression.element).toEqual(
+        expect.arrayContaining([
+          {
+            name: 'observation',
+            value: {
+              name: exampleFunctionName,
+              type: 'FunctionRef',
+              operand: [
+                {
+                  name: 'MP',
+                  type: 'AliasRef'
+                }
+              ]
+            }
+          }
+        ])
+      );
     });
   });
 });

--- a/test/MeasureReportBuilder.test.ts
+++ b/test/MeasureReportBuilder.test.ts
@@ -1,0 +1,215 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { R4 } from '@ahryman40k/ts-fhir-types';
+import * as MeasureReportBuilder from '../src/MeasureReportBuilder';
+import { getJSONFixture } from './helpers/testHelpers';
+import { ExecutionResult, CalculationOptions } from '../src/types/Calculator';
+import { PopulationType } from '../src/types/Enums';
+
+const patient1 = getJSONFixture(
+  'EXM130-8.0.000/EXM130-8.0.000-patients/numerator/Adeline686_Prohaska837_ee009b12-7dbe-4610-abc4-5f92ad5b2804.json'
+);
+
+const patient2 = getJSONFixture('EXM111-9.1.000/Armando772_Almanza534_08fc9439-b7ff-4309-b409-4d143388594c.json');
+
+// ids from fixture patients
+const patient1Id = '3413754c-73f0-4559-9f67-df8e593ce7e1';
+
+const simpleMeasure = getJSONFixture('measure/simple-measure.json') as R4.IMeasure;
+const cvMeasure = getJSONFixture('measure/cv-measure.json') as R4.IMeasure;
+
+const simpleMeasureBundle: R4.IBundle = {
+  resourceType: 'Bundle',
+  type: R4.BundleTypeKind._collection,
+  entry: [
+    {
+      resource: simpleMeasure
+    }
+  ]
+};
+
+const cvMeasureBundle: R4.IBundle = {
+  resourceType: 'Bundle',
+  type: R4.BundleTypeKind._collection,
+  entry: [
+    {
+      resource: cvMeasure
+    }
+  ]
+};
+
+const executionResults: ExecutionResult[] = [
+  {
+    patientId: patient1Id,
+    detailedResults: [
+      {
+        groupId: 'group-1',
+        statementResults: [],
+        populationResults: [
+          {
+            populationType: PopulationType.NUMER,
+            result: false
+          },
+          {
+            populationType: PopulationType.DENOM,
+            result: true
+          },
+          {
+            populationType: PopulationType.IPP,
+            result: true
+          },
+          {
+            populationType: PopulationType.DENEX,
+            result: false
+          }
+        ],
+        html: 'example-html'
+      }
+    ],
+    supplementalData: [
+      {
+        name: 'sde-code',
+        rawResult: {
+          isCode: true,
+          code: 'example',
+          system: 'http://example.com',
+          display: 'Example'
+        }
+      }
+    ]
+  }
+];
+
+const calculationOptions: CalculationOptions = {
+  measurementPeriodStart: '2021-01-01',
+  measurementPeriodEnd: '2021-12-31',
+  calculateHTML: true,
+  calculateSDEs: true
+};
+
+describe('MeasureReportBuilder', () => {
+  describe('Simple Measure Report', () => {
+    let measureReports: R4.IMeasureReport[];
+    beforeAll(() => {
+      measureReports = MeasureReportBuilder.buildMeasureReports(
+        simpleMeasureBundle,
+        [patient1],
+        executionResults,
+        calculationOptions
+      );
+    });
+
+    test('should generate 1 result', () => {
+      expect(measureReports).toBeDefined();
+      expect(measureReports).toHaveLength(1);
+    });
+
+    test('should set basic options correctly', () => {
+      const [mr] = measureReports;
+
+      expect(mr.status).toEqual(R4.MeasureReportStatusKind._complete);
+      expect(mr.type).toEqual(R4.MeasureReportTypeKind._individual);
+
+      expect(mr.period).toEqual({
+        start: calculationOptions.measurementPeriodStart,
+        end: calculationOptions.measurementPeriodEnd
+      });
+
+      expect(mr.text).toBeDefined();
+      expect(mr.measure).toEqual(simpleMeasure.url);
+
+      expect(mr.subject).toEqual({
+        reference: `Patient/${patient1Id}`
+      });
+    });
+
+    test('should contain proper populationResults', () => {
+      const [mr] = measureReports;
+
+      expect(mr.group).toBeDefined();
+      expect(mr.group).toHaveLength(1);
+
+      const [group] = mr.group!;
+      const result = executionResults[0].detailedResults?.[0];
+
+      expect(group.id).toEqual(result!.groupId);
+      expect(group.measureScore).toBeDefined();
+      expect(group.population).toBeDefined();
+
+      result!.populationResults!.forEach(pr => {
+        const populationResult = group.population?.find(p => p.code?.coding?.[0].code === pr.populationType);
+        expect(populationResult).toBeDefined();
+        expect(populationResult!.count).toEqual(pr.result === true ? 1 : 0);
+      });
+    });
+
+    test('should include SDEs', () => {
+      const [mr] = measureReports;
+
+      // expect 1 SDE defined above
+      expect(mr.contained).toBeDefined();
+      expect(mr.contained).toHaveLength(1);
+
+      const sde = mr.contained?.[0] as R4.IObservation;
+
+      expect(sde.status).toEqual(R4.ObservationStatusKind._final);
+      expect(sde.code).toEqual({
+        text: 'sde-code'
+      });
+
+      expect(sde.valueCodeableConcept).toBeDefined();
+      const result = executionResults[0].supplementalData?.[0];
+
+      expect(sde.valueCodeableConcept).toEqual({
+        coding: expect.arrayContaining([
+          {
+            code: result!.rawResult.code,
+            system: result!.rawResult.system,
+            display: result!.rawResult.display
+          }
+        ])
+      });
+    });
+  });
+
+  describe('CV stratifier Measure Report', () => {
+    let measureReports: R4.IMeasureReport[];
+    beforeAll(() => {
+      measureReports = MeasureReportBuilder.buildMeasureReports(
+        cvMeasureBundle,
+        [patient2],
+        executionResults,
+        calculationOptions
+      );
+    });
+
+    test('should generate MeasureReport', () => {
+      expect(measureReports).toBeDefined();
+      expect(measureReports).toHaveLength(1);
+    });
+
+    test('should include CV-specific properties', () => {
+      const [mr] = measureReports;
+
+      expect(mr.contained).toBeDefined();
+      expect(mr.contained).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            resourceType: 'Observation',
+            code: {
+              text: 'MeasureObservation'
+            }
+          })
+        ])
+      );
+    });
+
+    test('should include stratifier in each group', () => {
+      const [mr] = measureReports;
+
+      expect(mr.group).toBeDefined();
+      mr.group?.forEach(g => {
+        expect(g.stratifier).toBeDefined();
+      });
+    });
+  });
+});

--- a/test/ResultsHelpers.test.ts
+++ b/test/ResultsHelpers.test.ts
@@ -1,0 +1,427 @@
+import * as ResultsHelpers from '../src/ResultsHelpers';
+import { getJSONFixture, getELMFixture } from './helpers/testHelpers';
+import { R4 } from '@ahryman40k/ts-fhir-types';
+import { PopulationResult, StatementResult } from '../src/types/Calculator';
+import { PopulationType, Relevance, FinalResult } from '../src/types/Enums';
+import * as cql from '../src/types/CQLTypes';
+
+type MeasureWithGroup = R4.IMeasure & {
+  group: R4.IMeasure_Group[];
+};
+
+const simpleMeasure = getJSONFixture('measure/simple-measure.json') as MeasureWithGroup;
+const exampleELM = getELMFixture('elm/ExampleMeasure.json');
+const mainLibraryId = exampleELM.library.identifier.id;
+const populationResults: PopulationResult[] = [
+  {
+    populationType: PopulationType.IPP,
+    result: true
+  },
+  {
+    populationType: PopulationType.DENOM,
+    result: true
+  },
+  {
+    populationType: PopulationType.NUMER,
+    result: true
+  },
+  {
+    populationType: PopulationType.NUMEX,
+    result: false
+  },
+  {
+    populationType: PopulationType.DENEX,
+    result: false
+  }
+];
+const localIdResults: cql.LocalIdResults = {
+  [mainLibraryId]: {
+    '2': true,
+    '3': true,
+    '4': true,
+    '5': true,
+    '6': true,
+    '7': true,
+    '8': false,
+    '9': false,
+    '10': false,
+    '11': false,
+    '12': true,
+    '13': true
+  }
+};
+const statementResults: StatementResult[] = [
+  {
+    libraryName: mainLibraryId,
+    statementName: 'Initial Population',
+    localId: '3',
+    final: FinalResult.TRUE,
+    relevance: Relevance.TRUE,
+    raw: true
+  },
+  {
+    libraryName: mainLibraryId,
+    statementName: 'Denominator',
+    localId: '5',
+    final: FinalResult.TRUE,
+    relevance: Relevance.TRUE,
+    raw: true
+  },
+  {
+    libraryName: mainLibraryId,
+    statementName: 'Numerator',
+    localId: '7',
+    final: FinalResult.TRUE,
+    relevance: Relevance.TRUE,
+    raw: true
+  },
+  {
+    libraryName: mainLibraryId,
+    statementName: 'Numerator Exclusion',
+    localId: '9',
+    final: FinalResult.FALSE,
+    relevance: Relevance.FALSE,
+    raw: false
+  },
+  {
+    libraryName: mainLibraryId,
+    statementName: 'Denominator Exclusion',
+    localId: '11',
+    final: FinalResult.FALSE,
+    relevance: Relevance.FALSE,
+    raw: false
+  },
+  {
+    libraryName: mainLibraryId,
+    statementName: 'SDE',
+    localId: '13',
+    final: FinalResult.TRUE,
+    relevance: Relevance.TRUE,
+    raw: true
+  }
+];
+
+describe('ResultsHelper', () => {
+  describe('Statement Maps', () => {
+    test('should build statement relevance map', () => {
+      const map = ResultsHelpers.buildStatementRelevanceMap(
+        simpleMeasure,
+        populationResults,
+        mainLibraryId,
+        [exampleELM],
+        simpleMeasure.group[0],
+        true
+      );
+
+      expect(map).toHaveLength(exampleELM.library.statements.def.length);
+
+      expect(map).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            libraryName: mainLibraryId,
+            statementName: 'Initial Population',
+            relevance: Relevance.TRUE
+          }),
+
+          expect.objectContaining({
+            libraryName: mainLibraryId,
+            statementName: 'Denominator',
+            relevance: Relevance.TRUE
+          }),
+
+          expect.objectContaining({
+            libraryName: mainLibraryId,
+            statementName: 'Numerator',
+            relevance: Relevance.TRUE
+          }),
+
+          expect.objectContaining({
+            libraryName: mainLibraryId,
+            statementName: 'Denominator Exclusion',
+            relevance: Relevance.FALSE
+          })
+        ])
+      );
+    });
+
+    test('should build statement and clause results', () => {
+      const results = ResultsHelpers.buildStatementAndClauseResults(
+        simpleMeasure,
+        [exampleELM],
+        localIdResults,
+        statementResults,
+        true,
+        true
+      );
+
+      const numResults = Object.keys(localIdResults[mainLibraryId]).length;
+
+      expect(results).toHaveLength(numResults);
+
+      expect(results).toEqual(
+        expect.arrayContaining([
+          {
+            raw: true,
+            statementName: 'Initial Population',
+            libraryName: 'ExampleMeasure',
+            localId: '3',
+            final: FinalResult.TRUE
+          },
+          {
+            raw: true,
+            statementName: 'Denominator',
+            libraryName: 'ExampleMeasure',
+            localId: '5',
+            final: FinalResult.TRUE
+          },
+          {
+            raw: true,
+            statementName: 'Numerator',
+            libraryName: 'ExampleMeasure',
+            localId: '7',
+            final: FinalResult.TRUE
+          },
+          {
+            raw: false,
+            statementName: 'Numerator Exclusion',
+            libraryName: 'ExampleMeasure',
+            localId: '9',
+            final: FinalResult.UNHIT
+          },
+          {
+            raw: false,
+            statementName: 'Denominator Exclusion',
+            libraryName: 'ExampleMeasure',
+            localId: '11',
+            final: FinalResult.UNHIT
+          },
+          {
+            raw: true,
+            statementName: 'SDE',
+            libraryName: 'ExampleMeasure',
+            localId: '13',
+            final: FinalResult.TRUE
+          }
+        ])
+      );
+    });
+  });
+
+  describe('episodes', () => {
+    test('should mark master results relevant if any episode is true', () => {
+      const truePopulationResults: PopulationResult[] = [
+        { populationType: PopulationType.IPP, result: true },
+        { populationType: PopulationType.DENOM, result: true },
+        { populationType: PopulationType.DENEX, result: false },
+        { populationType: PopulationType.NUMER, result: true },
+        { populationType: PopulationType.NUMEX, result: false }
+      ];
+
+      const falsePopulationResults: PopulationResult[] = [
+        { populationType: PopulationType.IPP, result: false },
+        { populationType: PopulationType.DENOM, result: false },
+        { populationType: PopulationType.DENEX, result: false },
+        { populationType: PopulationType.NUMER, result: false },
+        { populationType: PopulationType.NUMEX, result: false }
+      ];
+
+      const expectedMasterResults: PopulationResult[] = [
+        { populationType: PopulationType.IPP, result: true },
+        { populationType: PopulationType.DENOM, result: true },
+        { populationType: PopulationType.DENEX, result: true },
+        { populationType: PopulationType.NUMER, result: true },
+        { populationType: PopulationType.NUMEX, result: true }
+      ];
+
+      const results = ResultsHelpers.buildPopulationRelevanceForAllEpisodes(simpleMeasure.group[0], [
+        { episodeId: '1', populationResults: truePopulationResults },
+        { episodeId: '2', populationResults: falsePopulationResults }
+      ]);
+
+      expect(results.length).toEqual(expectedMasterResults.length);
+      expect(results).toEqual(expect.arrayContaining(expectedMasterResults));
+    });
+  });
+
+  describe('prettyResult', () => {
+    test('should not destroy objects passed in', () => {
+      const before: { [key: string]: any } = { a: 1, b: 2 };
+      const beforeClone: { [key: string]: any } = { a: 1, b: 2 };
+      ResultsHelpers.prettyResult(before);
+      Object.entries(before).map(([key, value]) => expect(value).toEqual(beforeClone[key]));
+    });
+
+    test('should not destroy arrays passed in', () => {
+      const before = [1, 2, 3];
+      const beforeClone = [1, 2, 3];
+      ResultsHelpers.prettyResult(before);
+      Array.from(before).map((item, index) => expect(item).toEqual(beforeClone[index]));
+    });
+
+    test('should properly indent nested objects', () => {
+      const nestedObject = {
+        one: 'single item',
+        two: { nested: 'item', nested2: 'item' },
+        three: { doubleNested: { a: '1', b: '2', c: '3' }, nested: 'item' }
+      };
+      const prettyNestedObject =
+        '{\n  one: "single item",\n  three: {\n    doubleNested: {\n      a: "1",\n      b: "2",\n      c: "3"\n    },\n    nested: "item"\n  },\n' +
+        '  two: {\n    nested: "item",\n    nested2: "item"\n  }\n}';
+      expect(ResultsHelpers.prettyResult(nestedObject)).toEqual(prettyNestedObject);
+    });
+
+    test('should properly indent a single array', () => {
+      const singleArray = [1, 2, 3];
+      expect(ResultsHelpers.prettyResult(singleArray)).toEqual('[1,\n2,\n3]');
+    });
+
+    test('should properly indent an array in an object', () => {
+      const arrayObject = { array: [1, 2, 3] };
+      expect(ResultsHelpers.prettyResult(arrayObject)).toEqual('{\n  array: [1,\n         2,\n         3]\n}');
+    });
+  });
+
+  describe('buildStatementRelevanceMap', () => {
+    test('marks all false when IPP is false', () => {
+      const populationResults: PopulationResult[] = [
+        { populationType: PopulationType.IPP, result: false },
+        { populationType: PopulationType.DENOM, result: false },
+        { populationType: PopulationType.DENEX, result: false },
+        { populationType: PopulationType.DENEXCEP, result: false },
+        { populationType: PopulationType.NUMER, result: false },
+        { populationType: PopulationType.NUMEX, result: false }
+      ];
+      const expectedRelevanceMap: PopulationResult[] = [
+        { populationType: PopulationType.IPP, result: true },
+        { populationType: PopulationType.DENOM, result: false },
+        { populationType: PopulationType.DENEX, result: false },
+        { populationType: PopulationType.DENEXCEP, result: false },
+        { populationType: PopulationType.NUMER, result: false },
+        { populationType: PopulationType.NUMEX, result: false }
+      ];
+
+      const relevanceMap = ResultsHelpers.buildPopulationRelevanceMap(populationResults);
+      expect(relevanceMap).toEqual(expectedRelevanceMap);
+    });
+
+    test('marks DENEX, DENEXCP, NUMER, NUMEX all false when DENOM is false', () => {
+      const populationResults: PopulationResult[] = [
+        { populationType: PopulationType.IPP, result: true },
+        { populationType: PopulationType.DENOM, result: false },
+        { populationType: PopulationType.DENEX, result: false },
+        { populationType: PopulationType.DENEXCEP, result: false },
+        { populationType: PopulationType.NUMER, result: false },
+        { populationType: PopulationType.NUMEX, result: false }
+      ];
+      const expectedRelevanceMap: PopulationResult[] = [
+        { populationType: PopulationType.IPP, result: true },
+        { populationType: PopulationType.DENOM, result: true },
+        { populationType: PopulationType.DENEX, result: false },
+        { populationType: PopulationType.DENEXCEP, result: false },
+        { populationType: PopulationType.NUMER, result: false },
+        { populationType: PopulationType.NUMEX, result: false }
+      ];
+
+      const relevanceMap = ResultsHelpers.buildPopulationRelevanceMap(populationResults);
+      expect(relevanceMap).toEqual(expectedRelevanceMap);
+    });
+
+    test('marks DENEXCP, NUMER, NUMEX all false when DENEX is false', () => {
+      const populationResults: PopulationResult[] = [
+        { populationType: PopulationType.IPP, result: true },
+        { populationType: PopulationType.DENOM, result: true },
+        { populationType: PopulationType.DENEX, result: true },
+        { populationType: PopulationType.DENEXCEP, result: false },
+        { populationType: PopulationType.NUMER, result: false },
+        { populationType: PopulationType.NUMEX, result: false }
+      ];
+      const expectedRelevanceMap: PopulationResult[] = [
+        { populationType: PopulationType.IPP, result: true },
+        { populationType: PopulationType.DENOM, result: true },
+        { populationType: PopulationType.DENEX, result: true },
+        { populationType: PopulationType.DENEXCEP, result: false },
+        { populationType: PopulationType.NUMER, result: false },
+        { populationType: PopulationType.NUMEX, result: false }
+      ];
+
+      const relevanceMap = ResultsHelpers.buildPopulationRelevanceMap(populationResults);
+      expect(relevanceMap).toEqual(expectedRelevanceMap);
+    });
+
+    test('marks DENEXCP false when NUMER is true', () => {
+      const populationResults: PopulationResult[] = [
+        { populationType: PopulationType.IPP, result: true },
+        { populationType: PopulationType.DENOM, result: true },
+        { populationType: PopulationType.DENEX, result: false },
+        { populationType: PopulationType.DENEXCEP, result: false },
+        { populationType: PopulationType.NUMER, result: true },
+        { populationType: PopulationType.NUMEX, result: false }
+      ];
+      const expectedRelevanceMap: PopulationResult[] = [
+        { populationType: PopulationType.IPP, result: true },
+        { populationType: PopulationType.DENOM, result: true },
+        { populationType: PopulationType.DENEX, result: true },
+        { populationType: PopulationType.DENEXCEP, result: false },
+        { populationType: PopulationType.NUMER, result: true },
+        { populationType: PopulationType.NUMEX, result: true }
+      ];
+
+      const relevanceMap = ResultsHelpers.buildPopulationRelevanceMap(populationResults);
+      expect(relevanceMap).toEqual(expectedRelevanceMap);
+    });
+
+    test('marks NUMEX false when NUMER is false', () => {
+      const populationResults: PopulationResult[] = [
+        { populationType: PopulationType.IPP, result: true },
+        { populationType: PopulationType.DENOM, result: true },
+        { populationType: PopulationType.DENEX, result: false },
+        { populationType: PopulationType.DENEXCEP, result: false },
+        { populationType: PopulationType.NUMER, result: false },
+        { populationType: PopulationType.NUMEX, result: false }
+      ];
+      const expectedRelevanceMap: PopulationResult[] = [
+        { populationType: PopulationType.IPP, result: true },
+        { populationType: PopulationType.DENOM, result: true },
+        { populationType: PopulationType.DENEX, result: true },
+        { populationType: PopulationType.DENEXCEP, result: true },
+        { populationType: PopulationType.NUMER, result: true },
+        { populationType: PopulationType.NUMEX, result: false }
+      ];
+
+      const relevanceMap = ResultsHelpers.buildPopulationRelevanceMap(populationResults);
+      expect(relevanceMap).toEqual(expectedRelevanceMap);
+    });
+
+    test('marks OBSERV, MSRPOPLEX false when MSRPOPL is false', () => {
+      const populationResults: PopulationResult[] = [
+        { populationType: PopulationType.MSRPOPL, result: false },
+        { populationType: PopulationType.OBSERV, result: false },
+        { populationType: PopulationType.MSRPOPLEX, result: false }
+      ];
+      const expectedRelevanceMap: PopulationResult[] = [
+        { populationType: PopulationType.MSRPOPL, result: false },
+        { populationType: PopulationType.OBSERV, result: false },
+        { populationType: PopulationType.MSRPOPLEX, result: false }
+      ];
+
+      const relevanceMap = ResultsHelpers.buildPopulationRelevanceMap(populationResults);
+      expect(relevanceMap).toEqual(expectedRelevanceMap);
+    });
+
+    test('marks OBSERV false when MSRPOPLEX is true', () => {
+      const populationResults: PopulationResult[] = [
+        { populationType: PopulationType.MSRPOPL, result: true },
+        { populationType: PopulationType.OBSERV, result: false },
+        { populationType: PopulationType.MSRPOPLEX, result: true }
+      ];
+      const expectedRelevanceMap: PopulationResult[] = [
+        { populationType: PopulationType.MSRPOPL, result: false },
+        { populationType: PopulationType.OBSERV, result: false },
+        { populationType: PopulationType.MSRPOPLEX, result: false }
+      ];
+
+      const relevanceMap = ResultsHelpers.buildPopulationRelevanceMap(populationResults);
+      expect(relevanceMap).toEqual(expectedRelevanceMap);
+    });
+  });
+});

--- a/test/ValueSetHelper.test.ts
+++ b/test/ValueSetHelper.test.ts
@@ -1,0 +1,61 @@
+import { R4 } from '@ahryman40k/ts-fhir-types';
+import { valueSetsForCodeService } from '../src/ValueSetHelper';
+import { getJSONFixture } from './helpers/testHelpers';
+
+type ValueSetWithNoUndefined = R4.IValueSet & {
+  url: string;
+  version: string;
+  compose: {
+    include: (R4.IValueSet_Include & {
+      concept: R4.IValueSet_Concept;
+      system: string;
+      version: string;
+    })[];
+  };
+};
+
+const exampleValueSet1 = getJSONFixture('valuesets/example-vs-1.json') as ValueSetWithNoUndefined;
+const exampleValueSet2 = getJSONFixture('valuesets/example-vs-2.json') as ValueSetWithNoUndefined;
+
+describe('ValueSetHelper', () => {
+  test('valueSetMapper should include all codes', () => {
+    const map = valueSetsForCodeService([exampleValueSet1, exampleValueSet2]);
+
+    // map should key both URLs
+    const vsetUrls = Object.keys(map);
+    expect(vsetUrls).toHaveLength(2);
+    expect(vsetUrls).toEqual(expect.arrayContaining([exampleValueSet1.url, exampleValueSet2.url]));
+
+    const vs1Entry = map[exampleValueSet1.url];
+    const vs1Codes = vs1Entry[exampleValueSet1.version];
+    const vs2Entry = map[exampleValueSet2.url];
+    const vs2Codes = vs2Entry[exampleValueSet2.version];
+
+    // This entry of the map should contain all codes defined in compose.include
+    expect(vs1Codes).toBeDefined();
+    expect(vs2Codes).toBeDefined();
+
+    // Check all codes listed
+    exampleValueSet1.compose.include.forEach(i => {
+      expect(vs1Codes).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            system: i.system,
+            version: i.version
+          })
+        ])
+      );
+
+      i.concept?.forEach(c => {
+        expect(vs1Codes).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              code: c.code,
+              display: c.display
+            })
+          ])
+        );
+      });
+    });
+  });
+});

--- a/test/fixtures/elm/ExampleMeasure.json
+++ b/test/fixtures/elm/ExampleMeasure.json
@@ -1,0 +1,286 @@
+{
+  "library": {
+    "annotation": [
+      {
+        "translatorOptions": "EnableAnnotations,EnableLocators",
+        "type": "CqlToElmInfo"
+      },
+      {
+        "type": "Annotation",
+        "s": {
+          "r": "13",
+          "s": [
+            {
+              "value": [
+                "",
+                "library ExampleMeasure version '1'"
+              ]
+            }
+          ]
+        }
+      }
+    ],
+    "identifier": {
+      "id": "ExampleMeasure",
+      "version": "1"
+    },
+    "schemaIdentifier": {
+      "id": "urn:hl7-org:elm",
+      "version": "r1"
+    },
+    "usings": {
+      "def": [
+        {
+          "localIdentifier": "System",
+          "uri": "urn:hl7-org:elm-types:r1"
+        },
+        {
+          "localId": "1",
+          "locator": "3:1-3:26",
+          "localIdentifier": "FHIR",
+          "uri": "http://hl7.org/fhir",
+          "version": "4.0.1",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "1",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "using "
+                    ]
+                  },
+                  {
+                    "s": [
+                      {
+                        "value": [
+                          "FHIR"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " version ",
+                      "'4.0.1'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "statements": {
+      "def": [
+        {
+          "localId": "3",
+          "locator": "5:1-5:33",
+          "name": "Initial Population",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "3",
+                "s": [
+                  {
+                    "r": "2",
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Initial Population\"",
+                      ": ",
+                      "true"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "2",
+            "locator": "5:30-5:33",
+            "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+            "value": "true",
+            "type": "Literal"
+          }
+        },
+        {
+          "localId": "5",
+          "locator": "6:1-6:26",
+          "name": "Denominator",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "5",
+                "s": [
+                  {
+                    "r": "4",
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Denominator\"",
+                      ": ",
+                      "true"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "4",
+            "locator": "6:23-6:26",
+            "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+            "value": "true",
+            "type": "Literal"
+          }
+        },
+        {
+          "localId": "7",
+          "locator": "7:1-7:24",
+          "name": "Numerator",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "7",
+                "s": [
+                  {
+                    "r": "6",
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Numerator\"",
+                      ": ",
+                      "true"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "6",
+            "locator": "7:21-7:24",
+            "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+            "value": "true",
+            "type": "Literal"
+          }
+        },
+        {
+          "localId": "9",
+          "locator": "8:1-8:35",
+          "name": "Numerator Exclusion",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "9",
+                "s": [
+                  {
+                    "r": "8",
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Numerator Exclusion\"",
+                      ": ",
+                      "false"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "8",
+            "locator": "8:31-8:35",
+            "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+            "value": "false",
+            "type": "Literal"
+          }
+        },
+        {
+          "localId": "11",
+          "locator": "9:1-9:37",
+          "name": "Denominator Exclusion",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "11",
+                "s": [
+                  {
+                    "r": "10",
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Denominator Exclusion\"",
+                      ": ",
+                      "false"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "10",
+            "locator": "9:33-9:37",
+            "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+            "value": "false",
+            "type": "Literal"
+          }
+        },
+        {
+          "localId": "13",
+          "locator": "10:1-10:18",
+          "name": "SDE",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "13",
+                "s": [
+                  {
+                    "r": "12",
+                    "value": [
+                      "",
+                      "define ",
+                      "\"SDE\"",
+                      ": ",
+                      "true"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "12",
+            "locator": "10:15-10:18",
+            "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+            "value": "true",
+            "type": "Literal"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/elm/queries/ExampleMeasure.cql
+++ b/test/fixtures/elm/queries/ExampleMeasure.cql
@@ -1,0 +1,10 @@
+library ExampleMeasure version '1'
+
+using FHIR version '4.0.1'
+
+define "Initial Population": true
+define "Denominator": true
+define "Numerator": true
+define "Numerator Exclusion": false
+define "Denominator Exclusion": false
+define "SDE": true

--- a/test/fixtures/measure/cv-measure.json
+++ b/test/fixtures/measure/cv-measure.json
@@ -1,0 +1,144 @@
+{
+  "resourceType": "Measure",
+  "id": "cv-example",
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis",
+      "valueCode": "Encounter"
+    },
+    {
+      "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-softwaresystem",
+      "valueReference": {
+        "reference": "#cqf-tooling"
+      }
+    }
+  ],
+  "url": "http://example.com/cv-example",
+  "name": "CV Example",
+  "status": "active",
+  "effectivePeriod": {
+    "start": "2021-01-01",
+    "end": "2021-12-31"
+  },
+  "library": [
+    "Library/example-cv"
+  ],
+  "scoring": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/measure-scoring",
+        "code": "continuous-variable"
+      }
+    ]
+  },
+  "improvementNotation": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/measure-improvement-notation",
+        "code": "increase"
+      }
+    ]
+  },
+  "group": [
+    {
+      "id": "group-1",
+      "population": [
+        {
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "initial-population",
+                "display": "Initial Population"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql",
+            "expression": "Initial Population"
+          }
+        },
+        {
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "measure-population",
+                "display": "Measure Population"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql",
+            "expression": "Measure Population"
+          }
+        },
+        {
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "measure-population-exclusion",
+                "display": "Measure Population Exclusion"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql",
+            "expression": "Measure Population Exclusions"
+          }
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-criteriaReference",
+              "valueString": "measure-population-identifier"
+            },
+            {
+              "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-aggregateMethod",
+              "valueCode": "median"
+            }
+          ],
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "measure-observation",
+                "display": "Measure Observation"
+              }
+            ]
+          },
+          "description": "The duration from the Decision to Admit (order or assessment) to the departure from the Emergency Department",
+          "criteria": {
+            "language": "text/cql",
+            "expression": "MeasureObservation"
+          }
+        }
+      ],
+      "stratifier": [
+        {
+          "code": {
+            "text": "stratification-1"
+          },
+          "description": "Patient encounters without a principal diagnosis (rank=1) of 'Psychiatric/Mental Health Diagnosis'",
+          "criteria": {
+            "name": "stratification-1",
+            "language": "text/cql",
+            "expression": "Stratification 1"
+          }
+        },
+        {
+          "code": {
+            "text": "stratification-2"
+          },
+          "description": "Patient encounters with a principal diagnosis (rank=1) of 'Psychiatric/Mental Health Diagnosis'",
+          "criteria": {
+            "name": "stratification-2",
+            "language": "text/cql",
+            "expression": "Stratification 2"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/fixtures/measure/simple-measure.json
+++ b/test/fixtures/measure/simple-measure.json
@@ -1,0 +1,145 @@
+{
+  "resourceType": "Measure",
+  "id": "example",
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis",
+      "valueCode": "boolean"
+    }
+  ],
+  "status": "active",
+  "url": "http://example.com/example",
+  "identifier": [
+    {
+      "system": "http://example.com",
+      "value": "example"
+    }
+  ],
+  "name": "Example Measure",
+  "effectivePeriod": {
+    "start": "2021-01-01",
+    "end": "2021-12-31"
+  },
+  "library": [
+    "Library/example"
+  ],
+  "scoring": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/measure-scoring",
+        "code": "proportion"
+      }
+    ]
+  },
+  "improvementNotation": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/measure-improvement-notation",
+        "code": "increase"
+      }
+    ]
+  },
+  "group": [
+    {
+      "id": "group-1",
+      "population": [
+        {
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "initial-population",
+                "display": "Initial Population"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql",
+            "expression": "Initial Population"
+          }
+        },
+        {
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "numerator",
+                "display": "Numerator"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql",
+            "expression": "Numerator"
+          }
+        },
+        {
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "denominator",
+                "display": "Denominator"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql",
+            "expression": "Denominator"
+          }
+        },
+        {
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "denominator-exclusion",
+                "display": "Denominator Exclusion"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql",
+            "expression": "Denominator Exclusion"
+          }
+        },
+        {
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "numerator-exclusion",
+                "display": "Numerator Exclusion"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql",
+            "expression": "Numerator Exclusion"
+          }
+        }
+      ]
+    }
+  ],
+  "supplementalData": [
+    {
+      "code": {
+        "text": "sde-code"
+      },
+      "usage": [
+        {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/measure-data-usage",
+              "code": "supplemental-data"
+            }
+          ]
+        }
+      ],
+      "criteria": {
+        "language": "text/cql",
+        "expression": "SDE"
+      }
+    }
+  ]
+}

--- a/test/fixtures/valuesets/example-vs-1.json
+++ b/test/fixtures/valuesets/example-vs-1.json
@@ -1,0 +1,25 @@
+{
+  "resourceType": "ValueSet",
+  "id": "example-valueset-1",
+  "url": "http://example.com/example-valueset-1",
+  "status": "draft",
+  "version": "1",
+  "compose": {
+    "include": [
+      {
+        "system": "http://example.com",
+        "version": "1",
+        "concept": [
+          {
+            "code": "example-code-1",
+            "display": "Example Code 1"
+          },
+          {
+            "code": "example-code-2",
+            "display": "Example Code 2"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/test/fixtures/valuesets/example-vs-2.json
+++ b/test/fixtures/valuesets/example-vs-2.json
@@ -1,0 +1,21 @@
+{
+  "resourceType": "ValueSet",
+  "id": "example-valueset-2",
+  "url": "http://example.com/example-valueset-2",
+  "status": "draft",
+  "version": "1",
+  "compose": {
+    "include": [
+      {
+        "system": "http://example.com",
+        "version": "1",
+        "concept": [
+          {
+            "code": "example-code-3",
+            "display": "Example Code 3"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
# Summary

Add tests to increase test coverage

Some are home-grown, some are ported over from [cqm-execution](https://github.com/projecttacoma/cqm-execution/tree/master/spec/helpers)

**Note**: there is one `test.skip` in `CalculatorHelpers.test.ts`. We are going to need to make a task to investigate if our behavior is intentionally different than cqm-execution/potentially fix a bug

**Note Note**: Files ignored from coverage and reasoning for doing so
* `src/_tests_`: Integration test dir. Doesn't need to be unit tested
* `src/cli.ts`: Nothing to "unit" test in the CLI
* `src/Calculator.ts`: Would require a ton of mocks and needs refactor before testable. Will be a separate task
* `src/Execution.ts`: Same as Calculator
* `src/DebugHelper.ts`: Used for local development and does not deal with functionality of the actual software

## New behavior

More tests

## Code changes

* Added tests and fixtures
* Added coverage watch script
* Ignored certain files for coverage

# Testing guidance

`npm run test:coverage`