### PR TITLE
Parse Query Filter Information

### DIFF
--- a/src/Calculator.ts
+++ b/src/Calculator.ts
@@ -307,8 +307,13 @@ export function calculateGapsInCare(
         );
 
         retrieves.forEach(retrieve => {
-          if (retrieve.queryLocalId) {
-            retrieve.queryInfo = parseQueryInfo(mainLibraryELM, retrieve.queryLocalId, parameters);
+          // If the retrieves have a localId for the query and a known library name, we can get more info
+          // on how the query filters the sources.
+          if (retrieve.queryLocalId && retrieve.libraryName) {
+            const library = elmLibraries.find(lib => lib.library.identifier.id === retrieve.libraryName);
+            if (library) {
+              retrieve.queryInfo = parseQueryInfo(library, retrieve.queryLocalId, parameters);
+            }
           }
         });
 

--- a/src/Calculator.ts
+++ b/src/Calculator.ts
@@ -24,7 +24,13 @@ export function calculate(
   measureBundle: R4.IBundle,
   patientBundles: R4.IBundle[],
   options: CalculationOptions
-): { results: ExecutionResult[]; debugOutput?: DebugOutput; elmLibraries?: ELM[]; mainLibraryName?: string } {
+): {
+  results: ExecutionResult[];
+  debugOutput?: DebugOutput;
+  elmLibraries?: ELM[];
+  mainLibraryName?: string;
+  parameters?: { [key: string]: any };
+} {
   const debugObject: DebugOutput | undefined = options.enableDebugOutput ? <DebugOutput>{} : undefined;
 
   // Ensure the CalculationOptions have sane defaults, only if they're not set
@@ -160,7 +166,8 @@ export function calculate(
       results: executionResults,
       debugOutput: debugObject,
       elmLibraries: results.elmLibraries,
-      mainLibraryName: results.mainLibraryName
+      mainLibraryName: results.mainLibraryName,
+      parameters: results.parameters
     };
   } else {
     return { results: executionResults, debugOutput: debugObject };
@@ -213,7 +220,11 @@ export function calculateGapsInCare(
 ): { results: R4.IBundle; debugOutput?: DebugOutput } {
   // Detailed results for populations get ELM content back
   options.returnELM = true;
-  const { results, debugOutput, elmLibraries, mainLibraryName } = calculate(measureBundle, patientBundles, options);
+  const { results, debugOutput, elmLibraries, mainLibraryName, parameters } = calculate(
+    measureBundle,
+    patientBundles,
+    options
+  );
   const measureReports = MeasureReportBuilder.buildMeasureReports(measureBundle, patientBundles, results, options);
 
   let result: R4.IBundle = <R4.IBundle>{};
@@ -297,7 +308,7 @@ export function calculateGapsInCare(
 
         retrieves.forEach(retrieve => {
           if (retrieve.queryLocalId) {
-            retrieve.queryInfo = parseQueryInfo(mainLibraryELM, retrieve.queryLocalId, {});
+            retrieve.queryInfo = parseQueryInfo(mainLibraryELM, retrieve.queryLocalId, parameters);
           }
         });
 

--- a/src/Calculator.ts
+++ b/src/Calculator.ts
@@ -297,7 +297,7 @@ export function calculateGapsInCare(
 
         retrieves.forEach(retrieve => {
           if (retrieve.queryLocalId) {
-            retrieve.queryInfo = parseQueryInfo(mainLibraryELM, retrieve.queryLocalId);
+            retrieve.queryInfo = parseQueryInfo(mainLibraryELM, retrieve.queryLocalId, {});
           }
         });
 

--- a/src/Calculator.ts
+++ b/src/Calculator.ts
@@ -10,6 +10,7 @@ import * as MeasureReportBuilder from './MeasureReportBuilder';
 import * as GapsInCareHelpers from './GapsInCareHelpers';
 import { generateHTML } from './HTMLGenerator';
 import { ELM } from './types/ELMTypes';
+import { parseQueryInfo } from './QueryFilterHelpers';
 
 /**
  * Calculate measure against a set of patients. Returning detailed results for each patient and population group.
@@ -293,6 +294,12 @@ export function calculateGapsInCare(
           numerELMExpression.expression,
           dr
         );
+
+        retrieves.forEach(retrieve => {
+          if (retrieve.queryLocalId) {
+            retrieve.queryInfo = parseQueryInfo(mainLibraryELM, retrieve.queryLocalId);
+          }
+        });
 
         retrieves = GapsInCareHelpers.calculateNearMisses(retrieves, improvementNotation);
 

--- a/src/Execution.ts
+++ b/src/Execution.ts
@@ -152,5 +152,5 @@ export function execute(
     debugObject.rawResults = results;
   }
 
-  return { rawResults: results, elmLibraries: elmJSONs, mainLibraryName: rootLibIdentifer.id };
+  return { rawResults: results, elmLibraries: elmJSONs, mainLibraryName: rootLibIdentifer.id, parameters: parameters };
 }

--- a/src/QueryFilterHelpers.ts
+++ b/src/QueryFilterHelpers.ts
@@ -11,12 +11,19 @@ import {
   ELMProperty,
   ELMQuery,
   ELMRetrieve,
-  ELMStatement
+  ELMStatement,
+  ELMAnd,
+  ELMOr,
+  ELMEquivalent,
+  ELMConceptRef,
+  ELMIncludedIn,
+  ELMParameterRef,
+  ELMAs
 } from './types/ELMTypes';
 import { FinalResult } from './types/Enums';
 
-export function parseQueryInfo(library: ELM, querylocalId: string): any {
-  const expression = findClauseInLibrary(library, querylocalId);
+export function parseQueryInfo(library: ELM, queryLocalId: string): any {
+  const expression = findClauseInLibrary(library, queryLocalId);
   if (expression?.type == 'Query') {
     const query = expression as ELMQuery;
     const queryInfo = {
@@ -24,19 +31,13 @@ export function parseQueryInfo(library: ELM, querylocalId: string): any {
       sources: parseSources(query)
     };
     if (query.where) {
-      const whereInfo = parseExpression(query.where);
-      const source = queryInfo.sources.find(source => source.alias === whereInfo.alias);
-      if (source) {
-        source.filters.push({
-          attribute: whereInfo.attribute,
-          value: whereInfo.value,
-          localId: whereInfo.localId
-        });
-      }
+      const whereInfo = interpretExpression(query.where, library);
+      const source = queryInfo.sources[0]; //find(source => source.alias === whereInfo.alias);
+      source.filters = whereInfo;
     }
     return queryInfo;
   } else {
-    throw new Error(`Clause ${querylocalId} in ${library.library.identifier.id} was not a Query or not found.`);
+    throw new Error(`Clause ${queryLocalId} in ${library.library.identifier.id} was not a Query or not found.`);
   }
 }
 
@@ -76,7 +77,7 @@ function parseSources(query: ELMQuery): any[] {
       const retrieveInfo = parseRetrieveInfo(source.expression as ELMRetrieve);
       const sourceInfo = {
         sourceLocalId: source.localId,
-        retrievelocalId: source.expression.localId,
+        retrieveLocalId: source.expression.localId,
         alias: source.alias,
         resourceType: retrieveInfo.resourceType,
         filters: []
@@ -94,38 +95,145 @@ function parseRetrieveInfo(retrieve: ELMRetrieve): any {
   };
 }
 
-function parseExpression(expression: ELMExpression): any {
+function interpretExpression(expression: ELMExpression, library: ELM): any {
   switch (expression.type) {
     case 'FunctionRef':
-      //interpertFunctionRef(expression as ELMFunctionRef);
+      //interpretFunctionRef(expression as ELMFunctionRef, library);
       break;
     case 'Equal':
-      return interpretEqual(expression as ELMEqual);
+      return interpretEqual(expression as ELMEqual, library);
+      break;
+    case 'Equivalent':
+      return interpretEquivalent(expression as ELMEquivalent, library);
+      break;
+    case 'And':
+      return interpretAnd(expression as ELMAnd, library);
+      break;
+    case 'Or':
+      return interpretOr(expression as ELMOr, library);
+      break;
+    case 'IncludedIn':
+      return interpretIncludedIn(expression as ELMIncludedIn, library);
       break;
     default:
+      console.error(`Don't know how to parse ${expression.type} expression.`);
+      //TODO: recursively look for accessing attributes of sources to say they have been accessed
       break;
   }
 }
 
-function interpretFunctionRef(functionRef: ELMFunctionRef): any {
+function interpretAnd(andExpression: ELMAnd, library: ELM): any {
+  const andInfo = { type: 'and', children: [] as any[] };
+  if (andExpression.operand[0].type == 'And') {
+    andInfo.children.push(...interpretAnd(andExpression.operand[0] as ELMAnd, library).children);
+  } else {
+    andInfo.children.push(interpretExpression(andExpression.operand[0], library));
+  }
+  if (andExpression.operand[1].type == 'And') {
+    andInfo.children.push(...interpretAnd(andExpression.operand[1] as ELMAnd, library).children);
+  } else {
+    andInfo.children.push(interpretExpression(andExpression.operand[1], library));
+  }
+  return andInfo;
+}
+
+function interpretOr(orExpression: ELMOr, library: ELM): any {
+  const orInfo = { type: 'or', children: [] as any[] };
+  if (orExpression.operand[0].type == 'Or') {
+    orInfo.children.push(...interpretOr(orExpression.operand[0] as ELMOr, library).children);
+  } else {
+    orInfo.children.push(interpretExpression(orExpression.operand[0], library));
+  }
+  if (orExpression.operand[1].type == 'Or') {
+    orInfo.children.push(...interpretOr(orExpression.operand[1] as ELMOr, library).children);
+  } else {
+    orInfo.children.push(interpretExpression(orExpression.operand[1], library));
+  }
+  return orInfo;
+}
+
+function interpretFunctionRef(functionRef: ELMFunctionRef, library: ELM): any {
   // from fhir helpers
-  if (functionRef.libraryName == 'FHIRHelpers') {
+  if (functionRef.libraryName == 'FHIRHelpers' || functionRef.libraryName == 'Global') {
     switch (functionRef.name) {
       case 'ToString':
+      case 'ToConcept':
+      case 'ToInterval':
+      case 'Normalize Interval':
         // Act as pass through
-        return functionRef.operand[0] as ELMProperty;
+        if (functionRef.operand[0].type == 'Property') {
+          return functionRef.operand[0] as ELMProperty;
+        } else if (
+          functionRef.operand[0].type === 'As' &&
+          (functionRef.operand[0] as ELMAs).operand.type == 'Property'
+        ) {
+          return (functionRef.operand[0] as ELMAs).operand as ELMProperty;
+        }
         break;
-
       default:
         break;
     }
+  } else {
+    console.warn(`do not know how to interpret function ref ${functionRef.libraryName}."${functionRef.name}"`);
   }
 }
 
-function interpretEqual(equal: ELMEqual): any {
+function interpretEquivalent(equal: ELMEquivalent, library: ELM): any {
   let propRef: ELMProperty | null = null;
   if (equal.operand[0].type == 'FunctionRef') {
-    propRef = interpretFunctionRef(equal.operand[0] as ELMFunctionRef);
+    propRef = interpretFunctionRef(equal.operand[0] as ELMFunctionRef, library);
+  } else if (equal.operand[0].type == 'Property') {
+    propRef = equal.operand[0] as ELMProperty;
+  }
+
+  if (propRef == null) {
+    console.warn('could not resolve property ref for Equivalent');
+    return;
+  }
+
+  if (equal.operand[1].type == 'Literal') {
+    const literal = equal.operand[1] as ELMLiteral;
+    return {
+      type: 'equals',
+      alias: propRef.scope,
+      value: literal.value,
+      attribute: propRef.path,
+      localId: equal.localId
+    };
+  }
+
+  if (equal.operand[1].type == 'ConceptRef') {
+    const conceptRef = equal.operand[1] as ELMConceptRef;
+    return {
+      type: 'in',
+      alias: propRef.scope,
+      attribute: propRef.path,
+      valueList: getCodesInConcept(conceptRef.name, library),
+      localId: equal.localId
+    };
+  }
+}
+
+function getCodesInConcept(name: string, library: ELM): any {
+  const concept = library.library.concepts?.def.find(concept => concept.name === name);
+  if (concept) {
+    return concept.code.map(codeRef => {
+      const code = library.library.codes?.def.find(code => code.name == codeRef.name);
+      if (code) {
+        return {
+          code: code?.id,
+          system: library.library.codeSystems.def.find((systemRef: any) => code?.codeSystem.name === systemRef.name).id
+        };
+      }
+    });
+  }
+  return [];
+}
+
+function interpretEqual(equal: ELMEqual, library: ELM): any {
+  let propRef: ELMProperty | null = null;
+  if (equal.operand[0].type == 'FunctionRef') {
+    propRef = interpretFunctionRef(equal.operand[0] as ELMFunctionRef, library);
   } else if (equal.operand[0].type == 'Property') {
     propRef = equal.operand[0] as ELMProperty;
   }
@@ -137,6 +245,7 @@ function interpretEqual(equal: ELMEqual): any {
 
   if (propRef != undefined && literal != undefined) {
     return {
+      type: 'equals',
       alias: propRef.scope,
       value: literal.value,
       attribute: propRef.path,
@@ -144,5 +253,33 @@ function interpretEqual(equal: ELMEqual): any {
     };
   } else {
     console.log('could not find prop and literal for Equal');
+  }
+}
+
+function interpretIncludedIn(includedIn: ELMIncludedIn, library: ELM): any {
+  let propRef: ELMProperty | null = null;
+  if (includedIn.operand[0].type == 'FunctionRef') {
+    propRef = interpretFunctionRef(includedIn.operand[0] as ELMFunctionRef, library);
+  } else if (includedIn.operand[0].type == 'Property') {
+    propRef = includedIn.operand[0] as ELMProperty;
+  }
+
+  if (propRef == null) {
+    console.warn('could not resolve property ref for IncludedIn');
+    return;
+  }
+
+  if (includedIn.operand[1].type == 'ParameterRef') {
+    return {
+      type: 'during',
+      alias: propRef.scope,
+      valuePeriod: {
+        ref: (includedIn.operand[1] as ELMParameterRef).name
+      },
+      attribute: propRef.path,
+      localId: includedIn.localId
+    };
+  } else {
+    console.warn('could not resolve IncludedIn operand[1] ' + includedIn.operand[1].type);
   }
 }

--- a/src/QueryFilterHelpers.ts
+++ b/src/QueryFilterHelpers.ts
@@ -43,6 +43,8 @@ import {
  * @param library The library ELM the query resides in.
  * @param queryLocalId The localId for the query we want to get information on.
  * @param parameters The parameters used for calculation so they could be reused for re-calculating small bits for CQL.
+ *                    "Measurement Period" is the only supported parameter at the moment as it is the only parameter
+ *                    seen in eCQMs.
  * @returns Information about the query and how it is filtered.
  */
 export function parseQueryInfo(library: ELM, queryLocalId: string, parameters: { [key: string]: any } = {}): QueryInfo {

--- a/src/QueryFilterHelpers.ts
+++ b/src/QueryFilterHelpers.ts
@@ -1,0 +1,148 @@
+import { R4 } from '@ahryman40k/ts-fhir-types';
+import { v4 as uuidv4 } from 'uuid';
+import { ELMTypes } from './types';
+import { DataTypeQuery, DetailedPopulationGroupResult } from './types/Calculator';
+import {
+  ELM,
+  ELMEqual,
+  ELMExpression,
+  ELMFunctionRef,
+  ELMLiteral,
+  ELMProperty,
+  ELMQuery,
+  ELMRetrieve,
+  ELMStatement
+} from './types/ELMTypes';
+import { FinalResult } from './types/Enums';
+
+export function parseQueryInfo(library: ELM, querylocalId: string): any {
+  const expression = findClauseInLibrary(library, querylocalId);
+  if (expression?.type == 'Query') {
+    const query = expression as ELMQuery;
+    const queryInfo = {
+      localId: query?.localId,
+      sources: parseSources(query)
+    };
+    if (query.where) {
+      const whereInfo = parseExpression(query.where);
+      const source = queryInfo.sources.find(source => source.alias === whereInfo.alias);
+      if (source) {
+        source.filters.push({
+          attribute: whereInfo.attribute,
+          value: whereInfo.value,
+          localId: whereInfo.localId
+        });
+      }
+    }
+    return queryInfo;
+  } else {
+    throw new Error(`Clause ${querylocalId} in ${library.library.identifier.id} was not a Query or not found.`);
+  }
+}
+
+function findClauseInLibrary(library: ELM, localId: string): ELMExpression | null {
+  for (let i = 0; i < library.library.statements.def.length; i++) {
+    const statement = library.library.statements.def[i];
+    const expression = findClauseInExpression(statement.expression, localId);
+    if (expression) {
+      return expression;
+    }
+  }
+  return null;
+}
+
+function findClauseInExpression(expression: any, localId: string): ELMExpression | null {
+  if (typeof expression === 'string' || typeof expression === 'number' || typeof expression === 'boolean') {
+    return null;
+  } else if (Array.isArray(expression)) {
+    for (let i = 0; i < expression.length; i++) {
+      const memberExpression = findClauseInExpression(expression[i], localId);
+      if (memberExpression) {
+        return memberExpression as ELMExpression;
+      }
+    }
+    return null;
+  } else if (expression.localId == localId) {
+    return expression as ELMExpression;
+  } else {
+    return findClauseInExpression(Object.values(expression), localId);
+  }
+}
+
+function parseSources(query: ELMQuery): any[] {
+  const sources: any[] = [];
+  query.source.forEach(source => {
+    if (source.expression.type == 'Retrieve') {
+      const retrieveInfo = parseRetrieveInfo(source.expression as ELMRetrieve);
+      const sourceInfo = {
+        sourceLocalId: source.localId,
+        retrievelocalId: source.expression.localId,
+        alias: source.alias,
+        resourceType: retrieveInfo.resourceType,
+        filters: []
+      };
+      sources.push(sourceInfo);
+    }
+  });
+  return sources;
+}
+
+function parseRetrieveInfo(retrieve: ELMRetrieve): any {
+  // TODO: Parse and determine valueset or code filter info. Possibly share code in GapsInCareHelpers.
+  return {
+    resourceType: retrieve.dataType.replace(/^(\{http:\/\/hl7.org\/fhir\})?/, '')
+  };
+}
+
+function parseExpression(expression: ELMExpression): any {
+  switch (expression.type) {
+    case 'FunctionRef':
+      //interpertFunctionRef(expression as ELMFunctionRef);
+      break;
+    case 'Equal':
+      return interpertEqual(expression as ELMEqual);
+      break;
+    default:
+      break;
+  }
+}
+
+function interpertFunctionRef(functionRef: ELMFunctionRef): any {
+  // from fhir helpers
+  if (functionRef.libraryName == 'FHIRHelpers') {
+    switch (functionRef.name) {
+      case 'ToString':
+        // Act as pass through
+        return functionRef.operand[0] as ELMProperty;
+        break;
+
+      default:
+        break;
+    }
+  }
+}
+
+function interpertEqual(equal: ELMEqual): any {
+  let propRef: ELMProperty | null = null;
+  if (equal.operand[0].type == 'FunctionRef') {
+    propRef = interpertFunctionRef(equal.operand[0] as ELMFunctionRef);
+  } else if (equal.operand[0].type == 'Property') {
+    propRef = equal.operand[0] as ELMProperty;
+  }
+
+  let literal: ELMLiteral | null = null;
+  if (equal.operand[1].type == 'Literal') {
+    literal = equal.operand[1] as ELMLiteral;
+  }
+
+  if (propRef != undefined && literal != undefined) {
+    return {
+      alias: propRef.scope,
+      value: literal.value,
+      attribute: propRef.path,
+      localId: equal.localId
+    };
+  } else {
+    console.log('could not find prop and literal for Equal');
+  }
+}

--- a/src/QueryFilterHelpers.ts
+++ b/src/QueryFilterHelpers.ts
@@ -478,9 +478,7 @@ function interpretIncludedIn(includedIn: ELMIncludedIn, library: ELM, parameters
 
   if (includedIn.operand[1].type == 'ParameterRef') {
     const paramName = (includedIn.operand[1] as ELMParameterRef).name;
-    const valuePeriod: any = {
-      ref: paramName
-    };
+    const valuePeriod: { start?: string; end?: string } = {};
     // If this parameter is known use it
     if (parameters[paramName]) {
       valuePeriod.start = (parameters[paramName] as cql.Interval).start().toString().replace('+00:00', 'Z');
@@ -589,7 +587,6 @@ function interpretIn(inExpr: ELMIn, library: ELM, parameters: any): InFilter | D
         alias: propRef.scope,
         attribute: propRef.path,
         valuePeriod: {
-          ref: 'Measurement Period',
           start: interval.start().toString().replace('+00:00', 'Z'),
           end: interval.end().toString().replace('+00:00', 'Z')
         }

--- a/src/QueryFilterHelpers.ts
+++ b/src/QueryFilterHelpers.ts
@@ -36,7 +36,7 @@ import {
   UnknownFilter
 } from './types/QueryFilterTypes';
 
-export function parseQueryInfo(library: ELM, queryLocalId: string, parameters: any): QueryInfo {
+export function parseQueryInfo(library: ELM, queryLocalId: string, parameters: { [key: string]: any } = {}): QueryInfo {
   const expression = findClauseInLibrary(library, queryLocalId);
   if (expression?.type == 'Query') {
     const query = expression as ELMQuery;

--- a/src/QueryFilterHelpers.ts
+++ b/src/QueryFilterHelpers.ts
@@ -100,14 +100,14 @@ function parseExpression(expression: ELMExpression): any {
       //interpertFunctionRef(expression as ELMFunctionRef);
       break;
     case 'Equal':
-      return interpertEqual(expression as ELMEqual);
+      return interpretEqual(expression as ELMEqual);
       break;
     default:
       break;
   }
 }
 
-function interpertFunctionRef(functionRef: ELMFunctionRef): any {
+function interpretFunctionRef(functionRef: ELMFunctionRef): any {
   // from fhir helpers
   if (functionRef.libraryName == 'FHIRHelpers') {
     switch (functionRef.name) {
@@ -122,10 +122,10 @@ function interpertFunctionRef(functionRef: ELMFunctionRef): any {
   }
 }
 
-function interpertEqual(equal: ELMEqual): any {
+function interpretEqual(equal: ELMEqual): any {
   let propRef: ELMProperty | null = null;
   if (equal.operand[0].type == 'FunctionRef') {
-    propRef = interpertFunctionRef(equal.operand[0] as ELMFunctionRef);
+    propRef = interpretFunctionRef(equal.operand[0] as ELMFunctionRef);
   } else if (equal.operand[0].type == 'Property') {
     propRef = equal.operand[0] as ELMProperty;
   }

--- a/src/types/CQLExecution.d.ts
+++ b/src/types/CQLExecution.d.ts
@@ -7,7 +7,7 @@ declare module 'cql-execution' {
   }
 
   export class Executor {
-    constructor(library: Library, codeService: CodeService, parameters: any);
+    constructor(library: Library, codeService: CodeService, parameters: { [key: string]: any });
     exec(patientsource: PatientSource, executionDateTime: any): Results;
   }
 

--- a/src/types/CQLExecution.d.ts
+++ b/src/types/CQLExecution.d.ts
@@ -29,6 +29,8 @@ declare module 'cql-execution' {
     constructor(low: any, high: any, lowClosed?: boolean, highClosed?: boolean);
     low: any;
     high: any;
+    start(): DateTime;
+    end(): DateTime;
   }
 
   export class Code {

--- a/src/types/CQLExecution.d.ts
+++ b/src/types/CQLExecution.d.ts
@@ -26,7 +26,7 @@ declare module 'cql-execution' {
   }
 
   export class Interval {
-    constructor(start: any, end: any);
+    constructor(low: any, high: any, lowClosed?: boolean, highClosed?: boolean);
     low: any;
     high: any;
   }
@@ -39,5 +39,15 @@ declare module 'cql-execution' {
   export class Quantity {
     value: number;
     unit: string;
+  }
+
+  export class Expression {
+    constructor(json: any);
+    execute(context: any);
+    arg: Expression;
+  }
+
+  export class PatientContext {
+    constructor(library: Library, patient: any, codeService: any, parameters: any);
   }
 }

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -41,6 +41,10 @@ export interface RawExecutionData {
   elmLibraries?: ELM[];
   /** the name of the "main" library used for execution. */
   mainLibraryName?: string;
+  /** Parameters used in execution. Useful for gaps in care processing. */
+  parameters?: {
+    [key: string]: any;
+  };
 }
 
 /**

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -204,6 +204,8 @@ export interface DataTypeQuery {
   libraryName?: string;
   /** stack of expressions traversed during calculation */
   expressionStack?: ExpressionStackEntry[];
+  /** Info about query */
+  queryInfo?: any;
 }
 
 /**

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -2,6 +2,7 @@ import { R4 } from '@ahryman40k/ts-fhir-types';
 import { PopulationType, FinalResult, Relevance } from './Enums';
 import * as cql from './CQLTypes';
 import { ELM } from './ELMTypes';
+import { QueryInfo } from './QueryFilterTypes';
 
 /**
  * Options for calculation.
@@ -208,8 +209,8 @@ export interface DataTypeQuery {
   libraryName?: string;
   /** stack of expressions traversed during calculation */
   expressionStack?: ExpressionStackEntry[];
-  /** Info about query */
-  queryInfo?: any;
+  /** Info about query and how it is filtered. */
+  queryInfo?: QueryInfo;
 }
 
 /**

--- a/src/types/ELMTypes.ts
+++ b/src/types/ELMTypes.ts
@@ -130,6 +130,110 @@ export interface ELMCode {
   };
 }
 
+/**
+ * Abstract ELM Expression.
+ */
+export interface ELMExpression {
+  /** Type of expression. */
+  type: string;
+  /** Clause id for this expression. */
+  localId?: string;
+  /** Locator in the original CQL file. Only exists if compiled with this info. */
+  locator?: string;
+}
+
+export interface ELMRetrieve extends ELMExpression {
+  type: 'Retrieve';
+  dataType: string;
+  templateId?: string;
+  codeProperty?: string;
+  codes?: ELMExpression;
+}
+
+export interface ELMValueSetRef extends ELMExpression {
+  type: 'ValueSetRef';
+  name: string;
+  libraryName?: string;
+  locator?: string;
+}
+
+export interface ELMQuery extends ELMExpression {
+  type: 'Query';
+  source: [ELMAliasedQuerySource];
+  let: [ELMLetClause];
+  relationship: [ELMRelationshipClause];
+  where?: ELMExpression;
+  return?: ELMReturnClause;
+  sort?: any;
+}
+
+export interface ELMAliasedQuerySource {
+  /** Clause id for this alias. */
+  localId?: string;
+  /** Locator in the original CQL file. Only exists if compiled with this info. */
+  locator?: string;
+  /** Expression to fetch the source for the query. */
+  expression: ELMExpression;
+  /** Named alias to reference in the query scope. */
+  alias: string;
+}
+
+export interface ELMRelationshipClause extends ELMAliasedQuerySource {
+  suchThat: ELMExpression;
+}
+
+export interface ELMLetClause {
+  /** Clause id for this alias. */
+  localId?: string;
+  /** Locator in the original CQL file. Only exists if compiled with this info. */
+  locator?: string;
+  /** Expression to fetch the source for the query. */
+  expression: ELMExpression;
+  /** Named alias to reference in the query scope. */
+  identifier: string;
+}
+
+export interface ELMReturnClause {
+  expression: ELMExpression;
+  distinct?: string;
+}
+
+export interface ELMBinaryExpression extends ELMExpression {
+  operand: [ELMExpression, ELMExpression];
+}
+
+export interface ELMEqual extends ELMBinaryExpression {
+  type: 'Equal';
+}
+
+interface ELMIExpressionRef extends ELMExpression {
+  name: string;
+  libraryName?: string;
+}
+
+export interface ELMExpressionRef extends ELMExpression {
+  type: 'ExpressionRef';
+}
+
+export interface ELMFunctionRef extends ELMIExpressionRef {
+  type: 'FunctionRef';
+  signature?: [any];
+  operand: [ELMExpression];
+}
+
+export interface ELMProperty extends ELMExpression {
+  type: 'Property';
+  source?: ELMExpression;
+  path: string;
+  scope?: string;
+}
+
+export interface ELMLiteral extends ELMExpression {
+  type: 'Literal';
+  valueType: string;
+  value?: string | number;
+}
+
 export interface LibraryDependencyInfo {
   /** The library id */
   libraryId: string;

--- a/src/types/ELMTypes.ts
+++ b/src/types/ELMTypes.ts
@@ -154,12 +154,35 @@ export interface ELMExpression {
   locator?: string;
 }
 
+export type AnyELMExpression =
+  | ELMExpression
+  | ELMRetrieve
+  | ELMValueSetRef
+  | ELMQuery
+  | ELMAs
+  | ELMEqual
+  | ELMEquivalent
+  | ELMAnd
+  | ELMOr
+  | ELMIsNull
+  | ELMIncludedIn
+  | ELMIn
+  | ELMEnd
+  | ELMStart
+  | ELMExpressionRef
+  | ELMFunctionRef
+  | ELMParameterRef
+  | ELMProperty
+  | ELMConceptRef
+  | ELMLiteral
+  | ELMList;
+
 export interface ELMRetrieve extends ELMExpression {
   type: 'Retrieve';
   dataType: string;
   templateId?: string;
   codeProperty?: string;
-  codes?: ELMExpression;
+  codes?: AnyELMExpression;
 }
 
 export interface ELMValueSetRef extends ELMExpression {
@@ -174,7 +197,7 @@ export interface ELMQuery extends ELMExpression {
   source: [ELMAliasedQuerySource];
   let: [ELMLetClause];
   relationship: [ELMRelationshipClause];
-  where?: ELMExpression;
+  where?: AnyELMExpression;
   return?: ELMReturnClause;
   sort?: any;
 }
@@ -185,13 +208,13 @@ export interface ELMAliasedQuerySource {
   /** Locator in the original CQL file. Only exists if compiled with this info. */
   locator?: string;
   /** Expression to fetch the source for the query. */
-  expression: ELMExpression;
+  expression: AnyELMExpression;
   /** Named alias to reference in the query scope. */
   alias: string;
 }
 
 export interface ELMRelationshipClause extends ELMAliasedQuerySource {
-  suchThat: ELMExpression;
+  suchThat: AnyELMExpression;
 }
 
 export interface ELMLetClause {
@@ -200,28 +223,28 @@ export interface ELMLetClause {
   /** Locator in the original CQL file. Only exists if compiled with this info. */
   locator?: string;
   /** Expression to fetch the source for the query. */
-  expression: ELMExpression;
+  expression: AnyELMExpression;
   /** Named alias to reference in the query scope. */
   identifier: string;
 }
 
 export interface ELMReturnClause {
-  expression: ELMExpression;
+  expression: AnyELMExpression;
   distinct?: string;
 }
 
 export interface ELMAs extends ELMExpression {
   type: 'As';
   asType: string;
-  operand: ELMExpression;
+  operand: AnyELMExpression;
 }
 
 export interface ELMBinaryExpression extends ELMExpression {
-  operand: [ELMExpression, ELMExpression];
+  operand: [AnyELMExpression, AnyELMExpression];
 }
 
 export interface ELMUnaryExpression extends ELMExpression {
-  operand: ELMExpression;
+  operand: AnyELMExpression;
 }
 
 export interface ELMEqual extends ELMBinaryExpression {
@@ -276,7 +299,7 @@ export interface ELMExpressionRef extends ELMExpression {
 export interface ELMFunctionRef extends ELMIExpressionRef {
   type: 'FunctionRef';
   signature?: [any];
-  operand: [ELMExpression];
+  operand: [AnyELMExpression];
 }
 
 export interface ELMParameterRef extends ELMIExpressionRef {
@@ -285,7 +308,7 @@ export interface ELMParameterRef extends ELMIExpressionRef {
 
 export interface ELMProperty extends ELMExpression {
   type: 'Property';
-  source?: ELMExpression;
+  source?: AnyELMExpression;
   path: string;
   scope?: string;
 }

--- a/src/types/ELMTypes.ts
+++ b/src/types/ELMTypes.ts
@@ -236,8 +236,22 @@ export interface ELMOr extends ELMBinaryExpression {
   type: 'Or';
 }
 
+export interface ELMNot extends ELMExpression {
+  type: 'Not';
+  operand: ELMExpression;
+}
+
+export interface ELMIsNull extends ELMExpression {
+  type: 'IsNull';
+  operand: ELMExpression;
+}
+
 export interface ELMIncludedIn extends ELMBinaryExpression {
   type: 'IncludedIn';
+}
+
+export interface ELMIn extends ELMBinaryExpression {
+  type: 'In';
 }
 
 interface ELMIExpressionRef extends ELMExpression {
@@ -275,6 +289,11 @@ export interface ELMLiteral extends ELMExpression {
   type: 'Literal';
   valueType: string;
   value?: string | number;
+}
+
+export interface ELMList extends ELMExpression {
+  type: 'List';
+  element: ELMLiteral[];
 }
 
 export interface LibraryDependencyInfo {

--- a/src/types/ELMTypes.ts
+++ b/src/types/ELMTypes.ts
@@ -175,6 +175,7 @@ export type AnyELMExpression =
   | ELMProperty
   | ELMConceptRef
   | ELMLiteral
+  | ELMInterval
   | ELMList;
 
 export interface ELMRetrieve extends ELMExpression {
@@ -322,6 +323,14 @@ export interface ELMLiteral extends ELMExpression {
   type: 'Literal';
   valueType: string;
   value?: string | number;
+}
+
+export interface ELMInterval extends ELMExpression {
+  type: 'Interval';
+  lowClosed?: boolean;
+  highClosed?: boolean;
+  low?: AnyELMExpression;
+  high?: AnyELMExpression;
 }
 
 export interface ELMList extends ELMExpression {

--- a/src/types/ELMTypes.ts
+++ b/src/types/ELMTypes.ts
@@ -34,6 +34,9 @@ export interface ELMLibrary {
   codes?: {
     def: ELMCode[];
   };
+  concepts?: {
+    def: ELMConcept[];
+  };
   /** Standard define or define function statements. The actual logic is defined here. */
   statements: {
     /** List of statement definitions. */
@@ -130,6 +133,15 @@ export interface ELMCode {
   };
 }
 
+export interface ELMConcept {
+  name: string;
+  display: string;
+  accessLevel: string;
+  code: {
+    name: string;
+  }[];
+}
+
 /**
  * Abstract ELM Expression.
  */
@@ -198,12 +210,34 @@ export interface ELMReturnClause {
   distinct?: string;
 }
 
+export interface ELMAs extends ELMExpression {
+  type: 'As';
+  asType: string;
+  operand: ELMExpression;
+}
+
 export interface ELMBinaryExpression extends ELMExpression {
   operand: [ELMExpression, ELMExpression];
 }
 
 export interface ELMEqual extends ELMBinaryExpression {
   type: 'Equal';
+}
+
+export interface ELMEquivalent extends ELMBinaryExpression {
+  type: 'Equivalent';
+}
+
+export interface ELMAnd extends ELMBinaryExpression {
+  type: 'And';
+}
+
+export interface ELMOr extends ELMBinaryExpression {
+  type: 'Or';
+}
+
+export interface ELMIncludedIn extends ELMBinaryExpression {
+  type: 'IncludedIn';
 }
 
 interface ELMIExpressionRef extends ELMExpression {
@@ -221,11 +255,20 @@ export interface ELMFunctionRef extends ELMIExpressionRef {
   operand: [ELMExpression];
 }
 
+export interface ELMParameterRef extends ELMIExpressionRef {
+  type: 'ParameterRef';
+}
+
 export interface ELMProperty extends ELMExpression {
   type: 'Property';
   source?: ELMExpression;
   path: string;
   scope?: string;
+}
+
+export interface ELMConceptRef extends ELMExpression {
+  type: 'ConceptRef';
+  name: string;
 }
 
 export interface ELMLiteral extends ELMExpression {

--- a/src/types/ELMTypes.ts
+++ b/src/types/ELMTypes.ts
@@ -220,6 +220,10 @@ export interface ELMBinaryExpression extends ELMExpression {
   operand: [ELMExpression, ELMExpression];
 }
 
+export interface ELMUnaryExpression extends ELMExpression {
+  operand: ELMExpression;
+}
+
 export interface ELMEqual extends ELMBinaryExpression {
   type: 'Equal';
 }
@@ -236,14 +240,12 @@ export interface ELMOr extends ELMBinaryExpression {
   type: 'Or';
 }
 
-export interface ELMNot extends ELMExpression {
+export interface ELMNot extends ELMUnaryExpression {
   type: 'Not';
-  operand: ELMExpression;
 }
 
-export interface ELMIsNull extends ELMExpression {
+export interface ELMIsNull extends ELMUnaryExpression {
   type: 'IsNull';
-  operand: ELMExpression;
 }
 
 export interface ELMIncludedIn extends ELMBinaryExpression {
@@ -252,6 +254,14 @@ export interface ELMIncludedIn extends ELMBinaryExpression {
 
 export interface ELMIn extends ELMBinaryExpression {
   type: 'In';
+}
+
+export interface ELMEnd extends ELMUnaryExpression {
+  type: 'End';
+}
+
+export interface ELMStart extends ELMUnaryExpression {
+  type: 'Start';
 }
 
 interface ELMIExpressionRef extends ELMExpression {

--- a/src/types/QueryFilterTypes.ts
+++ b/src/types/QueryFilterTypes.ts
@@ -1,0 +1,61 @@
+import { R4 } from '@ahryman40k/ts-fhir-types';
+
+export interface Filter {
+  type: string;
+  localId?: string;
+}
+
+export interface AndFilter extends Filter {
+  type: 'and';
+  children: Filter[];
+}
+
+export interface OrFilter extends Filter {
+  type: 'or';
+  children: Filter[];
+}
+
+interface AttributeFilter extends Filter {
+  alias: string;
+  attribute: string;
+}
+
+export interface InFilter extends AttributeFilter {
+  type: 'in';
+  valueCodingList?: R4.ICoding[];
+  valueList?: (string | number)[];
+}
+
+export interface DuringFilter extends AttributeFilter {
+  type: 'during';
+  valuePeriod: {
+    ref?: string;
+    start?: string;
+    end?: string;
+  };
+}
+
+export interface NotNullFilter extends AttributeFilter {
+  type: 'notnull';
+}
+
+export interface EqualsFilter extends AttributeFilter {
+  type: 'equals';
+  value: string | number;
+}
+
+export interface UnknownAttributeFilter extends AttributeFilter {
+  type: 'unknown';
+}
+
+export interface UnknownFilter extends Filter {
+  type: 'unknown';
+}
+
+/**
+ * Represents something that will always be true and can be removed. eg. checking if
+ * the end of the Measurement Period exists.
+ */
+export interface TautologyFilter extends Filter {
+  type: 'truth';
+}

--- a/src/types/QueryFilterTypes.ts
+++ b/src/types/QueryFilterTypes.ts
@@ -12,6 +12,7 @@ export type AnyFilter =
   | EqualsFilter
   | TautologyFilter;
 
+/** Detailed information about a query and the filtering it does. */
 export interface QueryInfo {
   localId?: string;
   sources: SourceInfo[];

--- a/src/types/QueryFilterTypes.ts
+++ b/src/types/QueryFilterTypes.ts
@@ -1,5 +1,30 @@
 import { R4 } from '@ahryman40k/ts-fhir-types';
 
+export type AnyFilter =
+  | Filter
+  | AttributeFilter
+  | AndFilter
+  | OrFilter
+  | UnknownFilter
+  | InFilter
+  | DuringFilter
+  | NotNullFilter
+  | EqualsFilter
+  | TautologyFilter;
+
+export interface QueryInfo {
+  localId?: string;
+  sources: SourceInfo[];
+  filter: AnyFilter;
+}
+
+export interface SourceInfo {
+  retrieveLocalId?: string;
+  sourceLocalId?: string;
+  alias: string;
+  resourceType: string;
+}
+
 export interface Filter {
   type: string;
   localId?: string;
@@ -7,12 +32,12 @@ export interface Filter {
 
 export interface AndFilter extends Filter {
   type: 'and';
-  children: Filter[];
+  children: AnyFilter[];
 }
 
 export interface OrFilter extends Filter {
   type: 'or';
-  children: Filter[];
+  children: AnyFilter[];
 }
 
 interface AttributeFilter extends Filter {
@@ -44,12 +69,10 @@ export interface EqualsFilter extends AttributeFilter {
   value: string | number;
 }
 
-export interface UnknownAttributeFilter extends AttributeFilter {
-  type: 'unknown';
-}
-
 export interface UnknownFilter extends Filter {
   type: 'unknown';
+  alias?: string;
+  attribute?: string;
 }
 
 /**

--- a/src/types/QueryFilterTypes.ts
+++ b/src/types/QueryFilterTypes.ts
@@ -1,5 +1,6 @@
 import { R4 } from '@ahryman40k/ts-fhir-types';
 
+/** Any type of query filter. */
 export type AnyFilter =
   | Filter
   | AttributeFilter
@@ -12,13 +13,18 @@ export type AnyFilter =
   | EqualsFilter
   | TautologyFilter;
 
-/** Detailed information about a query and the filtering it does. */
+/**
+ * Detailed information about a query and the filtering it does.
+ */
 export interface QueryInfo {
   localId?: string;
   sources: SourceInfo[];
   filter: AnyFilter;
 }
 
+/**
+ * Information about a single source in a query.
+ */
 export interface SourceInfo {
   retrieveLocalId?: string;
   sourceLocalId?: string;
@@ -26,32 +32,51 @@ export interface SourceInfo {
   resourceType: string;
 }
 
+/**
+ * Information for that all filters contain.
+ */
 export interface Filter {
   type: string;
   localId?: string;
 }
 
+/**
+ * Represents an `and` filter. Which is a collection of filters that must all be true.
+ */
 export interface AndFilter extends Filter {
   type: 'and';
   children: AnyFilter[];
 }
 
+/**
+ * Represents a `or` filter. Collection of filters where one must be true.
+ */
 export interface OrFilter extends Filter {
   type: 'or';
   children: AnyFilter[];
 }
 
+/**
+ * "Abstract" interface for a filter that checks the value of an attribute of a source resource.
+ */
 interface AttributeFilter extends Filter {
   alias: string;
   attribute: string;
 }
 
+/**
+ * Represents a filter on a value that should be in a list of items. This can either be a list of
+ * FHIR Codings or list of strings or numbers.
+ */
 export interface InFilter extends AttributeFilter {
   type: 'in';
   valueCodingList?: R4.ICoding[];
   valueList?: (string | number)[];
 }
 
+/**
+ * Represents a filter on a time value that should be in a specified time period.
+ */
 export interface DuringFilter extends AttributeFilter {
   type: 'during';
   valuePeriod: {
@@ -61,15 +86,24 @@ export interface DuringFilter extends AttributeFilter {
   };
 }
 
+/**
+ * Represents a filter that checks if a value is not null.
+ */
 export interface NotNullFilter extends AttributeFilter {
   type: 'notnull';
 }
 
+/**
+ * Represents a filter that checks if a value is equal to another value.
+ */
 export interface EqualsFilter extends AttributeFilter {
   type: 'equals';
   value: string | number;
 }
 
+/**
+ * Represents a filter that we were unable to parse.
+ */
 export interface UnknownFilter extends Filter {
   type: 'unknown';
   alias?: string;
@@ -77,7 +111,7 @@ export interface UnknownFilter extends Filter {
 }
 
 /**
- * Represents something that will always be true and can be removed. eg. checking if
+ * Represents a filter that will always be true and can be removed. eg. checking if
  * the end of the Measurement Period exists.
  */
 export interface TautologyFilter extends Filter {

--- a/src/types/QueryFilterTypes.ts
+++ b/src/types/QueryFilterTypes.ts
@@ -80,7 +80,6 @@ export interface InFilter extends AttributeFilter {
 export interface DuringFilter extends AttributeFilter {
   type: 'during';
   valuePeriod: {
-    ref?: string;
     start?: string;
     end?: string;
   };

--- a/test/QueryFilterHelpers.test.ts
+++ b/test/QueryFilterHelpers.test.ts
@@ -58,7 +58,6 @@ const EXPECTED_CODE_AND_STARTS_DURING_MP: QueryInfo = {
         alias: 'C',
         attribute: 'onset',
         valuePeriod: {
-          ref: 'Measurement Period',
           start: '2019-01-01T00:00:00.000Z',
           end: '2019-12-31T23:59:59.999Z'
         },
@@ -99,7 +98,6 @@ const EXPECTED_STATUS_VALUE_EXISTS_DURING_MP: QueryInfo = {
         alias: 'Obs',
         attribute: 'effective',
         valuePeriod: {
-          ref: 'Measurement Period',
           start: '2019-01-01T00:00:00.000Z',
           end: '2019-12-31T23:59:59.999Z'
         },
@@ -127,7 +125,6 @@ const EXPECTED_ENC_TWO_YEAR_BEFORE_END_OF_MP: QueryInfo = {
         alias: 'Enc',
         attribute: 'period.end',
         valuePeriod: {
-          ref: 'Measurement Period',
           start: '2017-12-31T23:59:59.999Z',
           end: '2019-12-31T23:59:59.998Z'
         }

--- a/test/QueryFilterHelpers.test.ts
+++ b/test/QueryFilterHelpers.test.ts
@@ -5,39 +5,130 @@ import { getELMFixture, getJSONFixture } from './helpers/testHelpers';
 import { parseQueryInfo } from '../src/QueryFilterHelpers';
 
 const simpleQueryELM = getELMFixture('elm/queries/SimpleQueries.json');
+const complexQueryELM = getELMFixture('elm/queries/ComplexQueries.json');
 const simpleQueryELMDependency = getELMFixture('elm/queries/SimpleQueriesDependency.json');
 
 const EXPECTED_VS_WITH_ID_CHECK_QUERY = {
   localId: '24',
   sources: [
     {
-      retrievelocalId: '18',
+      retrieveLocalId: '18',
       sourceLocalId: '19',
       alias: 'C',
       resourceType: 'Condition',
-      filters: [
-        {
-          attribute: 'id',
-          value: 'test',
-          localId: '23'
-        }
-      ]
+      filters: {
+        type: 'equals',
+        alias: 'C',
+        attribute: 'id',
+        value: 'test',
+        localId: '23'
+      }
+    }
+  ]
+};
+
+const EXPECTED_CODE_AND_STARTS_DURING_MP = {
+  localId: '42',
+  sources: [
+    {
+      retrieveLocalId: '31',
+      sourceLocalId: '32',
+      alias: 'C',
+      resourceType: 'Condition',
+      filters: {
+        type: 'and',
+        children: [
+          {
+            type: 'in',
+            alias: 'C',
+            attribute: 'clinicalStatus',
+            valueList: [
+              { code: 'active', system: 'http://terminology.hl7.org/CodeSystem/condition-clinical' },
+              { code: 'recurrence', system: 'http://terminology.hl7.org/CodeSystem/condition-clinical' },
+              { code: 'relapse', system: 'http://terminology.hl7.org/CodeSystem/condition-clinical' }
+            ],
+            localId: '36'
+          },
+          {
+            type: 'during',
+            alias: 'C',
+            attribute: 'onset',
+            valuePeriod: {
+              ref: 'Measurement Period'
+            },
+            localId: '40'
+          }
+        ]
+      }
+    }
+  ]
+};
+
+const EXPECTED_STATUS_VALUE_EXISTS_DURING_MP = {
+  localId: '65',
+  sources: [
+    {
+      retrieveLocalId: '44',
+      sourceLocalId: '45',
+      alias: 'Obs',
+      resourceType: 'Observation',
+      filters: {
+        type: 'and',
+        children: [
+          {
+            type: 'in',
+            alias: 'Obs',
+            attribute: 'status',
+            valueList: ['final', 'amended', 'corrected', 'preliminary'],
+            localId: '53'
+          },
+          {
+            type: 'during',
+            alias: 'Obs',
+            attribute: 'effective',
+            valuePeriod: {
+              ref: 'Measurement Period'
+            },
+            localId: '63'
+          },
+          {
+            type: 'notnull',
+            alias: 'Obs',
+            attribute: 'value',
+            localId: '56'
+          }
+        ]
+      }
     }
   ]
 };
 
 describe('Parse Query Info', () => {
-  test('simple valueset lookup', () => {
-    const valueSetExpr = simpleQueryELM.library.statements.def[0].expression; // expression for valueset lookup
-  });
-
-  test('simple code lookup', () => {
-    const codeExpr = simpleQueryELM.library.statements.def[1].expression; // expression for code lookup
-  });
-
   test('simple valueset with id check', () => {
     const queryLocalId = simpleQueryELM.library.statements.def[2].expression.localId; // expression with aliased query
     const queryInfo = parseQueryInfo(simpleQueryELM, queryLocalId);
     expect(queryInfo).toEqual(EXPECTED_VS_WITH_ID_CHECK_QUERY);
+  });
+
+  test('complex - valueset with code AND interval check', () => {
+    const statement = complexQueryELM.library.statements.def.find(def => def.name == 'Code And Starts During MP');
+    if (!statement) {
+      fail('Could not find statement.');
+    }
+    const queryLocalId = statement.expression.localId;
+    const queryInfo = parseQueryInfo(complexQueryELM, queryLocalId);
+    expect(queryInfo).toEqual(EXPECTED_CODE_AND_STARTS_DURING_MP);
+  });
+
+  test('complex - valueset with status AND value exists AND interval check', () => {
+    const statement = complexQueryELM.library.statements.def.find(
+      def => def.name == 'Observation Status Value Exists and During MP'
+    );
+    if (!statement) {
+      fail('Could not find statement.');
+    }
+    const queryLocalId = statement.expression.localId;
+    const queryInfo = parseQueryInfo(complexQueryELM, queryLocalId);
+    expect(queryInfo).toEqual(EXPECTED_STATUS_VALUE_EXISTS_DURING_MP);
   });
 });

--- a/test/QueryFilterHelpers.test.ts
+++ b/test/QueryFilterHelpers.test.ts
@@ -103,6 +103,31 @@ const EXPECTED_STATUS_VALUE_EXISTS_DURING_MP = {
   ]
 };
 
+const EXPECTED_ENC_TWO_YEAR_BEFORE_END_OF_MP = {
+  localId: '77',
+  sources: [
+    {
+      retrieveLocalId: '67',
+      sourceLocalId: '68',
+      alias: 'Enc',
+      resourceType: 'Encounter',
+      filters: {
+        type: 'and',
+        children: [
+          {
+            type: 'during',
+            alias: 'Enc',
+            attribute: 'period',
+            valuePeriod: {
+              ref: 'Measurement Period'
+            }
+          }
+        ]
+      }
+    }
+  ]
+};
+
 describe('Parse Query Info', () => {
   test('simple valueset with id check', () => {
     const queryLocalId = simpleQueryELM.library.statements.def[2].expression.localId; // expression with aliased query
@@ -130,5 +155,17 @@ describe('Parse Query Info', () => {
     const queryLocalId = statement.expression.localId;
     const queryInfo = parseQueryInfo(complexQueryELM, queryLocalId);
     expect(queryInfo).toEqual(EXPECTED_STATUS_VALUE_EXISTS_DURING_MP);
+  });
+
+  test('complex - valueset with period two years before end of MP', () => {
+    const statement = complexQueryELM.library.statements.def.find(
+      def => def.name == 'Encounter 2 Years Before End of MP'
+    );
+    if (!statement) {
+      fail('Could not find statement.');
+    }
+    const queryLocalId = statement.expression.localId;
+    const queryInfo = parseQueryInfo(complexQueryELM, queryLocalId);
+    expect(queryInfo).toEqual(EXPECTED_ENC_TWO_YEAR_BEFORE_END_OF_MP);
   });
 });

--- a/test/QueryFilterHelpers.test.ts
+++ b/test/QueryFilterHelpers.test.ts
@@ -5,7 +5,6 @@ import { QueryInfo } from '../src/types/QueryFilterTypes';
 
 const simpleQueryELM = getELMFixture('elm/queries/SimpleQueries.json');
 const complexQueryELM = getELMFixture('elm/queries/ComplexQueries.json');
-const simpleQueryELMDependency = getELMFixture('elm/queries/SimpleQueriesDependency.json');
 
 const START_MP = cql.DateTime.fromJSDate(new Date('2019-01-01T00:00:00Z'), 0);
 const END_MP = cql.DateTime.fromJSDate(new Date('2020-01-01T00:00:00Z'), 0);
@@ -59,7 +58,9 @@ const EXPECTED_CODE_AND_STARTS_DURING_MP: QueryInfo = {
         alias: 'C',
         attribute: 'onset',
         valuePeriod: {
-          ref: 'Measurement Period'
+          ref: 'Measurement Period',
+          start: '2019-01-01T00:00:00.000Z',
+          end: '2019-12-31T23:59:59.999Z'
         },
         localId: '40'
       }
@@ -128,7 +129,7 @@ const EXPECTED_ENC_TWO_YEAR_BEFORE_END_OF_MP: QueryInfo = {
         valuePeriod: {
           ref: 'Measurement Period',
           start: '2017-12-31T23:59:59.999Z',
-          end: '2019-12-31T23:59:59.999Z'
+          end: '2019-12-31T23:59:59.998Z'
         }
       }
     ]

--- a/test/QueryFilterHelpers.test.ts
+++ b/test/QueryFilterHelpers.test.ts
@@ -1,9 +1,7 @@
-import { R4 } from '@ahryman40k/ts-fhir-types';
-import { DataTypeQuery, DetailedPopulationGroupResult } from '../src/types/Calculator';
-import { FinalResult } from '../src/types/Enums';
-import { getELMFixture, getJSONFixture } from './helpers/testHelpers';
+import { getELMFixture } from './helpers/testHelpers';
 import { parseQueryInfo } from '../src/QueryFilterHelpers';
 import * as cql from 'cql-execution';
+import { QueryInfo } from '../src/types/QueryFilterTypes';
 
 const simpleQueryELM = getELMFixture('elm/queries/SimpleQueries.json');
 const complexQueryELM = getELMFixture('elm/queries/ComplexQueries.json');
@@ -13,128 +11,128 @@ const START_MP = cql.DateTime.fromJSDate(new Date('2019-01-01T00:00:00Z'), 0);
 const END_MP = cql.DateTime.fromJSDate(new Date('2020-01-01T00:00:00Z'), 0);
 const PARAMETERS = { 'Measurement Period': new cql.Interval(START_MP, END_MP, true, false) };
 
-const EXPECTED_VS_WITH_ID_CHECK_QUERY = {
+const EXPECTED_VS_WITH_ID_CHECK_QUERY: QueryInfo = {
   localId: '24',
   sources: [
     {
       retrieveLocalId: '18',
       sourceLocalId: '19',
       alias: 'C',
-      resourceType: 'Condition',
-      filters: {
-        type: 'equals',
-        alias: 'C',
-        attribute: 'id',
-        value: 'test',
-        localId: '23'
-      }
+      resourceType: 'Condition'
     }
-  ]
+  ],
+  filter: {
+    type: 'equals',
+    alias: 'C',
+    attribute: 'id',
+    value: 'test',
+    localId: '23'
+  }
 };
 
-const EXPECTED_CODE_AND_STARTS_DURING_MP = {
+const EXPECTED_CODE_AND_STARTS_DURING_MP: QueryInfo = {
   localId: '42',
   sources: [
     {
       retrieveLocalId: '31',
       sourceLocalId: '32',
       alias: 'C',
-      resourceType: 'Condition',
-      filters: {
-        type: 'and',
-        children: [
-          {
-            type: 'in',
-            alias: 'C',
-            attribute: 'clinicalStatus',
-            valueCodingList: [
-              { code: 'active', system: 'http://terminology.hl7.org/CodeSystem/condition-clinical' },
-              { code: 'recurrence', system: 'http://terminology.hl7.org/CodeSystem/condition-clinical' },
-              { code: 'relapse', system: 'http://terminology.hl7.org/CodeSystem/condition-clinical' }
-            ],
-            localId: '36'
-          },
-          {
-            type: 'during',
-            alias: 'C',
-            attribute: 'onset',
-            valuePeriod: {
-              ref: 'Measurement Period'
-            },
-            localId: '40'
-          }
-        ]
-      }
+      resourceType: 'Condition'
     }
-  ]
+  ],
+  filter: {
+    type: 'and',
+    children: [
+      {
+        type: 'in',
+        alias: 'C',
+        attribute: 'clinicalStatus',
+        valueCodingList: [
+          { code: 'active', system: 'http://terminology.hl7.org/CodeSystem/condition-clinical' },
+          { code: 'recurrence', system: 'http://terminology.hl7.org/CodeSystem/condition-clinical' },
+          { code: 'relapse', system: 'http://terminology.hl7.org/CodeSystem/condition-clinical' }
+        ],
+        localId: '36'
+      },
+      {
+        type: 'during',
+        alias: 'C',
+        attribute: 'onset',
+        valuePeriod: {
+          ref: 'Measurement Period'
+        },
+        localId: '40'
+      }
+    ]
+  }
 };
 
-const EXPECTED_STATUS_VALUE_EXISTS_DURING_MP = {
+const EXPECTED_STATUS_VALUE_EXISTS_DURING_MP: QueryInfo = {
   localId: '65',
   sources: [
     {
       retrieveLocalId: '44',
       sourceLocalId: '45',
       alias: 'Obs',
-      resourceType: 'Observation',
-      filters: {
-        type: 'and',
-        children: [
-          {
-            type: 'in',
-            alias: 'Obs',
-            attribute: 'status',
-            valueList: ['final', 'amended', 'corrected', 'preliminary'],
-            localId: '53'
-          },
-          {
-            type: 'notnull',
-            alias: 'Obs',
-            attribute: 'value',
-            localId: '56'
-          },
-          {
-            type: 'during',
-            alias: 'Obs',
-            attribute: 'effective',
-            valuePeriod: {
-              ref: 'Measurement Period',
-              start: '2019-01-01T00:00:00.000Z',
-              end: '2019-12-31T23:59:59.999Z'
-            },
-            localId: '63'
-          }
-        ]
-      }
+      resourceType: 'Observation'
     }
-  ]
+  ],
+  filter: {
+    type: 'and',
+    children: [
+      {
+        type: 'in',
+        alias: 'Obs',
+        attribute: 'status',
+        valueList: ['final', 'amended', 'corrected', 'preliminary'],
+        localId: '53'
+      },
+      {
+        type: 'notnull',
+        alias: 'Obs',
+        attribute: 'value',
+        localId: '56'
+      },
+      {
+        type: 'during',
+        alias: 'Obs',
+        attribute: 'effective',
+        valuePeriod: {
+          ref: 'Measurement Period',
+          start: '2019-01-01T00:00:00.000Z',
+          end: '2019-12-31T23:59:59.999Z'
+        },
+        localId: '63'
+      }
+    ]
+  }
 };
 
-const EXPECTED_ENC_TWO_YEAR_BEFORE_END_OF_MP = {
+const EXPECTED_ENC_TWO_YEAR_BEFORE_END_OF_MP: QueryInfo = {
   localId: '77',
   sources: [
     {
       retrieveLocalId: '67',
       sourceLocalId: '68',
       alias: 'Enc',
-      resourceType: 'Encounter',
-      filters: {
-        type: 'and',
-        children: [
-          {
-            type: 'during',
-            alias: 'Enc',
-            attribute: 'period.end',
-            valuePeriod: {
-              ref: 'Measurement Period',
-              start: '2017-12-31T23:59:59.999Z',
-              end: '2019-12-31T23:59:59.999Z'
-            }
-          }
-        ]
-      }
+      resourceType: 'Encounter'
     }
-  ]
+  ],
+  filter: {
+    type: 'and',
+    children: [
+      {
+        type: 'during',
+        alias: 'Enc',
+        attribute: 'period.end',
+        valuePeriod: {
+          ref: 'Measurement Period',
+          start: '2017-12-31T23:59:59.999Z',
+          end: '2019-12-31T23:59:59.999Z'
+        }
+      }
+    ]
+  }
 };
 
 describe('Parse Query Info', () => {

--- a/test/QueryFilterHelpers.test.ts
+++ b/test/QueryFilterHelpers.test.ts
@@ -83,6 +83,12 @@ const EXPECTED_STATUS_VALUE_EXISTS_DURING_MP = {
             localId: '53'
           },
           {
+            type: 'notnull',
+            alias: 'Obs',
+            attribute: 'value',
+            localId: '56'
+          },
+          {
             type: 'during',
             alias: 'Obs',
             attribute: 'effective',
@@ -90,12 +96,6 @@ const EXPECTED_STATUS_VALUE_EXISTS_DURING_MP = {
               ref: 'Measurement Period'
             },
             localId: '63'
-          },
-          {
-            type: 'notnull',
-            alias: 'Obs',
-            attribute: 'value',
-            localId: '56'
           }
         ]
       }

--- a/test/QueryFilterHelpers.test.ts
+++ b/test/QueryFilterHelpers.test.ts
@@ -1,0 +1,43 @@
+import { R4 } from '@ahryman40k/ts-fhir-types';
+import { DataTypeQuery, DetailedPopulationGroupResult } from '../src/types/Calculator';
+import { FinalResult } from '../src/types/Enums';
+import { getELMFixture, getJSONFixture } from './helpers/testHelpers';
+import { parseQueryInfo } from '../src/QueryFilterHelpers';
+
+const simpleQueryELM = getELMFixture('elm/queries/SimpleQueries.json');
+const simpleQueryELMDependency = getELMFixture('elm/queries/SimpleQueriesDependency.json');
+
+const EXPECTED_VS_WITH_ID_CHECK_QUERY = {
+  localId: '24',
+  sources: [
+    {
+      retrievelocalId: '18',
+      sourceLocalId: '19',
+      alias: 'C',
+      resourceType: 'Condition',
+      filters: [
+        {
+          attribute: 'id',
+          value: 'test',
+          localId: '23'
+        }
+      ]
+    }
+  ]
+};
+
+describe('Parse Query Info', () => {
+  test('simple valueset lookup', () => {
+    const valueSetExpr = simpleQueryELM.library.statements.def[0].expression; // expression for valueset lookup
+  });
+
+  test('simple code lookup', () => {
+    const codeExpr = simpleQueryELM.library.statements.def[1].expression; // expression for code lookup
+  });
+
+  test('simple valueset with id check', () => {
+    const queryLocalId = simpleQueryELM.library.statements.def[2].expression.localId; // expression with aliased query
+    const queryInfo = parseQueryInfo(simpleQueryELM, queryLocalId);
+    expect(queryInfo).toEqual(EXPECTED_VS_WITH_ID_CHECK_QUERY);
+  });
+});

--- a/test/fixtures/elm/queries/ComplexQueries.cql
+++ b/test/fixtures/elm/queries/ComplexQueries.cql
@@ -37,3 +37,7 @@ define "Observation Status Value Exists and During MP":
     where Obs.status in {'final', 'amended', 'corrected', 'preliminary'}
       and Obs.value is not null
       and Global."Normalize Interval"(Obs.effective) during "Measurement Period"
+
+define "Encounter 2 Years Before End of MP":
+  [Encounter: "test-vs"] Enc
+    where Global."Normalize Interval"(Enc.period) ends 2 years or less before end of "Measurement Period"

--- a/test/fixtures/elm/queries/ComplexQueries.cql
+++ b/test/fixtures/elm/queries/ComplexQueries.cql
@@ -1,0 +1,39 @@
+library ComplexQueries version '0.0.1'
+
+using FHIR version '4.0.1'
+
+include FHIRHelpers version '4.0.1'
+include MATGlobalCommonFunctions version '5.0.000' called Global
+
+codesystem "EXAMPLE": 'http://example.com'
+codesystem "EXAMPLE-2": 'http://example.com/2'
+codesystem "ConditionClinicalStatusCodes": 'http://terminology.hl7.org/CodeSystem/condition-clinical'
+
+valueset "test-vs": 'http://example.com/test-vs'
+
+code "test-code": 'test' from "EXAMPLE"
+code "test-code-2": 'test-2' from "EXAMPLE-2"
+
+code "Active": 'active' from "ConditionClinicalStatusCodes"
+code "Recurrence": 'recurrence' from "ConditionClinicalStatusCodes"
+code "Relapse": 'relapse' from "ConditionClinicalStatusCodes"
+
+concept "test-concept": { "test-code", "test-code-2" } display 'test-concept'
+
+concept "Condition Active": { "Active", "Recurrence", "Relapse" } display 'Active'
+
+parameter "Measurement Period" Interval<DateTime>
+  default Interval[@2019-01-01T00:00:00.0, @2020-01-01T00:00:00.0)
+
+context Patient
+
+define "Code And Starts During MP":
+  [Condition: "test-vs"] C
+    where C.clinicalStatus ~ "Condition Active"
+      and C.onset during "Measurement Period"
+
+define "Observation Status Value Exists and During MP":
+  [Observation: "test-vs"] Obs
+    where Obs.status in {'final', 'amended', 'corrected', 'preliminary'}
+      and Obs.value is not null
+      and Global."Normalize Interval"(Obs.effective) during "Measurement Period"

--- a/test/fixtures/elm/queries/ComplexQueries.json
+++ b/test/fixtures/elm/queries/ComplexQueries.json
@@ -1,0 +1,769 @@
+{
+   "library" : {
+      "annotation" : [ {
+         "translatorOptions" : "EnableAnnotations,EnableLocators",
+         "type" : "CqlToElmInfo"
+      }, {
+         "libraryId" : "MATGlobalCommonFunctions",
+         "libraryVersion" : "5.0.000",
+         "startLine" : 277,
+         "startChar" : 19,
+         "endLine" : 277,
+         "endChar" : 53,
+         "message" : "Could not resolve membership operator for terminology target of the retrieve.",
+         "errorType" : "semantic",
+         "errorSeverity" : "warning",
+         "type" : "CqlToElmError"
+      } ],
+      "identifier" : {
+         "id" : "ComplexQueries",
+         "version" : "0.0.1"
+      },
+      "schemaIdentifier" : {
+         "id" : "urn:hl7-org:elm",
+         "version" : "r1"
+      },
+      "usings" : {
+         "def" : [ {
+            "localIdentifier" : "System",
+            "uri" : "urn:hl7-org:elm-types:r1"
+         }, {
+            "localId" : "1",
+            "locator" : "3:1-3:26",
+            "localIdentifier" : "FHIR",
+            "uri" : "http://hl7.org/fhir",
+            "version" : "4.0.1"
+         } ]
+      },
+      "includes" : {
+         "def" : [ {
+            "localId" : "2",
+            "locator" : "5:1-5:35",
+            "localIdentifier" : "FHIRHelpers",
+            "path" : "FHIRHelpers",
+            "version" : "4.0.1"
+         }, {
+            "localId" : "3",
+            "locator" : "6:1-6:64",
+            "localIdentifier" : "Global",
+            "path" : "MATGlobalCommonFunctions",
+            "version" : "5.0.000"
+         } ]
+      },
+      "parameters" : {
+         "def" : [ {
+            "localId" : "30",
+            "locator" : "25:1-26:66",
+            "name" : "Measurement Period",
+            "accessLevel" : "Public",
+            "default" : {
+               "localId" : "27",
+               "locator" : "26:11-26:66",
+               "lowClosed" : true,
+               "highClosed" : false,
+               "type" : "Interval",
+               "low" : {
+                  "localId" : "25",
+                  "locator" : "26:20-26:41",
+                  "type" : "DateTime",
+                  "year" : {
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "2019",
+                     "type" : "Literal"
+                  },
+                  "month" : {
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "1",
+                     "type" : "Literal"
+                  },
+                  "day" : {
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "1",
+                     "type" : "Literal"
+                  },
+                  "hour" : {
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "0",
+                     "type" : "Literal"
+                  },
+                  "minute" : {
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "0",
+                     "type" : "Literal"
+                  },
+                  "second" : {
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "0",
+                     "type" : "Literal"
+                  },
+                  "millisecond" : {
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "0",
+                     "type" : "Literal"
+                  }
+               },
+               "high" : {
+                  "localId" : "26",
+                  "locator" : "26:44-26:65",
+                  "type" : "DateTime",
+                  "year" : {
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "2020",
+                     "type" : "Literal"
+                  },
+                  "month" : {
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "1",
+                     "type" : "Literal"
+                  },
+                  "day" : {
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "1",
+                     "type" : "Literal"
+                  },
+                  "hour" : {
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "0",
+                     "type" : "Literal"
+                  },
+                  "minute" : {
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "0",
+                     "type" : "Literal"
+                  },
+                  "second" : {
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "0",
+                     "type" : "Literal"
+                  },
+                  "millisecond" : {
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "0",
+                     "type" : "Literal"
+                  }
+               }
+            },
+            "parameterTypeSpecifier" : {
+               "localId" : "29",
+               "locator" : "25:32-25:49",
+               "type" : "IntervalTypeSpecifier",
+               "pointType" : {
+                  "localId" : "28",
+                  "locator" : "25:41-25:48",
+                  "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }
+         } ]
+      },
+      "codeSystems" : {
+         "def" : [ {
+            "localId" : "4",
+            "locator" : "8:1-8:42",
+            "name" : "EXAMPLE",
+            "id" : "http://example.com",
+            "accessLevel" : "Public"
+         }, {
+            "localId" : "5",
+            "locator" : "9:1-9:46",
+            "name" : "EXAMPLE-2",
+            "id" : "http://example.com/2",
+            "accessLevel" : "Public"
+         }, {
+            "localId" : "6",
+            "locator" : "10:1-10:101",
+            "name" : "ConditionClinicalStatusCodes",
+            "id" : "http://terminology.hl7.org/CodeSystem/condition-clinical",
+            "accessLevel" : "Public"
+         } ]
+      },
+      "valueSets" : {
+         "def" : [ {
+            "localId" : "7",
+            "locator" : "12:1-12:48",
+            "name" : "test-vs",
+            "id" : "http://example.com/test-vs",
+            "accessLevel" : "Public"
+         } ]
+      },
+      "codes" : {
+         "def" : [ {
+            "localId" : "9",
+            "locator" : "14:1-14:39",
+            "name" : "test-code",
+            "id" : "test",
+            "accessLevel" : "Public",
+            "codeSystem" : {
+               "localId" : "8",
+               "locator" : "14:31-14:39",
+               "name" : "EXAMPLE"
+            }
+         }, {
+            "localId" : "11",
+            "locator" : "15:1-15:45",
+            "name" : "test-code-2",
+            "id" : "test-2",
+            "accessLevel" : "Public",
+            "codeSystem" : {
+               "localId" : "10",
+               "locator" : "15:35-15:45",
+               "name" : "EXAMPLE-2"
+            }
+         }, {
+            "localId" : "13",
+            "locator" : "17:1-17:59",
+            "name" : "Active",
+            "id" : "active",
+            "accessLevel" : "Public",
+            "codeSystem" : {
+               "localId" : "12",
+               "locator" : "17:30-17:59",
+               "name" : "ConditionClinicalStatusCodes"
+            }
+         }, {
+            "localId" : "15",
+            "locator" : "18:1-18:67",
+            "name" : "Recurrence",
+            "id" : "recurrence",
+            "accessLevel" : "Public",
+            "codeSystem" : {
+               "localId" : "14",
+               "locator" : "18:38-18:67",
+               "name" : "ConditionClinicalStatusCodes"
+            }
+         }, {
+            "localId" : "17",
+            "locator" : "19:1-19:61",
+            "name" : "Relapse",
+            "id" : "relapse",
+            "accessLevel" : "Public",
+            "codeSystem" : {
+               "localId" : "16",
+               "locator" : "19:32-19:61",
+               "name" : "ConditionClinicalStatusCodes"
+            }
+         } ]
+      },
+      "concepts" : {
+         "def" : [ {
+            "localId" : "20",
+            "locator" : "21:1-21:77",
+            "name" : "test-concept",
+            "display" : "test-concept",
+            "accessLevel" : "Public",
+            "code" : [ {
+               "localId" : "18",
+               "locator" : "21:27-21:37",
+               "name" : "test-code"
+            }, {
+               "localId" : "19",
+               "locator" : "21:40-21:52",
+               "name" : "test-code-2"
+            } ]
+         }, {
+            "localId" : "24",
+            "locator" : "23:1-23:82",
+            "name" : "Condition Active",
+            "display" : "Active",
+            "accessLevel" : "Public",
+            "code" : [ {
+               "localId" : "21",
+               "locator" : "23:31-23:38",
+               "name" : "Active"
+            }, {
+               "localId" : "22",
+               "locator" : "23:41-23:52",
+               "name" : "Recurrence"
+            }, {
+               "localId" : "23",
+               "locator" : "23:55-23:63",
+               "name" : "Relapse"
+            } ]
+         } ]
+      },
+      "statements" : {
+         "def" : [ {
+            "locator" : "28:1-28:15",
+            "name" : "Patient",
+            "context" : "Patient",
+            "expression" : {
+               "type" : "SingletonFrom",
+               "operand" : {
+                  "locator" : "28:1-28:15",
+                  "dataType" : "{http://hl7.org/fhir}Patient",
+                  "templateId" : "http://hl7.org/fhir/StructureDefinition/Patient",
+                  "type" : "Retrieve"
+               }
+            }
+         }, {
+            "localId" : "43",
+            "locator" : "30:1-33:45",
+            "name" : "Code And Starts During MP",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "43",
+                  "s" : [ {
+                     "value" : [ "define ","\"Code And Starts During MP\"",":\n  " ]
+                  }, {
+                     "r" : "42",
+                     "s" : [ {
+                        "s" : [ {
+                           "r" : "32",
+                           "s" : [ {
+                              "r" : "31",
+                              "s" : [ {
+                                 "r" : "31",
+                                 "s" : [ {
+                                    "value" : [ "[","Condition",": " ]
+                                 }, {
+                                    "s" : [ {
+                                       "value" : [ "\"test-vs\"" ]
+                                    } ]
+                                 }, {
+                                    "value" : [ "]" ]
+                                 } ]
+                              } ]
+                           }, {
+                              "value" : [ " ","C" ]
+                           } ]
+                        } ]
+                     }, {
+                        "value" : [ "\n    " ]
+                     }, {
+                        "r" : "41",
+                        "s" : [ {
+                           "value" : [ "where " ]
+                        }, {
+                           "r" : "41",
+                           "s" : [ {
+                              "r" : "36",
+                              "s" : [ {
+                                 "r" : "34",
+                                 "s" : [ {
+                                    "r" : "33",
+                                    "s" : [ {
+                                       "value" : [ "C" ]
+                                    } ]
+                                 }, {
+                                    "value" : [ "." ]
+                                 }, {
+                                    "r" : "34",
+                                    "s" : [ {
+                                       "value" : [ "clinicalStatus" ]
+                                    } ]
+                                 } ]
+                              }, {
+                                 "value" : [ " ","~"," " ]
+                              }, {
+                                 "r" : "35",
+                                 "s" : [ {
+                                    "value" : [ "\"Condition Active\"" ]
+                                 } ]
+                              } ]
+                           }, {
+                              "value" : [ "\n      and " ]
+                           }, {
+                              "r" : "40",
+                              "s" : [ {
+                                 "r" : "38",
+                                 "s" : [ {
+                                    "r" : "37",
+                                    "s" : [ {
+                                       "value" : [ "C" ]
+                                    } ]
+                                 }, {
+                                    "value" : [ "." ]
+                                 }, {
+                                    "r" : "38",
+                                    "s" : [ {
+                                       "value" : [ "onset" ]
+                                    } ]
+                                 } ]
+                              }, {
+                                 "r" : "40",
+                                 "value" : [ " ","during"," " ]
+                              }, {
+                                 "r" : "39",
+                                 "s" : [ {
+                                    "value" : [ "\"Measurement Period\"" ]
+                                 } ]
+                              } ]
+                           } ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "42",
+               "locator" : "31:3-33:45",
+               "type" : "Query",
+               "source" : [ {
+                  "localId" : "32",
+                  "locator" : "31:3-31:26",
+                  "alias" : "C",
+                  "expression" : {
+                     "localId" : "31",
+                     "locator" : "31:3-31:24",
+                     "dataType" : "{http://hl7.org/fhir}Condition",
+                     "templateId" : "http://hl7.org/fhir/StructureDefinition/Condition",
+                     "codeProperty" : "code",
+                     "type" : "Retrieve",
+                     "codes" : {
+                        "locator" : "31:15-31:23",
+                        "name" : "test-vs",
+                        "type" : "ValueSetRef"
+                     }
+                  }
+               } ],
+               "relationship" : [ ],
+               "where" : {
+                  "localId" : "41",
+                  "locator" : "32:5-33:45",
+                  "type" : "And",
+                  "operand" : [ {
+                     "localId" : "36",
+                     "locator" : "32:11-32:47",
+                     "type" : "Equivalent",
+                     "operand" : [ {
+                        "name" : "ToConcept",
+                        "libraryName" : "FHIRHelpers",
+                        "type" : "FunctionRef",
+                        "operand" : [ {
+                           "localId" : "34",
+                           "locator" : "32:11-32:26",
+                           "path" : "clinicalStatus",
+                           "scope" : "C",
+                           "type" : "Property"
+                        } ]
+                     }, {
+                        "localId" : "35",
+                        "locator" : "32:30-32:47",
+                        "name" : "Condition Active",
+                        "type" : "ConceptRef"
+                     } ]
+                  }, {
+                     "localId" : "40",
+                     "locator" : "33:11-33:45",
+                     "type" : "IncludedIn",
+                     "operand" : [ {
+                        "name" : "ToInterval",
+                        "libraryName" : "FHIRHelpers",
+                        "type" : "FunctionRef",
+                        "operand" : [ {
+                           "asType" : "{http://hl7.org/fhir}Period",
+                           "type" : "As",
+                           "operand" : {
+                              "localId" : "38",
+                              "locator" : "33:11-33:17",
+                              "path" : "onset",
+                              "scope" : "C",
+                              "type" : "Property"
+                           }
+                        } ]
+                     }, {
+                        "localId" : "39",
+                        "locator" : "33:26-33:45",
+                        "name" : "Measurement Period",
+                        "type" : "ParameterRef"
+                     } ]
+                  } ]
+               }
+            }
+         }, {
+            "localId" : "66",
+            "locator" : "35:1-39:80",
+            "name" : "Observation Status Value Exists and During MP",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "66",
+                  "s" : [ {
+                     "value" : [ "define ","\"Observation Status Value Exists and During MP\"",":\n  " ]
+                  }, {
+                     "r" : "65",
+                     "s" : [ {
+                        "s" : [ {
+                           "r" : "45",
+                           "s" : [ {
+                              "r" : "44",
+                              "s" : [ {
+                                 "r" : "44",
+                                 "s" : [ {
+                                    "value" : [ "[","Observation",": " ]
+                                 }, {
+                                    "s" : [ {
+                                       "value" : [ "\"test-vs\"" ]
+                                    } ]
+                                 }, {
+                                    "value" : [ "]" ]
+                                 } ]
+                              } ]
+                           }, {
+                              "value" : [ " ","Obs" ]
+                           } ]
+                        } ]
+                     }, {
+                        "value" : [ "\n    " ]
+                     }, {
+                        "r" : "64",
+                        "s" : [ {
+                           "value" : [ "where " ]
+                        }, {
+                           "r" : "64",
+                           "s" : [ {
+                              "r" : "57",
+                              "s" : [ {
+                                 "r" : "53",
+                                 "s" : [ {
+                                    "r" : "47",
+                                    "s" : [ {
+                                       "r" : "46",
+                                       "s" : [ {
+                                          "value" : [ "Obs" ]
+                                       } ]
+                                    }, {
+                                       "value" : [ "." ]
+                                    }, {
+                                       "r" : "47",
+                                       "s" : [ {
+                                          "value" : [ "status" ]
+                                       } ]
+                                    } ]
+                                 }, {
+                                    "value" : [ " in " ]
+                                 }, {
+                                    "r" : "52",
+                                    "s" : [ {
+                                       "value" : [ "{" ]
+                                    }, {
+                                       "r" : "48",
+                                       "s" : [ {
+                                          "value" : [ "'final'" ]
+                                       } ]
+                                    }, {
+                                       "value" : [ ", " ]
+                                    }, {
+                                       "r" : "49",
+                                       "s" : [ {
+                                          "value" : [ "'amended'" ]
+                                       } ]
+                                    }, {
+                                       "value" : [ ", " ]
+                                    }, {
+                                       "r" : "50",
+                                       "s" : [ {
+                                          "value" : [ "'corrected'" ]
+                                       } ]
+                                    }, {
+                                       "value" : [ ", " ]
+                                    }, {
+                                       "r" : "51",
+                                       "s" : [ {
+                                          "value" : [ "'preliminary'" ]
+                                       } ]
+                                    }, {
+                                       "value" : [ "}" ]
+                                    } ]
+                                 } ]
+                              }, {
+                                 "value" : [ "\n      and " ]
+                              }, {
+                                 "r" : "56",
+                                 "s" : [ {
+                                    "r" : "55",
+                                    "s" : [ {
+                                       "r" : "54",
+                                       "s" : [ {
+                                          "value" : [ "Obs" ]
+                                       } ]
+                                    }, {
+                                       "value" : [ "." ]
+                                    }, {
+                                       "r" : "55",
+                                       "s" : [ {
+                                          "value" : [ "value" ]
+                                       } ]
+                                    } ]
+                                 }, {
+                                    "value" : [ " is not null" ]
+                                 } ]
+                              } ]
+                           }, {
+                              "value" : [ "\n      and " ]
+                           }, {
+                              "r" : "63",
+                              "s" : [ {
+                                 "r" : "61",
+                                 "s" : [ {
+                                    "r" : "58",
+                                    "s" : [ {
+                                       "value" : [ "Global" ]
+                                    } ]
+                                 }, {
+                                    "value" : [ "." ]
+                                 }, {
+                                    "r" : "61",
+                                    "s" : [ {
+                                       "value" : [ "\"Normalize Interval\"","(" ]
+                                    }, {
+                                       "r" : "60",
+                                       "s" : [ {
+                                          "r" : "59",
+                                          "s" : [ {
+                                             "value" : [ "Obs" ]
+                                          } ]
+                                       }, {
+                                          "value" : [ "." ]
+                                       }, {
+                                          "r" : "60",
+                                          "s" : [ {
+                                             "value" : [ "effective" ]
+                                          } ]
+                                       } ]
+                                    }, {
+                                       "value" : [ ")" ]
+                                    } ]
+                                 } ]
+                              }, {
+                                 "r" : "63",
+                                 "value" : [ " ","during"," " ]
+                              }, {
+                                 "r" : "62",
+                                 "s" : [ {
+                                    "value" : [ "\"Measurement Period\"" ]
+                                 } ]
+                              } ]
+                           } ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "65",
+               "locator" : "36:3-39:80",
+               "type" : "Query",
+               "source" : [ {
+                  "localId" : "45",
+                  "locator" : "36:3-36:30",
+                  "alias" : "Obs",
+                  "expression" : {
+                     "localId" : "44",
+                     "locator" : "36:3-36:26",
+                     "dataType" : "{http://hl7.org/fhir}Observation",
+                     "templateId" : "http://hl7.org/fhir/StructureDefinition/Observation",
+                     "codeProperty" : "code",
+                     "type" : "Retrieve",
+                     "codes" : {
+                        "locator" : "36:17-36:25",
+                        "name" : "test-vs",
+                        "type" : "ValueSetRef"
+                     }
+                  }
+               } ],
+               "relationship" : [ ],
+               "where" : {
+                  "localId" : "64",
+                  "locator" : "37:5-39:80",
+                  "type" : "And",
+                  "operand" : [ {
+                     "localId" : "57",
+                     "locator" : "37:11-38:31",
+                     "type" : "And",
+                     "operand" : [ {
+                        "localId" : "53",
+                        "locator" : "37:11-37:72",
+                        "type" : "In",
+                        "operand" : [ {
+                           "name" : "ToString",
+                           "libraryName" : "FHIRHelpers",
+                           "type" : "FunctionRef",
+                           "operand" : [ {
+                              "localId" : "47",
+                              "locator" : "37:11-37:20",
+                              "path" : "status",
+                              "scope" : "Obs",
+                              "type" : "Property"
+                           } ]
+                        }, {
+                           "localId" : "52",
+                           "locator" : "37:25-37:72",
+                           "type" : "List",
+                           "element" : [ {
+                              "localId" : "48",
+                              "locator" : "37:26-37:32",
+                              "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                              "value" : "final",
+                              "type" : "Literal"
+                           }, {
+                              "localId" : "49",
+                              "locator" : "37:35-37:43",
+                              "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                              "value" : "amended",
+                              "type" : "Literal"
+                           }, {
+                              "localId" : "50",
+                              "locator" : "37:46-37:56",
+                              "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                              "value" : "corrected",
+                              "type" : "Literal"
+                           }, {
+                              "localId" : "51",
+                              "locator" : "37:59-37:71",
+                              "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                              "value" : "preliminary",
+                              "type" : "Literal"
+                           } ]
+                        } ]
+                     }, {
+                        "localId" : "56",
+                        "locator" : "38:11-38:31",
+                        "type" : "Not",
+                        "operand" : {
+                           "locator" : "38:11-38:31",
+                           "type" : "IsNull",
+                           "operand" : {
+                              "localId" : "55",
+                              "locator" : "38:11-38:19",
+                              "path" : "value",
+                              "scope" : "Obs",
+                              "type" : "Property"
+                           }
+                        }
+                     } ]
+                  }, {
+                     "localId" : "63",
+                     "locator" : "39:11-39:80",
+                     "type" : "IncludedIn",
+                     "operand" : [ {
+                        "localId" : "61",
+                        "locator" : "39:11-39:52",
+                        "name" : "Normalize Interval",
+                        "libraryName" : "Global",
+                        "type" : "FunctionRef",
+                        "operand" : [ {
+                           "localId" : "60",
+                           "locator" : "39:39-39:51",
+                           "path" : "effective",
+                           "scope" : "Obs",
+                           "type" : "Property"
+                        } ]
+                     }, {
+                        "localId" : "62",
+                        "locator" : "39:61-39:80",
+                        "name" : "Measurement Period",
+                        "type" : "ParameterRef"
+                     } ]
+                  } ]
+               }
+            }
+         } ]
+      }
+   }
+}

--- a/test/fixtures/elm/queries/ComplexQueries.json
+++ b/test/fixtures/elm/queries/ComplexQueries.json
@@ -1,769 +1,1494 @@
 {
-   "library" : {
-      "annotation" : [ {
-         "translatorOptions" : "EnableAnnotations,EnableLocators",
-         "type" : "CqlToElmInfo"
-      }, {
-         "libraryId" : "MATGlobalCommonFunctions",
-         "libraryVersion" : "5.0.000",
-         "startLine" : 277,
-         "startChar" : 19,
-         "endLine" : 277,
-         "endChar" : 53,
-         "message" : "Could not resolve membership operator for terminology target of the retrieve.",
-         "errorType" : "semantic",
-         "errorSeverity" : "warning",
-         "type" : "CqlToElmError"
-      } ],
-      "identifier" : {
-         "id" : "ComplexQueries",
-         "version" : "0.0.1"
+  "library": {
+    "annotation": [
+      {
+        "translatorOptions": "EnableAnnotations,EnableLocators",
+        "type": "CqlToElmInfo"
       },
-      "schemaIdentifier" : {
-         "id" : "urn:hl7-org:elm",
-         "version" : "r1"
-      },
-      "usings" : {
-         "def" : [ {
-            "localIdentifier" : "System",
-            "uri" : "urn:hl7-org:elm-types:r1"
-         }, {
-            "localId" : "1",
-            "locator" : "3:1-3:26",
-            "localIdentifier" : "FHIR",
-            "uri" : "http://hl7.org/fhir",
-            "version" : "4.0.1"
-         } ]
-      },
-      "includes" : {
-         "def" : [ {
-            "localId" : "2",
-            "locator" : "5:1-5:35",
-            "localIdentifier" : "FHIRHelpers",
-            "path" : "FHIRHelpers",
-            "version" : "4.0.1"
-         }, {
-            "localId" : "3",
-            "locator" : "6:1-6:64",
-            "localIdentifier" : "Global",
-            "path" : "MATGlobalCommonFunctions",
-            "version" : "5.0.000"
-         } ]
-      },
-      "parameters" : {
-         "def" : [ {
-            "localId" : "30",
-            "locator" : "25:1-26:66",
-            "name" : "Measurement Period",
-            "accessLevel" : "Public",
-            "default" : {
-               "localId" : "27",
-               "locator" : "26:11-26:66",
-               "lowClosed" : true,
-               "highClosed" : false,
-               "type" : "Interval",
-               "low" : {
-                  "localId" : "25",
-                  "locator" : "26:20-26:41",
-                  "type" : "DateTime",
-                  "year" : {
-                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                     "value" : "2019",
-                     "type" : "Literal"
-                  },
-                  "month" : {
-                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                     "value" : "1",
-                     "type" : "Literal"
-                  },
-                  "day" : {
-                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                     "value" : "1",
-                     "type" : "Literal"
-                  },
-                  "hour" : {
-                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                     "value" : "0",
-                     "type" : "Literal"
-                  },
-                  "minute" : {
-                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                     "value" : "0",
-                     "type" : "Literal"
-                  },
-                  "second" : {
-                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                     "value" : "0",
-                     "type" : "Literal"
-                  },
-                  "millisecond" : {
-                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                     "value" : "0",
-                     "type" : "Literal"
-                  }
-               },
-               "high" : {
-                  "localId" : "26",
-                  "locator" : "26:44-26:65",
-                  "type" : "DateTime",
-                  "year" : {
-                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                     "value" : "2020",
-                     "type" : "Literal"
-                  },
-                  "month" : {
-                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                     "value" : "1",
-                     "type" : "Literal"
-                  },
-                  "day" : {
-                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                     "value" : "1",
-                     "type" : "Literal"
-                  },
-                  "hour" : {
-                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                     "value" : "0",
-                     "type" : "Literal"
-                  },
-                  "minute" : {
-                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                     "value" : "0",
-                     "type" : "Literal"
-                  },
-                  "second" : {
-                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                     "value" : "0",
-                     "type" : "Literal"
-                  },
-                  "millisecond" : {
-                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                     "value" : "0",
-                     "type" : "Literal"
-                  }
-               }
-            },
-            "parameterTypeSpecifier" : {
-               "localId" : "29",
-               "locator" : "25:32-25:49",
-               "type" : "IntervalTypeSpecifier",
-               "pointType" : {
-                  "localId" : "28",
-                  "locator" : "25:41-25:48",
-                  "name" : "{urn:hl7-org:elm-types:r1}DateTime",
-                  "type" : "NamedTypeSpecifier"
-               }
-            }
-         } ]
-      },
-      "codeSystems" : {
-         "def" : [ {
-            "localId" : "4",
-            "locator" : "8:1-8:42",
-            "name" : "EXAMPLE",
-            "id" : "http://example.com",
-            "accessLevel" : "Public"
-         }, {
-            "localId" : "5",
-            "locator" : "9:1-9:46",
-            "name" : "EXAMPLE-2",
-            "id" : "http://example.com/2",
-            "accessLevel" : "Public"
-         }, {
-            "localId" : "6",
-            "locator" : "10:1-10:101",
-            "name" : "ConditionClinicalStatusCodes",
-            "id" : "http://terminology.hl7.org/CodeSystem/condition-clinical",
-            "accessLevel" : "Public"
-         } ]
-      },
-      "valueSets" : {
-         "def" : [ {
-            "localId" : "7",
-            "locator" : "12:1-12:48",
-            "name" : "test-vs",
-            "id" : "http://example.com/test-vs",
-            "accessLevel" : "Public"
-         } ]
-      },
-      "codes" : {
-         "def" : [ {
-            "localId" : "9",
-            "locator" : "14:1-14:39",
-            "name" : "test-code",
-            "id" : "test",
-            "accessLevel" : "Public",
-            "codeSystem" : {
-               "localId" : "8",
-               "locator" : "14:31-14:39",
-               "name" : "EXAMPLE"
-            }
-         }, {
-            "localId" : "11",
-            "locator" : "15:1-15:45",
-            "name" : "test-code-2",
-            "id" : "test-2",
-            "accessLevel" : "Public",
-            "codeSystem" : {
-               "localId" : "10",
-               "locator" : "15:35-15:45",
-               "name" : "EXAMPLE-2"
-            }
-         }, {
-            "localId" : "13",
-            "locator" : "17:1-17:59",
-            "name" : "Active",
-            "id" : "active",
-            "accessLevel" : "Public",
-            "codeSystem" : {
-               "localId" : "12",
-               "locator" : "17:30-17:59",
-               "name" : "ConditionClinicalStatusCodes"
-            }
-         }, {
-            "localId" : "15",
-            "locator" : "18:1-18:67",
-            "name" : "Recurrence",
-            "id" : "recurrence",
-            "accessLevel" : "Public",
-            "codeSystem" : {
-               "localId" : "14",
-               "locator" : "18:38-18:67",
-               "name" : "ConditionClinicalStatusCodes"
-            }
-         }, {
-            "localId" : "17",
-            "locator" : "19:1-19:61",
-            "name" : "Relapse",
-            "id" : "relapse",
-            "accessLevel" : "Public",
-            "codeSystem" : {
-               "localId" : "16",
-               "locator" : "19:32-19:61",
-               "name" : "ConditionClinicalStatusCodes"
-            }
-         } ]
-      },
-      "concepts" : {
-         "def" : [ {
-            "localId" : "20",
-            "locator" : "21:1-21:77",
-            "name" : "test-concept",
-            "display" : "test-concept",
-            "accessLevel" : "Public",
-            "code" : [ {
-               "localId" : "18",
-               "locator" : "21:27-21:37",
-               "name" : "test-code"
-            }, {
-               "localId" : "19",
-               "locator" : "21:40-21:52",
-               "name" : "test-code-2"
-            } ]
-         }, {
-            "localId" : "24",
-            "locator" : "23:1-23:82",
-            "name" : "Condition Active",
-            "display" : "Active",
-            "accessLevel" : "Public",
-            "code" : [ {
-               "localId" : "21",
-               "locator" : "23:31-23:38",
-               "name" : "Active"
-            }, {
-               "localId" : "22",
-               "locator" : "23:41-23:52",
-               "name" : "Recurrence"
-            }, {
-               "localId" : "23",
-               "locator" : "23:55-23:63",
-               "name" : "Relapse"
-            } ]
-         } ]
-      },
-      "statements" : {
-         "def" : [ {
-            "locator" : "28:1-28:15",
-            "name" : "Patient",
-            "context" : "Patient",
-            "expression" : {
-               "type" : "SingletonFrom",
-               "operand" : {
-                  "locator" : "28:1-28:15",
-                  "dataType" : "{http://hl7.org/fhir}Patient",
-                  "templateId" : "http://hl7.org/fhir/StructureDefinition/Patient",
-                  "type" : "Retrieve"
-               }
-            }
-         }, {
-            "localId" : "43",
-            "locator" : "30:1-33:45",
-            "name" : "Code And Starts During MP",
-            "context" : "Patient",
-            "accessLevel" : "Public",
-            "annotation" : [ {
-               "type" : "Annotation",
-               "s" : {
-                  "r" : "43",
-                  "s" : [ {
-                     "value" : [ "define ","\"Code And Starts During MP\"",":\n  " ]
-                  }, {
-                     "r" : "42",
-                     "s" : [ {
-                        "s" : [ {
-                           "r" : "32",
-                           "s" : [ {
-                              "r" : "31",
-                              "s" : [ {
-                                 "r" : "31",
-                                 "s" : [ {
-                                    "value" : [ "[","Condition",": " ]
-                                 }, {
-                                    "s" : [ {
-                                       "value" : [ "\"test-vs\"" ]
-                                    } ]
-                                 }, {
-                                    "value" : [ "]" ]
-                                 } ]
-                              } ]
-                           }, {
-                              "value" : [ " ","C" ]
-                           } ]
-                        } ]
-                     }, {
-                        "value" : [ "\n    " ]
-                     }, {
-                        "r" : "41",
-                        "s" : [ {
-                           "value" : [ "where " ]
-                        }, {
-                           "r" : "41",
-                           "s" : [ {
-                              "r" : "36",
-                              "s" : [ {
-                                 "r" : "34",
-                                 "s" : [ {
-                                    "r" : "33",
-                                    "s" : [ {
-                                       "value" : [ "C" ]
-                                    } ]
-                                 }, {
-                                    "value" : [ "." ]
-                                 }, {
-                                    "r" : "34",
-                                    "s" : [ {
-                                       "value" : [ "clinicalStatus" ]
-                                    } ]
-                                 } ]
-                              }, {
-                                 "value" : [ " ","~"," " ]
-                              }, {
-                                 "r" : "35",
-                                 "s" : [ {
-                                    "value" : [ "\"Condition Active\"" ]
-                                 } ]
-                              } ]
-                           }, {
-                              "value" : [ "\n      and " ]
-                           }, {
-                              "r" : "40",
-                              "s" : [ {
-                                 "r" : "38",
-                                 "s" : [ {
-                                    "r" : "37",
-                                    "s" : [ {
-                                       "value" : [ "C" ]
-                                    } ]
-                                 }, {
-                                    "value" : [ "." ]
-                                 }, {
-                                    "r" : "38",
-                                    "s" : [ {
-                                       "value" : [ "onset" ]
-                                    } ]
-                                 } ]
-                              }, {
-                                 "r" : "40",
-                                 "value" : [ " ","during"," " ]
-                              }, {
-                                 "r" : "39",
-                                 "s" : [ {
-                                    "value" : [ "\"Measurement Period\"" ]
-                                 } ]
-                              } ]
-                           } ]
-                        } ]
-                     } ]
-                  } ]
-               }
-            } ],
-            "expression" : {
-               "localId" : "42",
-               "locator" : "31:3-33:45",
-               "type" : "Query",
-               "source" : [ {
-                  "localId" : "32",
-                  "locator" : "31:3-31:26",
-                  "alias" : "C",
-                  "expression" : {
-                     "localId" : "31",
-                     "locator" : "31:3-31:24",
-                     "dataType" : "{http://hl7.org/fhir}Condition",
-                     "templateId" : "http://hl7.org/fhir/StructureDefinition/Condition",
-                     "codeProperty" : "code",
-                     "type" : "Retrieve",
-                     "codes" : {
-                        "locator" : "31:15-31:23",
-                        "name" : "test-vs",
-                        "type" : "ValueSetRef"
-                     }
-                  }
-               } ],
-               "relationship" : [ ],
-               "where" : {
-                  "localId" : "41",
-                  "locator" : "32:5-33:45",
-                  "type" : "And",
-                  "operand" : [ {
-                     "localId" : "36",
-                     "locator" : "32:11-32:47",
-                     "type" : "Equivalent",
-                     "operand" : [ {
-                        "name" : "ToConcept",
-                        "libraryName" : "FHIRHelpers",
-                        "type" : "FunctionRef",
-                        "operand" : [ {
-                           "localId" : "34",
-                           "locator" : "32:11-32:26",
-                           "path" : "clinicalStatus",
-                           "scope" : "C",
-                           "type" : "Property"
-                        } ]
-                     }, {
-                        "localId" : "35",
-                        "locator" : "32:30-32:47",
-                        "name" : "Condition Active",
-                        "type" : "ConceptRef"
-                     } ]
-                  }, {
-                     "localId" : "40",
-                     "locator" : "33:11-33:45",
-                     "type" : "IncludedIn",
-                     "operand" : [ {
-                        "name" : "ToInterval",
-                        "libraryName" : "FHIRHelpers",
-                        "type" : "FunctionRef",
-                        "operand" : [ {
-                           "asType" : "{http://hl7.org/fhir}Period",
-                           "type" : "As",
-                           "operand" : {
-                              "localId" : "38",
-                              "locator" : "33:11-33:17",
-                              "path" : "onset",
-                              "scope" : "C",
-                              "type" : "Property"
-                           }
-                        } ]
-                     }, {
-                        "localId" : "39",
-                        "locator" : "33:26-33:45",
-                        "name" : "Measurement Period",
-                        "type" : "ParameterRef"
-                     } ]
-                  } ]
-               }
-            }
-         }, {
-            "localId" : "66",
-            "locator" : "35:1-39:80",
-            "name" : "Observation Status Value Exists and During MP",
-            "context" : "Patient",
-            "accessLevel" : "Public",
-            "annotation" : [ {
-               "type" : "Annotation",
-               "s" : {
-                  "r" : "66",
-                  "s" : [ {
-                     "value" : [ "define ","\"Observation Status Value Exists and During MP\"",":\n  " ]
-                  }, {
-                     "r" : "65",
-                     "s" : [ {
-                        "s" : [ {
-                           "r" : "45",
-                           "s" : [ {
-                              "r" : "44",
-                              "s" : [ {
-                                 "r" : "44",
-                                 "s" : [ {
-                                    "value" : [ "[","Observation",": " ]
-                                 }, {
-                                    "s" : [ {
-                                       "value" : [ "\"test-vs\"" ]
-                                    } ]
-                                 }, {
-                                    "value" : [ "]" ]
-                                 } ]
-                              } ]
-                           }, {
-                              "value" : [ " ","Obs" ]
-                           } ]
-                        } ]
-                     }, {
-                        "value" : [ "\n    " ]
-                     }, {
-                        "r" : "64",
-                        "s" : [ {
-                           "value" : [ "where " ]
-                        }, {
-                           "r" : "64",
-                           "s" : [ {
-                              "r" : "57",
-                              "s" : [ {
-                                 "r" : "53",
-                                 "s" : [ {
-                                    "r" : "47",
-                                    "s" : [ {
-                                       "r" : "46",
-                                       "s" : [ {
-                                          "value" : [ "Obs" ]
-                                       } ]
-                                    }, {
-                                       "value" : [ "." ]
-                                    }, {
-                                       "r" : "47",
-                                       "s" : [ {
-                                          "value" : [ "status" ]
-                                       } ]
-                                    } ]
-                                 }, {
-                                    "value" : [ " in " ]
-                                 }, {
-                                    "r" : "52",
-                                    "s" : [ {
-                                       "value" : [ "{" ]
-                                    }, {
-                                       "r" : "48",
-                                       "s" : [ {
-                                          "value" : [ "'final'" ]
-                                       } ]
-                                    }, {
-                                       "value" : [ ", " ]
-                                    }, {
-                                       "r" : "49",
-                                       "s" : [ {
-                                          "value" : [ "'amended'" ]
-                                       } ]
-                                    }, {
-                                       "value" : [ ", " ]
-                                    }, {
-                                       "r" : "50",
-                                       "s" : [ {
-                                          "value" : [ "'corrected'" ]
-                                       } ]
-                                    }, {
-                                       "value" : [ ", " ]
-                                    }, {
-                                       "r" : "51",
-                                       "s" : [ {
-                                          "value" : [ "'preliminary'" ]
-                                       } ]
-                                    }, {
-                                       "value" : [ "}" ]
-                                    } ]
-                                 } ]
-                              }, {
-                                 "value" : [ "\n      and " ]
-                              }, {
-                                 "r" : "56",
-                                 "s" : [ {
-                                    "r" : "55",
-                                    "s" : [ {
-                                       "r" : "54",
-                                       "s" : [ {
-                                          "value" : [ "Obs" ]
-                                       } ]
-                                    }, {
-                                       "value" : [ "." ]
-                                    }, {
-                                       "r" : "55",
-                                       "s" : [ {
-                                          "value" : [ "value" ]
-                                       } ]
-                                    } ]
-                                 }, {
-                                    "value" : [ " is not null" ]
-                                 } ]
-                              } ]
-                           }, {
-                              "value" : [ "\n      and " ]
-                           }, {
-                              "r" : "63",
-                              "s" : [ {
-                                 "r" : "61",
-                                 "s" : [ {
-                                    "r" : "58",
-                                    "s" : [ {
-                                       "value" : [ "Global" ]
-                                    } ]
-                                 }, {
-                                    "value" : [ "." ]
-                                 }, {
-                                    "r" : "61",
-                                    "s" : [ {
-                                       "value" : [ "\"Normalize Interval\"","(" ]
-                                    }, {
-                                       "r" : "60",
-                                       "s" : [ {
-                                          "r" : "59",
-                                          "s" : [ {
-                                             "value" : [ "Obs" ]
-                                          } ]
-                                       }, {
-                                          "value" : [ "." ]
-                                       }, {
-                                          "r" : "60",
-                                          "s" : [ {
-                                             "value" : [ "effective" ]
-                                          } ]
-                                       } ]
-                                    }, {
-                                       "value" : [ ")" ]
-                                    } ]
-                                 } ]
-                              }, {
-                                 "r" : "63",
-                                 "value" : [ " ","during"," " ]
-                              }, {
-                                 "r" : "62",
-                                 "s" : [ {
-                                    "value" : [ "\"Measurement Period\"" ]
-                                 } ]
-                              } ]
-                           } ]
-                        } ]
-                     } ]
-                  } ]
-               }
-            } ],
-            "expression" : {
-               "localId" : "65",
-               "locator" : "36:3-39:80",
-               "type" : "Query",
-               "source" : [ {
-                  "localId" : "45",
-                  "locator" : "36:3-36:30",
-                  "alias" : "Obs",
-                  "expression" : {
-                     "localId" : "44",
-                     "locator" : "36:3-36:26",
-                     "dataType" : "{http://hl7.org/fhir}Observation",
-                     "templateId" : "http://hl7.org/fhir/StructureDefinition/Observation",
-                     "codeProperty" : "code",
-                     "type" : "Retrieve",
-                     "codes" : {
-                        "locator" : "36:17-36:25",
-                        "name" : "test-vs",
-                        "type" : "ValueSetRef"
-                     }
-                  }
-               } ],
-               "relationship" : [ ],
-               "where" : {
-                  "localId" : "64",
-                  "locator" : "37:5-39:80",
-                  "type" : "And",
-                  "operand" : [ {
-                     "localId" : "57",
-                     "locator" : "37:11-38:31",
-                     "type" : "And",
-                     "operand" : [ {
-                        "localId" : "53",
-                        "locator" : "37:11-37:72",
-                        "type" : "In",
-                        "operand" : [ {
-                           "name" : "ToString",
-                           "libraryName" : "FHIRHelpers",
-                           "type" : "FunctionRef",
-                           "operand" : [ {
-                              "localId" : "47",
-                              "locator" : "37:11-37:20",
-                              "path" : "status",
-                              "scope" : "Obs",
-                              "type" : "Property"
-                           } ]
-                        }, {
-                           "localId" : "52",
-                           "locator" : "37:25-37:72",
-                           "type" : "List",
-                           "element" : [ {
-                              "localId" : "48",
-                              "locator" : "37:26-37:32",
-                              "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                              "value" : "final",
-                              "type" : "Literal"
-                           }, {
-                              "localId" : "49",
-                              "locator" : "37:35-37:43",
-                              "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                              "value" : "amended",
-                              "type" : "Literal"
-                           }, {
-                              "localId" : "50",
-                              "locator" : "37:46-37:56",
-                              "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                              "value" : "corrected",
-                              "type" : "Literal"
-                           }, {
-                              "localId" : "51",
-                              "locator" : "37:59-37:71",
-                              "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                              "value" : "preliminary",
-                              "type" : "Literal"
-                           } ]
-                        } ]
-                     }, {
-                        "localId" : "56",
-                        "locator" : "38:11-38:31",
-                        "type" : "Not",
-                        "operand" : {
-                           "locator" : "38:11-38:31",
-                           "type" : "IsNull",
-                           "operand" : {
-                              "localId" : "55",
-                              "locator" : "38:11-38:19",
-                              "path" : "value",
-                              "scope" : "Obs",
-                              "type" : "Property"
-                           }
-                        }
-                     } ]
-                  }, {
-                     "localId" : "63",
-                     "locator" : "39:11-39:80",
-                     "type" : "IncludedIn",
-                     "operand" : [ {
-                        "localId" : "61",
-                        "locator" : "39:11-39:52",
-                        "name" : "Normalize Interval",
-                        "libraryName" : "Global",
-                        "type" : "FunctionRef",
-                        "operand" : [ {
-                           "localId" : "60",
-                           "locator" : "39:39-39:51",
-                           "path" : "effective",
-                           "scope" : "Obs",
-                           "type" : "Property"
-                        } ]
-                     }, {
-                        "localId" : "62",
-                        "locator" : "39:61-39:80",
-                        "name" : "Measurement Period",
-                        "type" : "ParameterRef"
-                     } ]
-                  } ]
-               }
-            }
-         } ]
+      {
+        "libraryId": "MATGlobalCommonFunctions",
+        "libraryVersion": "5.0.000",
+        "startLine": 277,
+        "startChar": 19,
+        "endLine": 277,
+        "endChar": 53,
+        "message": "Could not resolve membership operator for terminology target of the retrieve.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
       }
-   }
+    ],
+    "identifier": {
+      "id": "ComplexQueries",
+      "version": "0.0.1"
+    },
+    "schemaIdentifier": {
+      "id": "urn:hl7-org:elm",
+      "version": "r1"
+    },
+    "usings": {
+      "def": [
+        {
+          "localIdentifier": "System",
+          "uri": "urn:hl7-org:elm-types:r1"
+        },
+        {
+          "localId": "1",
+          "locator": "3:1-3:26",
+          "localIdentifier": "FHIR",
+          "uri": "http://hl7.org/fhir",
+          "version": "4.0.1"
+        }
+      ]
+    },
+    "includes": {
+      "def": [
+        {
+          "localId": "2",
+          "locator": "5:1-5:35",
+          "localIdentifier": "FHIRHelpers",
+          "path": "FHIRHelpers",
+          "version": "4.0.1"
+        },
+        {
+          "localId": "3",
+          "locator": "6:1-6:64",
+          "localIdentifier": "Global",
+          "path": "MATGlobalCommonFunctions",
+          "version": "5.0.000"
+        }
+      ]
+    },
+    "parameters": {
+      "def": [
+        {
+          "localId": "30",
+          "locator": "25:1-26:66",
+          "name": "Measurement Period",
+          "accessLevel": "Public",
+          "default": {
+            "localId": "27",
+            "locator": "26:11-26:66",
+            "lowClosed": true,
+            "highClosed": false,
+            "type": "Interval",
+            "low": {
+              "localId": "25",
+              "locator": "26:20-26:41",
+              "type": "DateTime",
+              "year": {
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "2019",
+                "type": "Literal"
+              },
+              "month": {
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "1",
+                "type": "Literal"
+              },
+              "day": {
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "1",
+                "type": "Literal"
+              },
+              "hour": {
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "0",
+                "type": "Literal"
+              },
+              "minute": {
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "0",
+                "type": "Literal"
+              },
+              "second": {
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "0",
+                "type": "Literal"
+              },
+              "millisecond": {
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "0",
+                "type": "Literal"
+              }
+            },
+            "high": {
+              "localId": "26",
+              "locator": "26:44-26:65",
+              "type": "DateTime",
+              "year": {
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "2020",
+                "type": "Literal"
+              },
+              "month": {
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "1",
+                "type": "Literal"
+              },
+              "day": {
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "1",
+                "type": "Literal"
+              },
+              "hour": {
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "0",
+                "type": "Literal"
+              },
+              "minute": {
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "0",
+                "type": "Literal"
+              },
+              "second": {
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "0",
+                "type": "Literal"
+              },
+              "millisecond": {
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "0",
+                "type": "Literal"
+              }
+            }
+          },
+          "parameterTypeSpecifier": {
+            "localId": "29",
+            "locator": "25:32-25:49",
+            "type": "IntervalTypeSpecifier",
+            "pointType": {
+              "localId": "28",
+              "locator": "25:41-25:48",
+              "name": "{urn:hl7-org:elm-types:r1}DateTime",
+              "type": "NamedTypeSpecifier"
+            }
+          }
+        }
+      ]
+    },
+    "codeSystems": {
+      "def": [
+        {
+          "localId": "4",
+          "locator": "8:1-8:42",
+          "name": "EXAMPLE",
+          "id": "http://example.com",
+          "accessLevel": "Public"
+        },
+        {
+          "localId": "5",
+          "locator": "9:1-9:46",
+          "name": "EXAMPLE-2",
+          "id": "http://example.com/2",
+          "accessLevel": "Public"
+        },
+        {
+          "localId": "6",
+          "locator": "10:1-10:101",
+          "name": "ConditionClinicalStatusCodes",
+          "id": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+          "accessLevel": "Public"
+        }
+      ]
+    },
+    "valueSets": {
+      "def": [
+        {
+          "localId": "7",
+          "locator": "12:1-12:48",
+          "name": "test-vs",
+          "id": "http://example.com/test-vs",
+          "accessLevel": "Public"
+        }
+      ]
+    },
+    "codes": {
+      "def": [
+        {
+          "localId": "9",
+          "locator": "14:1-14:39",
+          "name": "test-code",
+          "id": "test",
+          "accessLevel": "Public",
+          "codeSystem": {
+            "localId": "8",
+            "locator": "14:31-14:39",
+            "name": "EXAMPLE"
+          }
+        },
+        {
+          "localId": "11",
+          "locator": "15:1-15:45",
+          "name": "test-code-2",
+          "id": "test-2",
+          "accessLevel": "Public",
+          "codeSystem": {
+            "localId": "10",
+            "locator": "15:35-15:45",
+            "name": "EXAMPLE-2"
+          }
+        },
+        {
+          "localId": "13",
+          "locator": "17:1-17:59",
+          "name": "Active",
+          "id": "active",
+          "accessLevel": "Public",
+          "codeSystem": {
+            "localId": "12",
+            "locator": "17:30-17:59",
+            "name": "ConditionClinicalStatusCodes"
+          }
+        },
+        {
+          "localId": "15",
+          "locator": "18:1-18:67",
+          "name": "Recurrence",
+          "id": "recurrence",
+          "accessLevel": "Public",
+          "codeSystem": {
+            "localId": "14",
+            "locator": "18:38-18:67",
+            "name": "ConditionClinicalStatusCodes"
+          }
+        },
+        {
+          "localId": "17",
+          "locator": "19:1-19:61",
+          "name": "Relapse",
+          "id": "relapse",
+          "accessLevel": "Public",
+          "codeSystem": {
+            "localId": "16",
+            "locator": "19:32-19:61",
+            "name": "ConditionClinicalStatusCodes"
+          }
+        }
+      ]
+    },
+    "concepts": {
+      "def": [
+        {
+          "localId": "20",
+          "locator": "21:1-21:77",
+          "name": "test-concept",
+          "display": "test-concept",
+          "accessLevel": "Public",
+          "code": [
+            {
+              "localId": "18",
+              "locator": "21:27-21:37",
+              "name": "test-code"
+            },
+            {
+              "localId": "19",
+              "locator": "21:40-21:52",
+              "name": "test-code-2"
+            }
+          ]
+        },
+        {
+          "localId": "24",
+          "locator": "23:1-23:82",
+          "name": "Condition Active",
+          "display": "Active",
+          "accessLevel": "Public",
+          "code": [
+            {
+              "localId": "21",
+              "locator": "23:31-23:38",
+              "name": "Active"
+            },
+            {
+              "localId": "22",
+              "locator": "23:41-23:52",
+              "name": "Recurrence"
+            },
+            {
+              "localId": "23",
+              "locator": "23:55-23:63",
+              "name": "Relapse"
+            }
+          ]
+        }
+      ]
+    },
+    "statements": {
+      "def": [
+        {
+          "locator": "28:1-28:15",
+          "name": "Patient",
+          "context": "Patient",
+          "expression": {
+            "type": "SingletonFrom",
+            "operand": {
+              "locator": "28:1-28:15",
+              "dataType": "{http://hl7.org/fhir}Patient",
+              "templateId": "http://hl7.org/fhir/StructureDefinition/Patient",
+              "type": "Retrieve"
+            }
+          }
+        },
+        {
+          "localId": "43",
+          "locator": "30:1-33:45",
+          "name": "Code And Starts During MP",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "43",
+                "s": [
+                  {
+                    "value": [
+                      "define ",
+                      "\"Code And Starts During MP\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "42",
+                    "s": [
+                      {
+                        "s": [
+                          {
+                            "r": "32",
+                            "s": [
+                              {
+                                "r": "31",
+                                "s": [
+                                  {
+                                    "r": "31",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "[",
+                                          "Condition",
+                                          ": "
+                                        ]
+                                      },
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"test-vs\""
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "]"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "C"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "\n    "
+                        ]
+                      },
+                      {
+                        "r": "41",
+                        "s": [
+                          {
+                            "value": [
+                              "where "
+                            ]
+                          },
+                          {
+                            "r": "41",
+                            "s": [
+                              {
+                                "r": "36",
+                                "s": [
+                                  {
+                                    "r": "34",
+                                    "s": [
+                                      {
+                                        "r": "33",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "C"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "."
+                                        ]
+                                      },
+                                      {
+                                        "r": "34",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "clinicalStatus"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      " ",
+                                      "~",
+                                      " "
+                                    ]
+                                  },
+                                  {
+                                    "r": "35",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "\"Condition Active\""
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  "\n      and "
+                                ]
+                              },
+                              {
+                                "r": "40",
+                                "s": [
+                                  {
+                                    "r": "38",
+                                    "s": [
+                                      {
+                                        "r": "37",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "C"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "."
+                                        ]
+                                      },
+                                      {
+                                        "r": "38",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "onset"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "r": "40",
+                                    "value": [
+                                      " ",
+                                      "during",
+                                      " "
+                                    ]
+                                  },
+                                  {
+                                    "r": "39",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "\"Measurement Period\""
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "42",
+            "locator": "31:3-33:45",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "32",
+                "locator": "31:3-31:26",
+                "alias": "C",
+                "expression": {
+                  "localId": "31",
+                  "locator": "31:3-31:24",
+                  "dataType": "{http://hl7.org/fhir}Condition",
+                  "templateId": "http://hl7.org/fhir/StructureDefinition/Condition",
+                  "codeProperty": "code",
+                  "type": "Retrieve",
+                  "codes": {
+                    "locator": "31:15-31:23",
+                    "name": "test-vs",
+                    "type": "ValueSetRef"
+                  }
+                }
+              }
+            ],
+            "relationship": [],
+            "where": {
+              "localId": "41",
+              "locator": "32:5-33:45",
+              "type": "And",
+              "operand": [
+                {
+                  "localId": "36",
+                  "locator": "32:11-32:47",
+                  "type": "Equivalent",
+                  "operand": [
+                    {
+                      "name": "ToConcept",
+                      "libraryName": "FHIRHelpers",
+                      "type": "FunctionRef",
+                      "operand": [
+                        {
+                          "localId": "34",
+                          "locator": "32:11-32:26",
+                          "path": "clinicalStatus",
+                          "scope": "C",
+                          "type": "Property"
+                        }
+                      ]
+                    },
+                    {
+                      "localId": "35",
+                      "locator": "32:30-32:47",
+                      "name": "Condition Active",
+                      "type": "ConceptRef"
+                    }
+                  ]
+                },
+                {
+                  "localId": "40",
+                  "locator": "33:11-33:45",
+                  "type": "IncludedIn",
+                  "operand": [
+                    {
+                      "name": "ToInterval",
+                      "libraryName": "FHIRHelpers",
+                      "type": "FunctionRef",
+                      "operand": [
+                        {
+                          "asType": "{http://hl7.org/fhir}Period",
+                          "type": "As",
+                          "operand": {
+                            "localId": "38",
+                            "locator": "33:11-33:17",
+                            "path": "onset",
+                            "scope": "C",
+                            "type": "Property"
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "localId": "39",
+                      "locator": "33:26-33:45",
+                      "name": "Measurement Period",
+                      "type": "ParameterRef"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        {
+          "localId": "66",
+          "locator": "35:1-39:80",
+          "name": "Observation Status Value Exists and During MP",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "66",
+                "s": [
+                  {
+                    "value": [
+                      "define ",
+                      "\"Observation Status Value Exists and During MP\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "65",
+                    "s": [
+                      {
+                        "s": [
+                          {
+                            "r": "45",
+                            "s": [
+                              {
+                                "r": "44",
+                                "s": [
+                                  {
+                                    "r": "44",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "[",
+                                          "Observation",
+                                          ": "
+                                        ]
+                                      },
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"test-vs\""
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "]"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "Obs"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "\n    "
+                        ]
+                      },
+                      {
+                        "r": "64",
+                        "s": [
+                          {
+                            "value": [
+                              "where "
+                            ]
+                          },
+                          {
+                            "r": "64",
+                            "s": [
+                              {
+                                "r": "57",
+                                "s": [
+                                  {
+                                    "r": "53",
+                                    "s": [
+                                      {
+                                        "r": "47",
+                                        "s": [
+                                          {
+                                            "r": "46",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "Obs"
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              "."
+                                            ]
+                                          },
+                                          {
+                                            "r": "47",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "status"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          " in "
+                                        ]
+                                      },
+                                      {
+                                        "r": "52",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "{"
+                                            ]
+                                          },
+                                          {
+                                            "r": "48",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "'final'"
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              ", "
+                                            ]
+                                          },
+                                          {
+                                            "r": "49",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "'amended'"
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              ", "
+                                            ]
+                                          },
+                                          {
+                                            "r": "50",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "'corrected'"
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              ", "
+                                            ]
+                                          },
+                                          {
+                                            "r": "51",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "'preliminary'"
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              "}"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "\n      and "
+                                    ]
+                                  },
+                                  {
+                                    "r": "56",
+                                    "s": [
+                                      {
+                                        "r": "55",
+                                        "s": [
+                                          {
+                                            "r": "54",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "Obs"
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              "."
+                                            ]
+                                          },
+                                          {
+                                            "r": "55",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "value"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          " is not null"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  "\n      and "
+                                ]
+                              },
+                              {
+                                "r": "63",
+                                "s": [
+                                  {
+                                    "r": "61",
+                                    "s": [
+                                      {
+                                        "r": "58",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "Global"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "."
+                                        ]
+                                      },
+                                      {
+                                        "r": "61",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"Normalize Interval\"",
+                                              "("
+                                            ]
+                                          },
+                                          {
+                                            "r": "60",
+                                            "s": [
+                                              {
+                                                "r": "59",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "Obs"
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  "."
+                                                ]
+                                              },
+                                              {
+                                                "r": "60",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "effective"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              ")"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "r": "63",
+                                    "value": [
+                                      " ",
+                                      "during",
+                                      " "
+                                    ]
+                                  },
+                                  {
+                                    "r": "62",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "\"Measurement Period\""
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "65",
+            "locator": "36:3-39:80",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "45",
+                "locator": "36:3-36:30",
+                "alias": "Obs",
+                "expression": {
+                  "localId": "44",
+                  "locator": "36:3-36:26",
+                  "dataType": "{http://hl7.org/fhir}Observation",
+                  "templateId": "http://hl7.org/fhir/StructureDefinition/Observation",
+                  "codeProperty": "code",
+                  "type": "Retrieve",
+                  "codes": {
+                    "locator": "36:17-36:25",
+                    "name": "test-vs",
+                    "type": "ValueSetRef"
+                  }
+                }
+              }
+            ],
+            "relationship": [],
+            "where": {
+              "localId": "64",
+              "locator": "37:5-39:80",
+              "type": "And",
+              "operand": [
+                {
+                  "localId": "57",
+                  "locator": "37:11-38:31",
+                  "type": "And",
+                  "operand": [
+                    {
+                      "localId": "53",
+                      "locator": "37:11-37:72",
+                      "type": "In",
+                      "operand": [
+                        {
+                          "name": "ToString",
+                          "libraryName": "FHIRHelpers",
+                          "type": "FunctionRef",
+                          "operand": [
+                            {
+                              "localId": "47",
+                              "locator": "37:11-37:20",
+                              "path": "status",
+                              "scope": "Obs",
+                              "type": "Property"
+                            }
+                          ]
+                        },
+                        {
+                          "localId": "52",
+                          "locator": "37:25-37:72",
+                          "type": "List",
+                          "element": [
+                            {
+                              "localId": "48",
+                              "locator": "37:26-37:32",
+                              "valueType": "{urn:hl7-org:elm-types:r1}String",
+                              "value": "final",
+                              "type": "Literal"
+                            },
+                            {
+                              "localId": "49",
+                              "locator": "37:35-37:43",
+                              "valueType": "{urn:hl7-org:elm-types:r1}String",
+                              "value": "amended",
+                              "type": "Literal"
+                            },
+                            {
+                              "localId": "50",
+                              "locator": "37:46-37:56",
+                              "valueType": "{urn:hl7-org:elm-types:r1}String",
+                              "value": "corrected",
+                              "type": "Literal"
+                            },
+                            {
+                              "localId": "51",
+                              "locator": "37:59-37:71",
+                              "valueType": "{urn:hl7-org:elm-types:r1}String",
+                              "value": "preliminary",
+                              "type": "Literal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "localId": "56",
+                      "locator": "38:11-38:31",
+                      "type": "Not",
+                      "operand": {
+                        "locator": "38:11-38:31",
+                        "type": "IsNull",
+                        "operand": {
+                          "localId": "55",
+                          "locator": "38:11-38:19",
+                          "path": "value",
+                          "scope": "Obs",
+                          "type": "Property"
+                        }
+                      }
+                    }
+                  ]
+                },
+                {
+                  "localId": "63",
+                  "locator": "39:11-39:80",
+                  "type": "IncludedIn",
+                  "operand": [
+                    {
+                      "localId": "61",
+                      "locator": "39:11-39:52",
+                      "name": "Normalize Interval",
+                      "libraryName": "Global",
+                      "type": "FunctionRef",
+                      "operand": [
+                        {
+                          "localId": "60",
+                          "locator": "39:39-39:51",
+                          "path": "effective",
+                          "scope": "Obs",
+                          "type": "Property"
+                        }
+                      ]
+                    },
+                    {
+                      "localId": "62",
+                      "locator": "39:61-39:80",
+                      "name": "Measurement Period",
+                      "type": "ParameterRef"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        {
+          "localId": "78",
+          "locator": "41:1-43:105",
+          "name": "Encounter 2 Years Before End of MP",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "78",
+                "s": [
+                  {
+                    "value": [
+                      "define ",
+                      "\"Encounter 2 Years Before End of MP\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "77",
+                    "s": [
+                      {
+                        "s": [
+                          {
+                            "r": "68",
+                            "s": [
+                              {
+                                "r": "67",
+                                "s": [
+                                  {
+                                    "r": "67",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "[",
+                                          "Encounter",
+                                          ": "
+                                        ]
+                                      },
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"test-vs\""
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "]"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "Enc"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "\n    "
+                        ]
+                      },
+                      {
+                        "r": "76",
+                        "s": [
+                          {
+                            "value": [
+                              "where "
+                            ]
+                          },
+                          {
+                            "r": "76",
+                            "s": [
+                              {
+                                "r": "72",
+                                "s": [
+                                  {
+                                    "r": "69",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "Global"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "."
+                                    ]
+                                  },
+                                  {
+                                    "r": "72",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "\"Normalize Interval\"",
+                                          "("
+                                        ]
+                                      },
+                                      {
+                                        "r": "71",
+                                        "s": [
+                                          {
+                                            "r": "70",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "Enc"
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              "."
+                                            ]
+                                          },
+                                          {
+                                            "r": "71",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "period"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          ")"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " "
+                                ]
+                              },
+                              {
+                                "r": "76",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "ends "
+                                    ]
+                                  },
+                                  {
+                                    "r": "75",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "2 ",
+                                          "years"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      " or less before"
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " "
+                                ]
+                              },
+                              {
+                                "r": "74",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "end of "
+                                    ]
+                                  },
+                                  {
+                                    "r": "73",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "\"Measurement Period\""
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "77",
+            "locator": "42:3-43:105",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "68",
+                "locator": "42:3-42:28",
+                "alias": "Enc",
+                "expression": {
+                  "localId": "67",
+                  "locator": "42:3-42:24",
+                  "dataType": "{http://hl7.org/fhir}Encounter",
+                  "templateId": "http://hl7.org/fhir/StructureDefinition/Encounter",
+                  "codeProperty": "type",
+                  "type": "Retrieve",
+                  "codes": {
+                    "locator": "42:15-42:23",
+                    "name": "test-vs",
+                    "type": "ValueSetRef"
+                  }
+                }
+              }
+            ],
+            "relationship": [],
+            "where": {
+              "localId": "76",
+              "locator": "43:5-43:105",
+              "type": "And",
+              "operand": [
+                {
+                  "locator": "43:56-43:70",
+                  "type": "In",
+                  "operand": [
+                    {
+                      "locator": "43:51-43:54",
+                      "type": "End",
+                      "operand": {
+                        "localId": "72",
+                        "locator": "43:11-43:49",
+                        "name": "Normalize Interval",
+                        "libraryName": "Global",
+                        "type": "FunctionRef",
+                        "operand": [
+                          {
+                            "type": "As",
+                            "operand": {
+                              "localId": "71",
+                              "locator": "43:39-43:48",
+                              "path": "period",
+                              "scope": "Enc",
+                              "type": "Property"
+                            },
+                            "asTypeSpecifier": {
+                              "type": "ChoiceTypeSpecifier",
+                              "choice": [
+                                {
+                                  "name": "{http://hl7.org/fhir}dateTime",
+                                  "type": "NamedTypeSpecifier"
+                                },
+                                {
+                                  "name": "{http://hl7.org/fhir}Period",
+                                  "type": "NamedTypeSpecifier"
+                                },
+                                {
+                                  "name": "{http://hl7.org/fhir}Timing",
+                                  "type": "NamedTypeSpecifier"
+                                },
+                                {
+                                  "name": "{http://hl7.org/fhir}instant",
+                                  "type": "NamedTypeSpecifier"
+                                },
+                                {
+                                  "name": "{http://hl7.org/fhir}string",
+                                  "type": "NamedTypeSpecifier"
+                                },
+                                {
+                                  "name": "{http://hl7.org/fhir}Age",
+                                  "type": "NamedTypeSpecifier"
+                                },
+                                {
+                                  "name": "{http://hl7.org/fhir}Range",
+                                  "type": "NamedTypeSpecifier"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "locator": "43:56-43:70",
+                      "lowClosed": true,
+                      "highClosed": false,
+                      "type": "Interval",
+                      "low": {
+                        "locator": "43:79-43:105",
+                        "type": "Subtract",
+                        "operand": [
+                          {
+                            "localId": "74",
+                            "locator": "43:79-43:105",
+                            "type": "End",
+                            "operand": {
+                              "localId": "73",
+                              "locator": "43:86-43:105",
+                              "name": "Measurement Period",
+                              "type": "ParameterRef"
+                            }
+                          },
+                          {
+                            "localId": "75",
+                            "locator": "43:56-43:62",
+                            "value": 2,
+                            "unit": "years",
+                            "type": "Quantity"
+                          }
+                        ]
+                      },
+                      "high": {
+                        "localId": "74",
+                        "locator": "43:79-43:105",
+                        "type": "End",
+                        "operand": {
+                          "localId": "73",
+                          "locator": "43:86-43:105",
+                          "name": "Measurement Period",
+                          "type": "ParameterRef"
+                        }
+                      }
+                    }
+                  ]
+                },
+                {
+                  "locator": "43:56-43:70",
+                  "type": "Not",
+                  "operand": {
+                    "locator": "43:56-43:70",
+                    "type": "IsNull",
+                    "operand": {
+                      "localId": "74",
+                      "locator": "43:79-43:105",
+                      "type": "End",
+                      "operand": {
+                        "localId": "73",
+                        "locator": "43:86-43:105",
+                        "name": "Measurement Period",
+                        "type": "ParameterRef"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }
 }

--- a/test/fixtures/elm/queries/MATGlobalCommonFunctions-5.0.000.json
+++ b/test/fixtures/elm/queries/MATGlobalCommonFunctions-5.0.000.json
@@ -1,0 +1,5020 @@
+{
+  "library": {
+    "annotation": [
+      {
+        "translatorOptions": "",
+        "type": "CqlToElmInfo"
+      },
+      {
+        "libraryId": "MATGlobalCommonFunctions",
+        "libraryVersion": "5.0.000",
+        "startLine": 277,
+        "startChar": 19,
+        "endLine": 277,
+        "endChar": 53,
+        "message": "Could not resolve membership operator for terminology target of the retrieve.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      }
+    ],
+    "identifier": {
+      "id": "MATGlobalCommonFunctions",
+      "version": "5.0.000"
+    },
+    "schemaIdentifier": {
+      "id": "urn:hl7-org:elm",
+      "version": "r1"
+    },
+    "usings": {
+      "def": [
+        {
+          "localIdentifier": "System",
+          "uri": "urn:hl7-org:elm-types:r1"
+        },
+        {
+          "localIdentifier": "FHIR",
+          "uri": "http://hl7.org/fhir",
+          "version": "4.0.1"
+        }
+      ]
+    },
+    "includes": {
+      "def": [
+        {
+          "localIdentifier": "FHIRHelpers",
+          "path": "FHIRHelpers",
+          "version": "4.0.1"
+        }
+      ]
+    },
+    "parameters": {
+      "def": [
+        {
+          "name": "Measurement Period",
+          "accessLevel": "Public",
+          "default": {
+            "lowClosed": true,
+            "highClosed": false,
+            "type": "Interval",
+            "low": {
+              "type": "DateTime",
+              "year": {
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "2019",
+                "type": "Literal"
+              },
+              "month": {
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "1",
+                "type": "Literal"
+              },
+              "day": {
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "1",
+                "type": "Literal"
+              },
+              "hour": {
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "0",
+                "type": "Literal"
+              },
+              "minute": {
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "0",
+                "type": "Literal"
+              },
+              "second": {
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "0",
+                "type": "Literal"
+              },
+              "millisecond": {
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "0",
+                "type": "Literal"
+              }
+            },
+            "high": {
+              "type": "DateTime",
+              "year": {
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "2020",
+                "type": "Literal"
+              },
+              "month": {
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "1",
+                "type": "Literal"
+              },
+              "day": {
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "1",
+                "type": "Literal"
+              },
+              "hour": {
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "0",
+                "type": "Literal"
+              },
+              "minute": {
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "0",
+                "type": "Literal"
+              },
+              "second": {
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "0",
+                "type": "Literal"
+              },
+              "millisecond": {
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "0",
+                "type": "Literal"
+              }
+            }
+          },
+          "parameterTypeSpecifier": {
+            "type": "IntervalTypeSpecifier",
+            "pointType": {
+              "name": "{urn:hl7-org:elm-types:r1}DateTime",
+              "type": "NamedTypeSpecifier"
+            }
+          }
+        }
+      ]
+    },
+    "codeSystems": {
+      "def": [
+        {
+          "name": "LOINC",
+          "id": "http://loinc.org",
+          "accessLevel": "Public"
+        },
+        {
+          "name": "SNOMEDCT",
+          "id": "http://snomed.info/sct/731000124108",
+          "accessLevel": "Public"
+        },
+        {
+          "name": "RoleCode",
+          "id": "http://hl7.org/fhir/v3/RoleCode",
+          "accessLevel": "Public"
+        },
+        {
+          "name": "Diagnosis Role",
+          "id": "http://terminology.hl7.org/CodeSystem/diagnosis-role",
+          "accessLevel": "Public"
+        },
+        {
+          "name": "RequestIntent",
+          "id": "http://terminology.hl7.org/CodeSystem/request-intent",
+          "accessLevel": "Public"
+        },
+        {
+          "name": "MedicationRequestCategory",
+          "id": "http://terminology.hl7.org/CodeSystem/medicationrequest-category",
+          "accessLevel": "Public"
+        },
+        {
+          "name": "ConditionClinicalStatusCodes",
+          "id": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+          "accessLevel": "Public"
+        },
+        {
+          "name": "ConditionVerificationStatusCodes",
+          "id": "http://terminology.hl7.org/CodeSystem/condition-verification",
+          "accessLevel": "Public"
+        },
+        {
+          "name": "AllergyIntoleranceClinicalStatusCodes",
+          "id": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+          "accessLevel": "Public"
+        },
+        {
+          "name": "AllergyIntoleranceVerificationStatusCodes",
+          "id": "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
+          "accessLevel": "Public"
+        }
+      ]
+    },
+    "valueSets": {
+      "def": [
+        {
+          "name": "Encounter Inpatient",
+          "id": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307",
+          "accessLevel": "Public"
+        },
+        {
+          "name": "Emergency Department Visit",
+          "id": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292",
+          "accessLevel": "Public"
+        },
+        {
+          "name": "Observation Services",
+          "id": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143",
+          "accessLevel": "Public"
+        }
+      ]
+    },
+    "codes": {
+      "def": [
+        {
+          "name": "Birthdate",
+          "id": "21112-8",
+          "display": "Birth date",
+          "accessLevel": "Public",
+          "codeSystem": {
+            "name": "LOINC"
+          }
+        },
+        {
+          "name": "Dead",
+          "id": "419099009",
+          "display": "Dead",
+          "accessLevel": "Public",
+          "codeSystem": {
+            "name": "SNOMEDCT"
+          }
+        },
+        {
+          "name": "ER",
+          "id": "ER",
+          "display": "Emergency room",
+          "accessLevel": "Public",
+          "codeSystem": {
+            "name": "RoleCode"
+          }
+        },
+        {
+          "name": "ICU",
+          "id": "ICU",
+          "display": "Intensive care unit",
+          "accessLevel": "Public",
+          "codeSystem": {
+            "name": "RoleCode"
+          }
+        },
+        {
+          "name": "Billing",
+          "id": "billing",
+          "display": "Billing",
+          "accessLevel": "Public",
+          "codeSystem": {
+            "name": "Diagnosis Role"
+          }
+        },
+        {
+          "name": "active",
+          "id": "active",
+          "accessLevel": "Public",
+          "codeSystem": {
+            "name": "ConditionClinicalStatusCodes"
+          }
+        },
+        {
+          "name": "recurrence",
+          "id": "recurrence",
+          "accessLevel": "Public",
+          "codeSystem": {
+            "name": "ConditionClinicalStatusCodes"
+          }
+        },
+        {
+          "name": "relapse",
+          "id": "relapse",
+          "accessLevel": "Public",
+          "codeSystem": {
+            "name": "ConditionClinicalStatusCodes"
+          }
+        },
+        {
+          "name": "inactive",
+          "id": "inactive",
+          "accessLevel": "Public",
+          "codeSystem": {
+            "name": "ConditionClinicalStatusCodes"
+          }
+        },
+        {
+          "name": "remission",
+          "id": "remission",
+          "accessLevel": "Public",
+          "codeSystem": {
+            "name": "ConditionClinicalStatusCodes"
+          }
+        },
+        {
+          "name": "resolved",
+          "id": "resolved",
+          "accessLevel": "Public",
+          "codeSystem": {
+            "name": "ConditionClinicalStatusCodes"
+          }
+        },
+        {
+          "name": "unconfirmed",
+          "id": "unconfirmed",
+          "accessLevel": "Public",
+          "codeSystem": {
+            "name": "ConditionVerificationStatusCodes"
+          }
+        },
+        {
+          "name": "provisional",
+          "id": "provisional",
+          "accessLevel": "Public",
+          "codeSystem": {
+            "name": "ConditionVerificationStatusCodes"
+          }
+        },
+        {
+          "name": "differential",
+          "id": "differential",
+          "accessLevel": "Public",
+          "codeSystem": {
+            "name": "ConditionVerificationStatusCodes"
+          }
+        },
+        {
+          "name": "confirmed",
+          "id": "confirmed",
+          "accessLevel": "Public",
+          "codeSystem": {
+            "name": "ConditionVerificationStatusCodes"
+          }
+        },
+        {
+          "name": "refuted",
+          "id": "refuted",
+          "accessLevel": "Public",
+          "codeSystem": {
+            "name": "ConditionVerificationStatusCodes"
+          }
+        },
+        {
+          "name": "entered-in-error",
+          "id": "entered-in-error",
+          "accessLevel": "Public",
+          "codeSystem": {
+            "name": "ConditionVerificationStatusCodes"
+          }
+        },
+        {
+          "name": "allergy-active",
+          "id": "active",
+          "accessLevel": "Public",
+          "codeSystem": {
+            "name": "AllergyIntoleranceClinicalStatusCodes"
+          }
+        },
+        {
+          "name": "allergy-inactive",
+          "id": "inactive",
+          "accessLevel": "Public",
+          "codeSystem": {
+            "name": "AllergyIntoleranceClinicalStatusCodes"
+          }
+        },
+        {
+          "name": "allergy-resolved",
+          "id": "resolved",
+          "accessLevel": "Public",
+          "codeSystem": {
+            "name": "AllergyIntoleranceClinicalStatusCodes"
+          }
+        },
+        {
+          "name": "allergy-unconfirmed",
+          "id": "unconfirmed",
+          "accessLevel": "Public",
+          "codeSystem": {
+            "name": "AllergyIntoleranceVerificationStatusCodes"
+          }
+        },
+        {
+          "name": "allergy-confirmed",
+          "id": "confirmed",
+          "accessLevel": "Public",
+          "codeSystem": {
+            "name": "AllergyIntoleranceVerificationStatusCodes"
+          }
+        },
+        {
+          "name": "allergy-refuted",
+          "id": "refuted",
+          "accessLevel": "Public",
+          "codeSystem": {
+            "name": "AllergyIntoleranceVerificationStatusCodes"
+          }
+        },
+        {
+          "name": "Community",
+          "id": "community",
+          "display": "Community",
+          "accessLevel": "Public",
+          "codeSystem": {
+            "name": "MedicationRequestCategory"
+          }
+        },
+        {
+          "name": "Discharge",
+          "id": "discharge",
+          "display": "Discharge",
+          "accessLevel": "Public",
+          "codeSystem": {
+            "name": "MedicationRequestCategory"
+          }
+        }
+      ]
+    },
+    "statements": {
+      "def": [
+        {
+          "name": "Patient",
+          "context": "Patient",
+          "expression": {
+            "type": "SingletonFrom",
+            "operand": {
+              "dataType": "{http://hl7.org/fhir}Patient",
+              "templateId": "http://hl7.org/fhir/StructureDefinition/Patient",
+              "type": "Retrieve"
+            }
+          }
+        },
+        {
+          "name": "LengthInDays",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "expression": {
+            "precision": "Day",
+            "type": "DifferenceBetween",
+            "operand": [
+              {
+                "type": "Start",
+                "operand": {
+                  "name": "Value",
+                  "type": "OperandRef"
+                }
+              },
+              {
+                "type": "End",
+                "operand": {
+                  "name": "Value",
+                  "type": "OperandRef"
+                }
+              }
+            ]
+          },
+          "operand": [
+            {
+              "name": "Value",
+              "operandTypeSpecifier": {
+                "type": "IntervalTypeSpecifier",
+                "pointType": {
+                  "name": "{urn:hl7-org:elm-types:r1}DateTime",
+                  "type": "NamedTypeSpecifier"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "name": "Inpatient Encounter",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "expression": {
+            "type": "Query",
+            "source": [
+              {
+                "alias": "EncounterInpatient",
+                "expression": {
+                  "dataType": "{http://hl7.org/fhir}Encounter",
+                  "templateId": "http://hl7.org/fhir/StructureDefinition/Encounter",
+                  "codeProperty": "type",
+                  "type": "Retrieve",
+                  "codes": {
+                    "name": "Encounter Inpatient",
+                    "type": "ValueSetRef"
+                  }
+                }
+              }
+            ],
+            "relationship": [],
+            "where": {
+              "type": "And",
+              "operand": [
+                {
+                  "type": "And",
+                  "operand": [
+                    {
+                      "type": "Equal",
+                      "operand": [
+                        {
+                          "name": "ToString",
+                          "libraryName": "FHIRHelpers",
+                          "type": "FunctionRef",
+                          "operand": [
+                            {
+                              "path": "status",
+                              "scope": "EncounterInpatient",
+                              "type": "Property"
+                            }
+                          ]
+                        },
+                        {
+                          "valueType": "{urn:hl7-org:elm-types:r1}String",
+                          "value": "finished",
+                          "type": "Literal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "LessOrEqual",
+                      "operand": [
+                        {
+                          "name": "LengthInDays",
+                          "type": "FunctionRef",
+                          "operand": [
+                            {
+                              "name": "ToInterval",
+                              "libraryName": "FHIRHelpers",
+                              "type": "FunctionRef",
+                              "operand": [
+                                {
+                                  "path": "period",
+                                  "scope": "EncounterInpatient",
+                                  "type": "Property"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                          "value": "120",
+                          "type": "Literal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "In",
+                  "operand": [
+                    {
+                      "type": "End",
+                      "operand": {
+                        "name": "ToInterval",
+                        "libraryName": "FHIRHelpers",
+                        "type": "FunctionRef",
+                        "operand": [
+                          {
+                            "path": "period",
+                            "scope": "EncounterInpatient",
+                            "type": "Property"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "Measurement Period",
+                      "type": "ParameterRef"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "ToDate",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "expression": {
+            "type": "DateTime",
+            "year": {
+              "precision": "Year",
+              "type": "DateTimeComponentFrom",
+              "operand": {
+                "name": "Value",
+                "type": "OperandRef"
+              }
+            },
+            "month": {
+              "precision": "Month",
+              "type": "DateTimeComponentFrom",
+              "operand": {
+                "name": "Value",
+                "type": "OperandRef"
+              }
+            },
+            "day": {
+              "precision": "Day",
+              "type": "DateTimeComponentFrom",
+              "operand": {
+                "name": "Value",
+                "type": "OperandRef"
+              }
+            },
+            "hour": {
+              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+              "value": "0",
+              "type": "Literal"
+            },
+            "minute": {
+              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+              "value": "0",
+              "type": "Literal"
+            },
+            "second": {
+              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+              "value": "0",
+              "type": "Literal"
+            },
+            "millisecond": {
+              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+              "value": "0",
+              "type": "Literal"
+            },
+            "timezoneOffset": {
+              "type": "TimezoneOffsetFrom",
+              "operand": {
+                "name": "Value",
+                "type": "OperandRef"
+              }
+            }
+          },
+          "operand": [
+            {
+              "name": "Value",
+              "operandTypeSpecifier": {
+                "name": "{urn:hl7-org:elm-types:r1}DateTime",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "name": "CalendarAgeInDaysAt",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "expression": {
+            "precision": "Day",
+            "type": "DurationBetween",
+            "operand": [
+              {
+                "name": "ToDate",
+                "type": "FunctionRef",
+                "operand": [
+                  {
+                    "name": "BirthDateTime",
+                    "type": "OperandRef"
+                  }
+                ]
+              },
+              {
+                "name": "ToDate",
+                "type": "FunctionRef",
+                "operand": [
+                  {
+                    "name": "AsOf",
+                    "type": "OperandRef"
+                  }
+                ]
+              }
+            ]
+          },
+          "operand": [
+            {
+              "name": "BirthDateTime",
+              "operandTypeSpecifier": {
+                "name": "{urn:hl7-org:elm-types:r1}DateTime",
+                "type": "NamedTypeSpecifier"
+              }
+            },
+            {
+              "name": "AsOf",
+              "operandTypeSpecifier": {
+                "name": "{urn:hl7-org:elm-types:r1}DateTime",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "name": "CalendarAgeInDays",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "expression": {
+            "name": "CalendarAgeInDaysAt",
+            "type": "FunctionRef",
+            "operand": [
+              {
+                "name": "BirthDateTime",
+                "type": "OperandRef"
+              },
+              {
+                "type": "ToDateTime",
+                "operand": {
+                  "type": "Today"
+                }
+              }
+            ]
+          },
+          "operand": [
+            {
+              "name": "BirthDateTime",
+              "operandTypeSpecifier": {
+                "name": "{urn:hl7-org:elm-types:r1}DateTime",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "name": "CalendarAgeInMonthsAt",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "expression": {
+            "precision": "Month",
+            "type": "DurationBetween",
+            "operand": [
+              {
+                "name": "ToDate",
+                "type": "FunctionRef",
+                "operand": [
+                  {
+                    "name": "BirthDateTime",
+                    "type": "OperandRef"
+                  }
+                ]
+              },
+              {
+                "name": "ToDate",
+                "type": "FunctionRef",
+                "operand": [
+                  {
+                    "name": "AsOf",
+                    "type": "OperandRef"
+                  }
+                ]
+              }
+            ]
+          },
+          "operand": [
+            {
+              "name": "BirthDateTime",
+              "operandTypeSpecifier": {
+                "name": "{urn:hl7-org:elm-types:r1}DateTime",
+                "type": "NamedTypeSpecifier"
+              }
+            },
+            {
+              "name": "AsOf",
+              "operandTypeSpecifier": {
+                "name": "{urn:hl7-org:elm-types:r1}DateTime",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "name": "CalendarAgeInMonths",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "expression": {
+            "name": "CalendarAgeInMonthsAt",
+            "type": "FunctionRef",
+            "operand": [
+              {
+                "name": "BirthDateTime",
+                "type": "OperandRef"
+              },
+              {
+                "type": "ToDateTime",
+                "operand": {
+                  "type": "Today"
+                }
+              }
+            ]
+          },
+          "operand": [
+            {
+              "name": "BirthDateTime",
+              "operandTypeSpecifier": {
+                "name": "{urn:hl7-org:elm-types:r1}DateTime",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "name": "CalendarAgeInYearsAt",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "expression": {
+            "precision": "Year",
+            "type": "DurationBetween",
+            "operand": [
+              {
+                "name": "ToDate",
+                "type": "FunctionRef",
+                "operand": [
+                  {
+                    "name": "BirthDateTime",
+                    "type": "OperandRef"
+                  }
+                ]
+              },
+              {
+                "name": "ToDate",
+                "type": "FunctionRef",
+                "operand": [
+                  {
+                    "name": "AsOf",
+                    "type": "OperandRef"
+                  }
+                ]
+              }
+            ]
+          },
+          "operand": [
+            {
+              "name": "BirthDateTime",
+              "operandTypeSpecifier": {
+                "name": "{urn:hl7-org:elm-types:r1}DateTime",
+                "type": "NamedTypeSpecifier"
+              }
+            },
+            {
+              "name": "AsOf",
+              "operandTypeSpecifier": {
+                "name": "{urn:hl7-org:elm-types:r1}DateTime",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "name": "CalendarAgeInYears",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "expression": {
+            "name": "CalendarAgeInYearsAt",
+            "type": "FunctionRef",
+            "operand": [
+              {
+                "name": "BirthDateTime",
+                "type": "OperandRef"
+              },
+              {
+                "type": "ToDateTime",
+                "operand": {
+                  "type": "Today"
+                }
+              }
+            ]
+          },
+          "operand": [
+            {
+              "name": "BirthDateTime",
+              "operandTypeSpecifier": {
+                "name": "{urn:hl7-org:elm-types:r1}DateTime",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "name": "ED Visit",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "expression": {
+            "type": "SingletonFrom",
+            "operand": {
+              "type": "Query",
+              "source": [
+                {
+                  "alias": "EDVisit",
+                  "expression": {
+                    "dataType": "{http://hl7.org/fhir}Encounter",
+                    "templateId": "http://hl7.org/fhir/StructureDefinition/Encounter",
+                    "codeProperty": "type",
+                    "type": "Retrieve",
+                    "codes": {
+                      "name": "Emergency Department Visit",
+                      "type": "ValueSetRef"
+                    }
+                  }
+                }
+              ],
+              "relationship": [],
+              "where": {
+                "type": "And",
+                "operand": [
+                  {
+                    "type": "Equal",
+                    "operand": [
+                      {
+                        "name": "ToString",
+                        "libraryName": "FHIRHelpers",
+                        "type": "FunctionRef",
+                        "operand": [
+                          {
+                            "path": "status",
+                            "scope": "EDVisit",
+                            "type": "Property"
+                          }
+                        ]
+                      },
+                      {
+                        "valueType": "{urn:hl7-org:elm-types:r1}String",
+                        "value": "finished",
+                        "type": "Literal"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "And",
+                    "operand": [
+                      {
+                        "type": "In",
+                        "operand": [
+                          {
+                            "type": "End",
+                            "operand": {
+                              "name": "ToInterval",
+                              "libraryName": "FHIRHelpers",
+                              "type": "FunctionRef",
+                              "operand": [
+                                {
+                                  "path": "period",
+                                  "scope": "EDVisit",
+                                  "type": "Property"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "lowClosed": true,
+                            "highClosed": true,
+                            "type": "Interval",
+                            "low": {
+                              "type": "Subtract",
+                              "operand": [
+                                {
+                                  "type": "Start",
+                                  "operand": {
+                                    "name": "ToInterval",
+                                    "libraryName": "FHIRHelpers",
+                                    "type": "FunctionRef",
+                                    "operand": [
+                                      {
+                                        "path": "period",
+                                        "type": "Property",
+                                        "source": {
+                                          "name": "TheEncounter",
+                                          "type": "OperandRef"
+                                        }
+                                      }
+                                    ]
+                                  }
+                                },
+                                {
+                                  "value": 1,
+                                  "unit": "hour",
+                                  "type": "Quantity"
+                                }
+                              ]
+                            },
+                            "high": {
+                              "type": "Start",
+                              "operand": {
+                                "name": "ToInterval",
+                                "libraryName": "FHIRHelpers",
+                                "type": "FunctionRef",
+                                "operand": [
+                                  {
+                                    "path": "period",
+                                    "type": "Property",
+                                    "source": {
+                                      "name": "TheEncounter",
+                                      "type": "OperandRef"
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "type": "Not",
+                        "operand": {
+                          "type": "IsNull",
+                          "operand": {
+                            "type": "Start",
+                            "operand": {
+                              "name": "ToInterval",
+                              "libraryName": "FHIRHelpers",
+                              "type": "FunctionRef",
+                              "operand": [
+                                {
+                                  "path": "period",
+                                  "type": "Property",
+                                  "source": {
+                                    "name": "TheEncounter",
+                                    "type": "OperandRef"
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "operand": [
+            {
+              "name": "TheEncounter",
+              "operandTypeSpecifier": {
+                "name": "{http://hl7.org/fhir}Encounter",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "name": "Hospitalization",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "expression": {
+            "type": "Query",
+            "source": [
+              {
+                "alias": "X",
+                "expression": {
+                  "name": "ED Visit",
+                  "type": "FunctionRef",
+                  "operand": [
+                    {
+                      "name": "TheEncounter",
+                      "type": "OperandRef"
+                    }
+                  ]
+                }
+              }
+            ],
+            "relationship": [],
+            "return": {
+              "expression": {
+                "type": "If",
+                "condition": {
+                  "asType": "{urn:hl7-org:elm-types:r1}Boolean",
+                  "type": "As",
+                  "operand": {
+                    "type": "IsNull",
+                    "operand": {
+                      "name": "X",
+                      "type": "AliasRef"
+                    }
+                  }
+                },
+                "then": {
+                  "name": "ToInterval",
+                  "libraryName": "FHIRHelpers",
+                  "type": "FunctionRef",
+                  "operand": [
+                    {
+                      "path": "period",
+                      "type": "Property",
+                      "source": {
+                        "name": "TheEncounter",
+                        "type": "OperandRef"
+                      }
+                    }
+                  ]
+                },
+                "else": {
+                  "lowClosed": true,
+                  "highClosed": true,
+                  "type": "Interval",
+                  "low": {
+                    "type": "Start",
+                    "operand": {
+                      "name": "ToInterval",
+                      "libraryName": "FHIRHelpers",
+                      "type": "FunctionRef",
+                      "operand": [
+                        {
+                          "path": "period",
+                          "scope": "X",
+                          "type": "Property"
+                        }
+                      ]
+                    }
+                  },
+                  "high": {
+                    "type": "End",
+                    "operand": {
+                      "name": "ToInterval",
+                      "libraryName": "FHIRHelpers",
+                      "type": "FunctionRef",
+                      "operand": [
+                        {
+                          "path": "period",
+                          "type": "Property",
+                          "source": {
+                            "name": "TheEncounter",
+                            "type": "OperandRef"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "operand": [
+            {
+              "name": "TheEncounter",
+              "operandTypeSpecifier": {
+                "name": "{http://hl7.org/fhir}Encounter",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "name": "Hospitalization Locations",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "expression": {
+            "type": "Query",
+            "source": [
+              {
+                "alias": "EDEncounter",
+                "expression": {
+                  "name": "ED Visit",
+                  "type": "FunctionRef",
+                  "operand": [
+                    {
+                      "name": "TheEncounter",
+                      "type": "OperandRef"
+                    }
+                  ]
+                }
+              }
+            ],
+            "relationship": [],
+            "return": {
+              "expression": {
+                "type": "If",
+                "condition": {
+                  "asType": "{urn:hl7-org:elm-types:r1}Boolean",
+                  "type": "As",
+                  "operand": {
+                    "type": "IsNull",
+                    "operand": {
+                      "name": "EDEncounter",
+                      "type": "AliasRef"
+                    }
+                  }
+                },
+                "then": {
+                  "path": "location",
+                  "type": "Property",
+                  "source": {
+                    "name": "TheEncounter",
+                    "type": "OperandRef"
+                  }
+                },
+                "else": {
+                  "type": "Flatten",
+                  "operand": {
+                    "type": "List",
+                    "element": [
+                      {
+                        "path": "location",
+                        "scope": "EDEncounter",
+                        "type": "Property"
+                      },
+                      {
+                        "path": "location",
+                        "type": "Property",
+                        "source": {
+                          "name": "TheEncounter",
+                          "type": "OperandRef"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "operand": [
+            {
+              "name": "TheEncounter",
+              "operandTypeSpecifier": {
+                "name": "{http://hl7.org/fhir}Encounter",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "name": "Hospitalization Length of Stay",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "expression": {
+            "name": "LengthInDays",
+            "type": "FunctionRef",
+            "operand": [
+              {
+                "name": "Hospitalization",
+                "type": "FunctionRef",
+                "operand": [
+                  {
+                    "name": "TheEncounter",
+                    "type": "OperandRef"
+                  }
+                ]
+              }
+            ]
+          },
+          "operand": [
+            {
+              "name": "TheEncounter",
+              "operandTypeSpecifier": {
+                "name": "{http://hl7.org/fhir}Encounter",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "name": "Hospital Admission Time",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "expression": {
+            "type": "Start",
+            "operand": {
+              "name": "Hospitalization",
+              "type": "FunctionRef",
+              "operand": [
+                {
+                  "name": "TheEncounter",
+                  "type": "OperandRef"
+                }
+              ]
+            }
+          },
+          "operand": [
+            {
+              "name": "TheEncounter",
+              "operandTypeSpecifier": {
+                "name": "{http://hl7.org/fhir}Encounter",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "name": "Hospital Discharge Time",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "expression": {
+            "type": "End",
+            "operand": {
+              "name": "ToInterval",
+              "libraryName": "FHIRHelpers",
+              "type": "FunctionRef",
+              "operand": [
+                {
+                  "path": "period",
+                  "type": "Property",
+                  "source": {
+                    "name": "TheEncounter",
+                    "type": "OperandRef"
+                  }
+                }
+              ]
+            }
+          },
+          "operand": [
+            {
+              "name": "TheEncounter",
+              "operandTypeSpecifier": {
+                "name": "{http://hl7.org/fhir}Encounter",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "name": "Hospital Arrival Time",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "expression": {
+            "type": "Start",
+            "operand": {
+              "name": "ToInterval",
+              "libraryName": "FHIRHelpers",
+              "type": "FunctionRef",
+              "operand": [
+                {
+                  "path": "period",
+                  "type": "Property",
+                  "source": {
+                    "type": "First",
+                    "source": {
+                      "type": "Query",
+                      "source": [
+                        {
+                          "alias": "HospitalLocation",
+                          "expression": {
+                            "name": "Hospitalization Locations",
+                            "type": "FunctionRef",
+                            "operand": [
+                              {
+                                "name": "TheEncounter",
+                                "type": "OperandRef"
+                              }
+                            ]
+                          }
+                        }
+                      ],
+                      "relationship": [],
+                      "sort": {
+                        "by": [
+                          {
+                            "direction": "asc",
+                            "type": "ByExpression",
+                            "expression": {
+                              "type": "Start",
+                              "operand": {
+                                "name": "ToInterval",
+                                "libraryName": "FHIRHelpers",
+                                "type": "FunctionRef",
+                                "operand": [
+                                  {
+                                    "name": "period",
+                                    "type": "IdentifierRef"
+                                  }
+                                ]
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "operand": [
+            {
+              "name": "TheEncounter",
+              "operandTypeSpecifier": {
+                "name": "{http://hl7.org/fhir}Encounter",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "name": "HospitalizationWithObservation",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "expression": {
+            "type": "Query",
+            "source": [
+              {
+                "alias": "Visit",
+                "expression": {
+                  "name": "TheEncounter",
+                  "type": "OperandRef"
+                }
+              }
+            ],
+            "let": [
+              {
+                "identifier": "ObsVisit",
+                "expression": {
+                  "type": "Last",
+                  "source": {
+                    "type": "Query",
+                    "source": [
+                      {
+                        "alias": "LastObs",
+                        "expression": {
+                          "dataType": "{http://hl7.org/fhir}Encounter",
+                          "templateId": "http://hl7.org/fhir/StructureDefinition/Encounter",
+                          "codeProperty": "type",
+                          "type": "Retrieve",
+                          "codes": {
+                            "name": "Observation Services",
+                            "type": "ValueSetRef"
+                          }
+                        }
+                      }
+                    ],
+                    "relationship": [],
+                    "where": {
+                      "type": "And",
+                      "operand": [
+                        {
+                          "type": "In",
+                          "operand": [
+                            {
+                              "type": "End",
+                              "operand": {
+                                "name": "ToInterval",
+                                "libraryName": "FHIRHelpers",
+                                "type": "FunctionRef",
+                                "operand": [
+                                  {
+                                    "path": "period",
+                                    "scope": "LastObs",
+                                    "type": "Property"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "lowClosed": true,
+                              "highClosed": true,
+                              "type": "Interval",
+                              "low": {
+                                "type": "Subtract",
+                                "operand": [
+                                  {
+                                    "type": "Start",
+                                    "operand": {
+                                      "name": "ToInterval",
+                                      "libraryName": "FHIRHelpers",
+                                      "type": "FunctionRef",
+                                      "operand": [
+                                        {
+                                          "path": "period",
+                                          "scope": "Visit",
+                                          "type": "Property"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  {
+                                    "value": 1,
+                                    "unit": "hour",
+                                    "type": "Quantity"
+                                  }
+                                ]
+                              },
+                              "high": {
+                                "type": "Start",
+                                "operand": {
+                                  "name": "ToInterval",
+                                  "libraryName": "FHIRHelpers",
+                                  "type": "FunctionRef",
+                                  "operand": [
+                                    {
+                                      "path": "period",
+                                      "scope": "Visit",
+                                      "type": "Property"
+                                    }
+                                  ]
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "Not",
+                          "operand": {
+                            "type": "IsNull",
+                            "operand": {
+                              "type": "Start",
+                              "operand": {
+                                "name": "ToInterval",
+                                "libraryName": "FHIRHelpers",
+                                "type": "FunctionRef",
+                                "operand": [
+                                  {
+                                    "path": "period",
+                                    "scope": "Visit",
+                                    "type": "Property"
+                                  }
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "sort": {
+                      "by": [
+                        {
+                          "direction": "asc",
+                          "type": "ByExpression",
+                          "expression": {
+                            "type": "End",
+                            "operand": {
+                              "name": "ToInterval",
+                              "libraryName": "FHIRHelpers",
+                              "type": "FunctionRef",
+                              "operand": [
+                                {
+                                  "name": "period",
+                                  "type": "IdentifierRef"
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
+              {
+                "identifier": "VisitStart",
+                "expression": {
+                  "type": "Coalesce",
+                  "operand": [
+                    {
+                      "type": "Start",
+                      "operand": {
+                        "name": "ToInterval",
+                        "libraryName": "FHIRHelpers",
+                        "type": "FunctionRef",
+                        "operand": [
+                          {
+                            "path": "period",
+                            "type": "Property",
+                            "source": {
+                              "name": "ObsVisit",
+                              "type": "QueryLetRef"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "type": "Start",
+                      "operand": {
+                        "name": "ToInterval",
+                        "libraryName": "FHIRHelpers",
+                        "type": "FunctionRef",
+                        "operand": [
+                          {
+                            "path": "period",
+                            "scope": "Visit",
+                            "type": "Property"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "identifier": "EDVisit",
+                "expression": {
+                  "type": "Last",
+                  "source": {
+                    "type": "Query",
+                    "source": [
+                      {
+                        "alias": "LastED",
+                        "expression": {
+                          "dataType": "{http://hl7.org/fhir}Encounter",
+                          "templateId": "http://hl7.org/fhir/StructureDefinition/Encounter",
+                          "codeProperty": "type",
+                          "type": "Retrieve",
+                          "codes": {
+                            "name": "Emergency Department Visit",
+                            "type": "ValueSetRef"
+                          }
+                        }
+                      }
+                    ],
+                    "relationship": [],
+                    "where": {
+                      "type": "And",
+                      "operand": [
+                        {
+                          "type": "In",
+                          "operand": [
+                            {
+                              "type": "End",
+                              "operand": {
+                                "name": "ToInterval",
+                                "libraryName": "FHIRHelpers",
+                                "type": "FunctionRef",
+                                "operand": [
+                                  {
+                                    "path": "period",
+                                    "scope": "LastED",
+                                    "type": "Property"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "lowClosed": true,
+                              "highClosed": true,
+                              "type": "Interval",
+                              "low": {
+                                "type": "Subtract",
+                                "operand": [
+                                  {
+                                    "name": "VisitStart",
+                                    "type": "QueryLetRef"
+                                  },
+                                  {
+                                    "value": 1,
+                                    "unit": "hour",
+                                    "type": "Quantity"
+                                  }
+                                ]
+                              },
+                              "high": {
+                                "name": "VisitStart",
+                                "type": "QueryLetRef"
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "Not",
+                          "operand": {
+                            "type": "IsNull",
+                            "operand": {
+                              "name": "VisitStart",
+                              "type": "QueryLetRef"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "sort": {
+                      "by": [
+                        {
+                          "direction": "asc",
+                          "type": "ByExpression",
+                          "expression": {
+                            "type": "End",
+                            "operand": {
+                              "name": "ToInterval",
+                              "libraryName": "FHIRHelpers",
+                              "type": "FunctionRef",
+                              "operand": [
+                                {
+                                  "name": "period",
+                                  "type": "IdentifierRef"
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            ],
+            "relationship": [],
+            "return": {
+              "expression": {
+                "lowClosed": true,
+                "highClosed": true,
+                "type": "Interval",
+                "low": {
+                  "type": "Coalesce",
+                  "operand": [
+                    {
+                      "type": "Start",
+                      "operand": {
+                        "name": "ToInterval",
+                        "libraryName": "FHIRHelpers",
+                        "type": "FunctionRef",
+                        "operand": [
+                          {
+                            "path": "period",
+                            "type": "Property",
+                            "source": {
+                              "name": "EDVisit",
+                              "type": "QueryLetRef"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "VisitStart",
+                      "type": "QueryLetRef"
+                    }
+                  ]
+                },
+                "high": {
+                  "type": "End",
+                  "operand": {
+                    "name": "ToInterval",
+                    "libraryName": "FHIRHelpers",
+                    "type": "FunctionRef",
+                    "operand": [
+                      {
+                        "path": "period",
+                        "scope": "Visit",
+                        "type": "Property"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "operand": [
+            {
+              "name": "TheEncounter",
+              "operandTypeSpecifier": {
+                "name": "{http://hl7.org/fhir}Encounter",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "name": "HospitalizationWithObservationLengthofStay",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "expression": {
+            "name": "LengthInDays",
+            "type": "FunctionRef",
+            "operand": [
+              {
+                "name": "HospitalizationWithObservation",
+                "type": "FunctionRef",
+                "operand": [
+                  {
+                    "name": "Encounter",
+                    "type": "OperandRef"
+                  }
+                ]
+              }
+            ]
+          },
+          "operand": [
+            {
+              "name": "Encounter",
+              "operandTypeSpecifier": {
+                "name": "{http://hl7.org/fhir}Encounter",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "name": "Normalize Interval",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "expression": {
+            "type": "Case",
+            "caseItem": [
+              {
+                "when": {
+                  "type": "Is",
+                  "operand": {
+                    "name": "choice",
+                    "type": "OperandRef"
+                  },
+                  "isTypeSpecifier": {
+                    "name": "{http://hl7.org/fhir}dateTime",
+                    "type": "NamedTypeSpecifier"
+                  }
+                },
+                "then": {
+                  "lowClosed": true,
+                  "highClosed": true,
+                  "type": "Interval",
+                  "low": {
+                    "name": "ToDateTime",
+                    "libraryName": "FHIRHelpers",
+                    "type": "FunctionRef",
+                    "operand": [
+                      {
+                        "strict": false,
+                        "type": "As",
+                        "operand": {
+                          "name": "choice",
+                          "type": "OperandRef"
+                        },
+                        "asTypeSpecifier": {
+                          "name": "{http://hl7.org/fhir}dateTime",
+                          "type": "NamedTypeSpecifier"
+                        }
+                      }
+                    ]
+                  },
+                  "high": {
+                    "name": "ToDateTime",
+                    "libraryName": "FHIRHelpers",
+                    "type": "FunctionRef",
+                    "operand": [
+                      {
+                        "strict": false,
+                        "type": "As",
+                        "operand": {
+                          "name": "choice",
+                          "type": "OperandRef"
+                        },
+                        "asTypeSpecifier": {
+                          "name": "{http://hl7.org/fhir}dateTime",
+                          "type": "NamedTypeSpecifier"
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "when": {
+                  "type": "Is",
+                  "operand": {
+                    "name": "choice",
+                    "type": "OperandRef"
+                  },
+                  "isTypeSpecifier": {
+                    "name": "{http://hl7.org/fhir}Period",
+                    "type": "NamedTypeSpecifier"
+                  }
+                },
+                "then": {
+                  "name": "ToInterval",
+                  "libraryName": "FHIRHelpers",
+                  "type": "FunctionRef",
+                  "operand": [
+                    {
+                      "strict": false,
+                      "type": "As",
+                      "operand": {
+                        "name": "choice",
+                        "type": "OperandRef"
+                      },
+                      "asTypeSpecifier": {
+                        "name": "{http://hl7.org/fhir}Period",
+                        "type": "NamedTypeSpecifier"
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "when": {
+                  "type": "Is",
+                  "operand": {
+                    "name": "choice",
+                    "type": "OperandRef"
+                  },
+                  "isTypeSpecifier": {
+                    "name": "{http://hl7.org/fhir}instant",
+                    "type": "NamedTypeSpecifier"
+                  }
+                },
+                "then": {
+                  "lowClosed": true,
+                  "highClosed": true,
+                  "type": "Interval",
+                  "low": {
+                    "name": "ToDateTime",
+                    "libraryName": "FHIRHelpers",
+                    "type": "FunctionRef",
+                    "operand": [
+                      {
+                        "strict": false,
+                        "type": "As",
+                        "operand": {
+                          "name": "choice",
+                          "type": "OperandRef"
+                        },
+                        "asTypeSpecifier": {
+                          "name": "{http://hl7.org/fhir}instant",
+                          "type": "NamedTypeSpecifier"
+                        }
+                      }
+                    ]
+                  },
+                  "high": {
+                    "name": "ToDateTime",
+                    "libraryName": "FHIRHelpers",
+                    "type": "FunctionRef",
+                    "operand": [
+                      {
+                        "strict": false,
+                        "type": "As",
+                        "operand": {
+                          "name": "choice",
+                          "type": "OperandRef"
+                        },
+                        "asTypeSpecifier": {
+                          "name": "{http://hl7.org/fhir}instant",
+                          "type": "NamedTypeSpecifier"
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "when": {
+                  "type": "Is",
+                  "operand": {
+                    "name": "choice",
+                    "type": "OperandRef"
+                  },
+                  "isTypeSpecifier": {
+                    "name": "{http://hl7.org/fhir}Age",
+                    "type": "NamedTypeSpecifier"
+                  }
+                },
+                "then": {
+                  "type": "Interval",
+                  "low": {
+                    "type": "ToDateTime",
+                    "operand": {
+                      "path": "low",
+                      "type": "Property",
+                      "source": {
+                        "lowClosed": true,
+                        "highClosed": false,
+                        "type": "Interval",
+                        "low": {
+                          "type": "Add",
+                          "operand": [
+                            {
+                              "name": "ToDate",
+                              "libraryName": "FHIRHelpers",
+                              "type": "FunctionRef",
+                              "operand": [
+                                {
+                                  "path": "birthDate",
+                                  "type": "Property",
+                                  "source": {
+                                    "name": "Patient",
+                                    "type": "ExpressionRef"
+                                  }
+                                }
+                              ]
+                            },
+                            {
+                              "name": "ToQuantity",
+                              "libraryName": "FHIRHelpers",
+                              "type": "FunctionRef",
+                              "operand": [
+                                {
+                                  "strict": false,
+                                  "type": "As",
+                                  "operand": {
+                                    "name": "choice",
+                                    "type": "OperandRef"
+                                  },
+                                  "asTypeSpecifier": {
+                                    "name": "{http://hl7.org/fhir}Age",
+                                    "type": "NamedTypeSpecifier"
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "high": {
+                          "type": "Add",
+                          "operand": [
+                            {
+                              "type": "Add",
+                              "operand": [
+                                {
+                                  "name": "ToDate",
+                                  "libraryName": "FHIRHelpers",
+                                  "type": "FunctionRef",
+                                  "operand": [
+                                    {
+                                      "path": "birthDate",
+                                      "type": "Property",
+                                      "source": {
+                                        "name": "Patient",
+                                        "type": "ExpressionRef"
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "name": "ToQuantity",
+                                  "libraryName": "FHIRHelpers",
+                                  "type": "FunctionRef",
+                                  "operand": [
+                                    {
+                                      "strict": false,
+                                      "type": "As",
+                                      "operand": {
+                                        "name": "choice",
+                                        "type": "OperandRef"
+                                      },
+                                      "asTypeSpecifier": {
+                                        "name": "{http://hl7.org/fhir}Age",
+                                        "type": "NamedTypeSpecifier"
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "value": 1,
+                              "unit": "year",
+                              "type": "Quantity"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "lowClosedExpression": {
+                    "path": "lowClosed",
+                    "type": "Property",
+                    "source": {
+                      "lowClosed": true,
+                      "highClosed": false,
+                      "type": "Interval",
+                      "low": {
+                        "type": "Add",
+                        "operand": [
+                          {
+                            "name": "ToDate",
+                            "libraryName": "FHIRHelpers",
+                            "type": "FunctionRef",
+                            "operand": [
+                              {
+                                "path": "birthDate",
+                                "type": "Property",
+                                "source": {
+                                  "name": "Patient",
+                                  "type": "ExpressionRef"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "name": "ToQuantity",
+                            "libraryName": "FHIRHelpers",
+                            "type": "FunctionRef",
+                            "operand": [
+                              {
+                                "strict": false,
+                                "type": "As",
+                                "operand": {
+                                  "name": "choice",
+                                  "type": "OperandRef"
+                                },
+                                "asTypeSpecifier": {
+                                  "name": "{http://hl7.org/fhir}Age",
+                                  "type": "NamedTypeSpecifier"
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      "high": {
+                        "type": "Add",
+                        "operand": [
+                          {
+                            "type": "Add",
+                            "operand": [
+                              {
+                                "name": "ToDate",
+                                "libraryName": "FHIRHelpers",
+                                "type": "FunctionRef",
+                                "operand": [
+                                  {
+                                    "path": "birthDate",
+                                    "type": "Property",
+                                    "source": {
+                                      "name": "Patient",
+                                      "type": "ExpressionRef"
+                                    }
+                                  }
+                                ]
+                              },
+                              {
+                                "name": "ToQuantity",
+                                "libraryName": "FHIRHelpers",
+                                "type": "FunctionRef",
+                                "operand": [
+                                  {
+                                    "strict": false,
+                                    "type": "As",
+                                    "operand": {
+                                      "name": "choice",
+                                      "type": "OperandRef"
+                                    },
+                                    "asTypeSpecifier": {
+                                      "name": "{http://hl7.org/fhir}Age",
+                                      "type": "NamedTypeSpecifier"
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": 1,
+                            "unit": "year",
+                            "type": "Quantity"
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "high": {
+                    "type": "ToDateTime",
+                    "operand": {
+                      "path": "high",
+                      "type": "Property",
+                      "source": {
+                        "lowClosed": true,
+                        "highClosed": false,
+                        "type": "Interval",
+                        "low": {
+                          "type": "Add",
+                          "operand": [
+                            {
+                              "name": "ToDate",
+                              "libraryName": "FHIRHelpers",
+                              "type": "FunctionRef",
+                              "operand": [
+                                {
+                                  "path": "birthDate",
+                                  "type": "Property",
+                                  "source": {
+                                    "name": "Patient",
+                                    "type": "ExpressionRef"
+                                  }
+                                }
+                              ]
+                            },
+                            {
+                              "name": "ToQuantity",
+                              "libraryName": "FHIRHelpers",
+                              "type": "FunctionRef",
+                              "operand": [
+                                {
+                                  "strict": false,
+                                  "type": "As",
+                                  "operand": {
+                                    "name": "choice",
+                                    "type": "OperandRef"
+                                  },
+                                  "asTypeSpecifier": {
+                                    "name": "{http://hl7.org/fhir}Age",
+                                    "type": "NamedTypeSpecifier"
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "high": {
+                          "type": "Add",
+                          "operand": [
+                            {
+                              "type": "Add",
+                              "operand": [
+                                {
+                                  "name": "ToDate",
+                                  "libraryName": "FHIRHelpers",
+                                  "type": "FunctionRef",
+                                  "operand": [
+                                    {
+                                      "path": "birthDate",
+                                      "type": "Property",
+                                      "source": {
+                                        "name": "Patient",
+                                        "type": "ExpressionRef"
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "name": "ToQuantity",
+                                  "libraryName": "FHIRHelpers",
+                                  "type": "FunctionRef",
+                                  "operand": [
+                                    {
+                                      "strict": false,
+                                      "type": "As",
+                                      "operand": {
+                                        "name": "choice",
+                                        "type": "OperandRef"
+                                      },
+                                      "asTypeSpecifier": {
+                                        "name": "{http://hl7.org/fhir}Age",
+                                        "type": "NamedTypeSpecifier"
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "value": 1,
+                              "unit": "year",
+                              "type": "Quantity"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "highClosedExpression": {
+                    "path": "highClosed",
+                    "type": "Property",
+                    "source": {
+                      "lowClosed": true,
+                      "highClosed": false,
+                      "type": "Interval",
+                      "low": {
+                        "type": "Add",
+                        "operand": [
+                          {
+                            "name": "ToDate",
+                            "libraryName": "FHIRHelpers",
+                            "type": "FunctionRef",
+                            "operand": [
+                              {
+                                "path": "birthDate",
+                                "type": "Property",
+                                "source": {
+                                  "name": "Patient",
+                                  "type": "ExpressionRef"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "name": "ToQuantity",
+                            "libraryName": "FHIRHelpers",
+                            "type": "FunctionRef",
+                            "operand": [
+                              {
+                                "strict": false,
+                                "type": "As",
+                                "operand": {
+                                  "name": "choice",
+                                  "type": "OperandRef"
+                                },
+                                "asTypeSpecifier": {
+                                  "name": "{http://hl7.org/fhir}Age",
+                                  "type": "NamedTypeSpecifier"
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      "high": {
+                        "type": "Add",
+                        "operand": [
+                          {
+                            "type": "Add",
+                            "operand": [
+                              {
+                                "name": "ToDate",
+                                "libraryName": "FHIRHelpers",
+                                "type": "FunctionRef",
+                                "operand": [
+                                  {
+                                    "path": "birthDate",
+                                    "type": "Property",
+                                    "source": {
+                                      "name": "Patient",
+                                      "type": "ExpressionRef"
+                                    }
+                                  }
+                                ]
+                              },
+                              {
+                                "name": "ToQuantity",
+                                "libraryName": "FHIRHelpers",
+                                "type": "FunctionRef",
+                                "operand": [
+                                  {
+                                    "strict": false,
+                                    "type": "As",
+                                    "operand": {
+                                      "name": "choice",
+                                      "type": "OperandRef"
+                                    },
+                                    "asTypeSpecifier": {
+                                      "name": "{http://hl7.org/fhir}Age",
+                                      "type": "NamedTypeSpecifier"
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": 1,
+                            "unit": "year",
+                            "type": "Quantity"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "when": {
+                  "type": "Is",
+                  "operand": {
+                    "name": "choice",
+                    "type": "OperandRef"
+                  },
+                  "isTypeSpecifier": {
+                    "name": "{http://hl7.org/fhir}Range",
+                    "type": "NamedTypeSpecifier"
+                  }
+                },
+                "then": {
+                  "type": "Interval",
+                  "low": {
+                    "type": "ToDateTime",
+                    "operand": {
+                      "path": "low",
+                      "type": "Property",
+                      "source": {
+                        "lowClosed": true,
+                        "highClosed": false,
+                        "type": "Interval",
+                        "low": {
+                          "type": "Add",
+                          "operand": [
+                            {
+                              "name": "ToDate",
+                              "libraryName": "FHIRHelpers",
+                              "type": "FunctionRef",
+                              "operand": [
+                                {
+                                  "path": "birthDate",
+                                  "type": "Property",
+                                  "source": {
+                                    "name": "Patient",
+                                    "type": "ExpressionRef"
+                                  }
+                                }
+                              ]
+                            },
+                            {
+                              "name": "ToQuantity",
+                              "libraryName": "FHIRHelpers",
+                              "type": "FunctionRef",
+                              "operand": [
+                                {
+                                  "path": "low",
+                                  "type": "Property",
+                                  "source": {
+                                    "strict": false,
+                                    "type": "As",
+                                    "operand": {
+                                      "name": "choice",
+                                      "type": "OperandRef"
+                                    },
+                                    "asTypeSpecifier": {
+                                      "name": "{http://hl7.org/fhir}Range",
+                                      "type": "NamedTypeSpecifier"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "high": {
+                          "type": "Add",
+                          "operand": [
+                            {
+                              "type": "Add",
+                              "operand": [
+                                {
+                                  "name": "ToDate",
+                                  "libraryName": "FHIRHelpers",
+                                  "type": "FunctionRef",
+                                  "operand": [
+                                    {
+                                      "path": "birthDate",
+                                      "type": "Property",
+                                      "source": {
+                                        "name": "Patient",
+                                        "type": "ExpressionRef"
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "name": "ToQuantity",
+                                  "libraryName": "FHIRHelpers",
+                                  "type": "FunctionRef",
+                                  "operand": [
+                                    {
+                                      "path": "high",
+                                      "type": "Property",
+                                      "source": {
+                                        "strict": false,
+                                        "type": "As",
+                                        "operand": {
+                                          "name": "choice",
+                                          "type": "OperandRef"
+                                        },
+                                        "asTypeSpecifier": {
+                                          "name": "{http://hl7.org/fhir}Range",
+                                          "type": "NamedTypeSpecifier"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "value": 1,
+                              "unit": "year",
+                              "type": "Quantity"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "lowClosedExpression": {
+                    "path": "lowClosed",
+                    "type": "Property",
+                    "source": {
+                      "lowClosed": true,
+                      "highClosed": false,
+                      "type": "Interval",
+                      "low": {
+                        "type": "Add",
+                        "operand": [
+                          {
+                            "name": "ToDate",
+                            "libraryName": "FHIRHelpers",
+                            "type": "FunctionRef",
+                            "operand": [
+                              {
+                                "path": "birthDate",
+                                "type": "Property",
+                                "source": {
+                                  "name": "Patient",
+                                  "type": "ExpressionRef"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "name": "ToQuantity",
+                            "libraryName": "FHIRHelpers",
+                            "type": "FunctionRef",
+                            "operand": [
+                              {
+                                "path": "low",
+                                "type": "Property",
+                                "source": {
+                                  "strict": false,
+                                  "type": "As",
+                                  "operand": {
+                                    "name": "choice",
+                                    "type": "OperandRef"
+                                  },
+                                  "asTypeSpecifier": {
+                                    "name": "{http://hl7.org/fhir}Range",
+                                    "type": "NamedTypeSpecifier"
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      "high": {
+                        "type": "Add",
+                        "operand": [
+                          {
+                            "type": "Add",
+                            "operand": [
+                              {
+                                "name": "ToDate",
+                                "libraryName": "FHIRHelpers",
+                                "type": "FunctionRef",
+                                "operand": [
+                                  {
+                                    "path": "birthDate",
+                                    "type": "Property",
+                                    "source": {
+                                      "name": "Patient",
+                                      "type": "ExpressionRef"
+                                    }
+                                  }
+                                ]
+                              },
+                              {
+                                "name": "ToQuantity",
+                                "libraryName": "FHIRHelpers",
+                                "type": "FunctionRef",
+                                "operand": [
+                                  {
+                                    "path": "high",
+                                    "type": "Property",
+                                    "source": {
+                                      "strict": false,
+                                      "type": "As",
+                                      "operand": {
+                                        "name": "choice",
+                                        "type": "OperandRef"
+                                      },
+                                      "asTypeSpecifier": {
+                                        "name": "{http://hl7.org/fhir}Range",
+                                        "type": "NamedTypeSpecifier"
+                                      }
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": 1,
+                            "unit": "year",
+                            "type": "Quantity"
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "high": {
+                    "type": "ToDateTime",
+                    "operand": {
+                      "path": "high",
+                      "type": "Property",
+                      "source": {
+                        "lowClosed": true,
+                        "highClosed": false,
+                        "type": "Interval",
+                        "low": {
+                          "type": "Add",
+                          "operand": [
+                            {
+                              "name": "ToDate",
+                              "libraryName": "FHIRHelpers",
+                              "type": "FunctionRef",
+                              "operand": [
+                                {
+                                  "path": "birthDate",
+                                  "type": "Property",
+                                  "source": {
+                                    "name": "Patient",
+                                    "type": "ExpressionRef"
+                                  }
+                                }
+                              ]
+                            },
+                            {
+                              "name": "ToQuantity",
+                              "libraryName": "FHIRHelpers",
+                              "type": "FunctionRef",
+                              "operand": [
+                                {
+                                  "path": "low",
+                                  "type": "Property",
+                                  "source": {
+                                    "strict": false,
+                                    "type": "As",
+                                    "operand": {
+                                      "name": "choice",
+                                      "type": "OperandRef"
+                                    },
+                                    "asTypeSpecifier": {
+                                      "name": "{http://hl7.org/fhir}Range",
+                                      "type": "NamedTypeSpecifier"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "high": {
+                          "type": "Add",
+                          "operand": [
+                            {
+                              "type": "Add",
+                              "operand": [
+                                {
+                                  "name": "ToDate",
+                                  "libraryName": "FHIRHelpers",
+                                  "type": "FunctionRef",
+                                  "operand": [
+                                    {
+                                      "path": "birthDate",
+                                      "type": "Property",
+                                      "source": {
+                                        "name": "Patient",
+                                        "type": "ExpressionRef"
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "name": "ToQuantity",
+                                  "libraryName": "FHIRHelpers",
+                                  "type": "FunctionRef",
+                                  "operand": [
+                                    {
+                                      "path": "high",
+                                      "type": "Property",
+                                      "source": {
+                                        "strict": false,
+                                        "type": "As",
+                                        "operand": {
+                                          "name": "choice",
+                                          "type": "OperandRef"
+                                        },
+                                        "asTypeSpecifier": {
+                                          "name": "{http://hl7.org/fhir}Range",
+                                          "type": "NamedTypeSpecifier"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "value": 1,
+                              "unit": "year",
+                              "type": "Quantity"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "highClosedExpression": {
+                    "path": "highClosed",
+                    "type": "Property",
+                    "source": {
+                      "lowClosed": true,
+                      "highClosed": false,
+                      "type": "Interval",
+                      "low": {
+                        "type": "Add",
+                        "operand": [
+                          {
+                            "name": "ToDate",
+                            "libraryName": "FHIRHelpers",
+                            "type": "FunctionRef",
+                            "operand": [
+                              {
+                                "path": "birthDate",
+                                "type": "Property",
+                                "source": {
+                                  "name": "Patient",
+                                  "type": "ExpressionRef"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "name": "ToQuantity",
+                            "libraryName": "FHIRHelpers",
+                            "type": "FunctionRef",
+                            "operand": [
+                              {
+                                "path": "low",
+                                "type": "Property",
+                                "source": {
+                                  "strict": false,
+                                  "type": "As",
+                                  "operand": {
+                                    "name": "choice",
+                                    "type": "OperandRef"
+                                  },
+                                  "asTypeSpecifier": {
+                                    "name": "{http://hl7.org/fhir}Range",
+                                    "type": "NamedTypeSpecifier"
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      "high": {
+                        "type": "Add",
+                        "operand": [
+                          {
+                            "type": "Add",
+                            "operand": [
+                              {
+                                "name": "ToDate",
+                                "libraryName": "FHIRHelpers",
+                                "type": "FunctionRef",
+                                "operand": [
+                                  {
+                                    "path": "birthDate",
+                                    "type": "Property",
+                                    "source": {
+                                      "name": "Patient",
+                                      "type": "ExpressionRef"
+                                    }
+                                  }
+                                ]
+                              },
+                              {
+                                "name": "ToQuantity",
+                                "libraryName": "FHIRHelpers",
+                                "type": "FunctionRef",
+                                "operand": [
+                                  {
+                                    "path": "high",
+                                    "type": "Property",
+                                    "source": {
+                                      "strict": false,
+                                      "type": "As",
+                                      "operand": {
+                                        "name": "choice",
+                                        "type": "OperandRef"
+                                      },
+                                      "asTypeSpecifier": {
+                                        "name": "{http://hl7.org/fhir}Range",
+                                        "type": "NamedTypeSpecifier"
+                                      }
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": 1,
+                            "unit": "year",
+                            "type": "Quantity"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "when": {
+                  "type": "Is",
+                  "operand": {
+                    "name": "choice",
+                    "type": "OperandRef"
+                  },
+                  "isTypeSpecifier": {
+                    "name": "{http://hl7.org/fhir}Timing",
+                    "type": "NamedTypeSpecifier"
+                  }
+                },
+                "then": {
+                  "type": "Message",
+                  "source": {
+                    "strict": false,
+                    "type": "As",
+                    "operand": {
+                      "type": "Null"
+                    },
+                    "asTypeSpecifier": {
+                      "type": "IntervalTypeSpecifier",
+                      "pointType": {
+                        "name": "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type": "NamedTypeSpecifier"
+                      }
+                    }
+                  },
+                  "condition": {
+                    "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+                    "value": "true",
+                    "type": "Literal"
+                  },
+                  "code": {
+                    "valueType": "{urn:hl7-org:elm-types:r1}String",
+                    "value": "1",
+                    "type": "Literal"
+                  },
+                  "severity": {
+                    "valueType": "{urn:hl7-org:elm-types:r1}String",
+                    "value": "Error",
+                    "type": "Literal"
+                  },
+                  "message": {
+                    "valueType": "{urn:hl7-org:elm-types:r1}String",
+                    "value": "Cannot compute a single interval from a Timing type",
+                    "type": "Literal"
+                  }
+                }
+              },
+              {
+                "when": {
+                  "type": "Is",
+                  "operand": {
+                    "name": "choice",
+                    "type": "OperandRef"
+                  },
+                  "isTypeSpecifier": {
+                    "name": "{http://hl7.org/fhir}string",
+                    "type": "NamedTypeSpecifier"
+                  }
+                },
+                "then": {
+                  "type": "Message",
+                  "source": {
+                    "strict": false,
+                    "type": "As",
+                    "operand": {
+                      "type": "Null"
+                    },
+                    "asTypeSpecifier": {
+                      "type": "IntervalTypeSpecifier",
+                      "pointType": {
+                        "name": "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type": "NamedTypeSpecifier"
+                      }
+                    }
+                  },
+                  "condition": {
+                    "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+                    "value": "true",
+                    "type": "Literal"
+                  },
+                  "code": {
+                    "valueType": "{urn:hl7-org:elm-types:r1}String",
+                    "value": "1",
+                    "type": "Literal"
+                  },
+                  "severity": {
+                    "valueType": "{urn:hl7-org:elm-types:r1}String",
+                    "value": "Error",
+                    "type": "Literal"
+                  },
+                  "message": {
+                    "valueType": "{urn:hl7-org:elm-types:r1}String",
+                    "value": "Cannot compute an interval from a String value",
+                    "type": "Literal"
+                  }
+                }
+              }
+            ],
+            "else": {
+              "strict": false,
+              "type": "As",
+              "operand": {
+                "type": "Null"
+              },
+              "asTypeSpecifier": {
+                "type": "IntervalTypeSpecifier",
+                "pointType": {
+                  "name": "{urn:hl7-org:elm-types:r1}DateTime",
+                  "type": "NamedTypeSpecifier"
+                }
+              }
+            }
+          },
+          "operand": [
+            {
+              "name": "choice",
+              "operandTypeSpecifier": {
+                "type": "ChoiceTypeSpecifier",
+                "choice": [
+                  {
+                    "name": "{http://hl7.org/fhir}dateTime",
+                    "type": "NamedTypeSpecifier"
+                  },
+                  {
+                    "name": "{http://hl7.org/fhir}Period",
+                    "type": "NamedTypeSpecifier"
+                  },
+                  {
+                    "name": "{http://hl7.org/fhir}Timing",
+                    "type": "NamedTypeSpecifier"
+                  },
+                  {
+                    "name": "{http://hl7.org/fhir}instant",
+                    "type": "NamedTypeSpecifier"
+                  },
+                  {
+                    "name": "{http://hl7.org/fhir}string",
+                    "type": "NamedTypeSpecifier"
+                  },
+                  {
+                    "name": "{http://hl7.org/fhir}Age",
+                    "type": "NamedTypeSpecifier"
+                  },
+                  {
+                    "name": "{http://hl7.org/fhir}Range",
+                    "type": "NamedTypeSpecifier"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Normalize Abatement",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "expression": {
+            "type": "If",
+            "condition": {
+              "asType": "{urn:hl7-org:elm-types:r1}Boolean",
+              "type": "As",
+              "operand": {
+                "type": "Is",
+                "operand": {
+                  "path": "abatement",
+                  "type": "Property",
+                  "source": {
+                    "name": "condition",
+                    "type": "OperandRef"
+                  }
+                },
+                "isTypeSpecifier": {
+                  "name": "{http://hl7.org/fhir}dateTime",
+                  "type": "NamedTypeSpecifier"
+                }
+              }
+            },
+            "then": {
+              "lowClosed": true,
+              "highClosed": true,
+              "type": "Interval",
+              "low": {
+                "name": "ToDateTime",
+                "libraryName": "FHIRHelpers",
+                "type": "FunctionRef",
+                "operand": [
+                  {
+                    "strict": false,
+                    "type": "As",
+                    "operand": {
+                      "path": "abatement",
+                      "type": "Property",
+                      "source": {
+                        "name": "condition",
+                        "type": "OperandRef"
+                      }
+                    },
+                    "asTypeSpecifier": {
+                      "name": "{http://hl7.org/fhir}dateTime",
+                      "type": "NamedTypeSpecifier"
+                    }
+                  }
+                ]
+              },
+              "high": {
+                "name": "ToDateTime",
+                "libraryName": "FHIRHelpers",
+                "type": "FunctionRef",
+                "operand": [
+                  {
+                    "strict": false,
+                    "type": "As",
+                    "operand": {
+                      "path": "abatement",
+                      "type": "Property",
+                      "source": {
+                        "name": "condition",
+                        "type": "OperandRef"
+                      }
+                    },
+                    "asTypeSpecifier": {
+                      "name": "{http://hl7.org/fhir}dateTime",
+                      "type": "NamedTypeSpecifier"
+                    }
+                  }
+                ]
+              }
+            },
+            "else": {
+              "type": "If",
+              "condition": {
+                "asType": "{urn:hl7-org:elm-types:r1}Boolean",
+                "type": "As",
+                "operand": {
+                  "type": "Is",
+                  "operand": {
+                    "path": "abatement",
+                    "type": "Property",
+                    "source": {
+                      "name": "condition",
+                      "type": "OperandRef"
+                    }
+                  },
+                  "isTypeSpecifier": {
+                    "name": "{http://hl7.org/fhir}Period",
+                    "type": "NamedTypeSpecifier"
+                  }
+                }
+              },
+              "then": {
+                "name": "ToInterval",
+                "libraryName": "FHIRHelpers",
+                "type": "FunctionRef",
+                "operand": [
+                  {
+                    "strict": false,
+                    "type": "As",
+                    "operand": {
+                      "path": "abatement",
+                      "type": "Property",
+                      "source": {
+                        "name": "condition",
+                        "type": "OperandRef"
+                      }
+                    },
+                    "asTypeSpecifier": {
+                      "name": "{http://hl7.org/fhir}Period",
+                      "type": "NamedTypeSpecifier"
+                    }
+                  }
+                ]
+              },
+              "else": {
+                "type": "If",
+                "condition": {
+                  "asType": "{urn:hl7-org:elm-types:r1}Boolean",
+                  "type": "As",
+                  "operand": {
+                    "type": "Is",
+                    "operand": {
+                      "path": "abatement",
+                      "type": "Property",
+                      "source": {
+                        "name": "condition",
+                        "type": "OperandRef"
+                      }
+                    },
+                    "isTypeSpecifier": {
+                      "name": "{http://hl7.org/fhir}string",
+                      "type": "NamedTypeSpecifier"
+                    }
+                  }
+                },
+                "then": {
+                  "type": "Message",
+                  "source": {
+                    "strict": false,
+                    "type": "As",
+                    "operand": {
+                      "type": "Null"
+                    },
+                    "asTypeSpecifier": {
+                      "type": "IntervalTypeSpecifier",
+                      "pointType": {
+                        "name": "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type": "NamedTypeSpecifier"
+                      }
+                    }
+                  },
+                  "condition": {
+                    "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+                    "value": "true",
+                    "type": "Literal"
+                  },
+                  "code": {
+                    "valueType": "{urn:hl7-org:elm-types:r1}String",
+                    "value": "1",
+                    "type": "Literal"
+                  },
+                  "severity": {
+                    "valueType": "{urn:hl7-org:elm-types:r1}String",
+                    "value": "Error",
+                    "type": "Literal"
+                  },
+                  "message": {
+                    "valueType": "{urn:hl7-org:elm-types:r1}String",
+                    "value": "Cannot compute an interval from a String value",
+                    "type": "Literal"
+                  }
+                },
+                "else": {
+                  "type": "If",
+                  "condition": {
+                    "asType": "{urn:hl7-org:elm-types:r1}Boolean",
+                    "type": "As",
+                    "operand": {
+                      "type": "Is",
+                      "operand": {
+                        "path": "abatement",
+                        "type": "Property",
+                        "source": {
+                          "name": "condition",
+                          "type": "OperandRef"
+                        }
+                      },
+                      "isTypeSpecifier": {
+                        "name": "{http://hl7.org/fhir}Age",
+                        "type": "NamedTypeSpecifier"
+                      }
+                    }
+                  },
+                  "then": {
+                    "type": "Interval",
+                    "low": {
+                      "type": "ToDateTime",
+                      "operand": {
+                        "path": "low",
+                        "type": "Property",
+                        "source": {
+                          "lowClosed": true,
+                          "highClosed": false,
+                          "type": "Interval",
+                          "low": {
+                            "type": "Add",
+                            "operand": [
+                              {
+                                "name": "ToDate",
+                                "libraryName": "FHIRHelpers",
+                                "type": "FunctionRef",
+                                "operand": [
+                                  {
+                                    "path": "birthDate",
+                                    "type": "Property",
+                                    "source": {
+                                      "name": "Patient",
+                                      "type": "ExpressionRef"
+                                    }
+                                  }
+                                ]
+                              },
+                              {
+                                "name": "ToQuantity",
+                                "libraryName": "FHIRHelpers",
+                                "type": "FunctionRef",
+                                "operand": [
+                                  {
+                                    "strict": false,
+                                    "type": "As",
+                                    "operand": {
+                                      "path": "abatement",
+                                      "type": "Property",
+                                      "source": {
+                                        "name": "condition",
+                                        "type": "OperandRef"
+                                      }
+                                    },
+                                    "asTypeSpecifier": {
+                                      "name": "{http://hl7.org/fhir}Age",
+                                      "type": "NamedTypeSpecifier"
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          "high": {
+                            "type": "Add",
+                            "operand": [
+                              {
+                                "type": "Add",
+                                "operand": [
+                                  {
+                                    "name": "ToDate",
+                                    "libraryName": "FHIRHelpers",
+                                    "type": "FunctionRef",
+                                    "operand": [
+                                      {
+                                        "path": "birthDate",
+                                        "type": "Property",
+                                        "source": {
+                                          "name": "Patient",
+                                          "type": "ExpressionRef"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "name": "ToQuantity",
+                                    "libraryName": "FHIRHelpers",
+                                    "type": "FunctionRef",
+                                    "operand": [
+                                      {
+                                        "strict": false,
+                                        "type": "As",
+                                        "operand": {
+                                          "path": "abatement",
+                                          "type": "Property",
+                                          "source": {
+                                            "name": "condition",
+                                            "type": "OperandRef"
+                                          }
+                                        },
+                                        "asTypeSpecifier": {
+                                          "name": "{http://hl7.org/fhir}Age",
+                                          "type": "NamedTypeSpecifier"
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": 1,
+                                "unit": "year",
+                                "type": "Quantity"
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "lowClosedExpression": {
+                      "path": "lowClosed",
+                      "type": "Property",
+                      "source": {
+                        "lowClosed": true,
+                        "highClosed": false,
+                        "type": "Interval",
+                        "low": {
+                          "type": "Add",
+                          "operand": [
+                            {
+                              "name": "ToDate",
+                              "libraryName": "FHIRHelpers",
+                              "type": "FunctionRef",
+                              "operand": [
+                                {
+                                  "path": "birthDate",
+                                  "type": "Property",
+                                  "source": {
+                                    "name": "Patient",
+                                    "type": "ExpressionRef"
+                                  }
+                                }
+                              ]
+                            },
+                            {
+                              "name": "ToQuantity",
+                              "libraryName": "FHIRHelpers",
+                              "type": "FunctionRef",
+                              "operand": [
+                                {
+                                  "strict": false,
+                                  "type": "As",
+                                  "operand": {
+                                    "path": "abatement",
+                                    "type": "Property",
+                                    "source": {
+                                      "name": "condition",
+                                      "type": "OperandRef"
+                                    }
+                                  },
+                                  "asTypeSpecifier": {
+                                    "name": "{http://hl7.org/fhir}Age",
+                                    "type": "NamedTypeSpecifier"
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "high": {
+                          "type": "Add",
+                          "operand": [
+                            {
+                              "type": "Add",
+                              "operand": [
+                                {
+                                  "name": "ToDate",
+                                  "libraryName": "FHIRHelpers",
+                                  "type": "FunctionRef",
+                                  "operand": [
+                                    {
+                                      "path": "birthDate",
+                                      "type": "Property",
+                                      "source": {
+                                        "name": "Patient",
+                                        "type": "ExpressionRef"
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "name": "ToQuantity",
+                                  "libraryName": "FHIRHelpers",
+                                  "type": "FunctionRef",
+                                  "operand": [
+                                    {
+                                      "strict": false,
+                                      "type": "As",
+                                      "operand": {
+                                        "path": "abatement",
+                                        "type": "Property",
+                                        "source": {
+                                          "name": "condition",
+                                          "type": "OperandRef"
+                                        }
+                                      },
+                                      "asTypeSpecifier": {
+                                        "name": "{http://hl7.org/fhir}Age",
+                                        "type": "NamedTypeSpecifier"
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "value": 1,
+                              "unit": "year",
+                              "type": "Quantity"
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    "high": {
+                      "type": "ToDateTime",
+                      "operand": {
+                        "path": "high",
+                        "type": "Property",
+                        "source": {
+                          "lowClosed": true,
+                          "highClosed": false,
+                          "type": "Interval",
+                          "low": {
+                            "type": "Add",
+                            "operand": [
+                              {
+                                "name": "ToDate",
+                                "libraryName": "FHIRHelpers",
+                                "type": "FunctionRef",
+                                "operand": [
+                                  {
+                                    "path": "birthDate",
+                                    "type": "Property",
+                                    "source": {
+                                      "name": "Patient",
+                                      "type": "ExpressionRef"
+                                    }
+                                  }
+                                ]
+                              },
+                              {
+                                "name": "ToQuantity",
+                                "libraryName": "FHIRHelpers",
+                                "type": "FunctionRef",
+                                "operand": [
+                                  {
+                                    "strict": false,
+                                    "type": "As",
+                                    "operand": {
+                                      "path": "abatement",
+                                      "type": "Property",
+                                      "source": {
+                                        "name": "condition",
+                                        "type": "OperandRef"
+                                      }
+                                    },
+                                    "asTypeSpecifier": {
+                                      "name": "{http://hl7.org/fhir}Age",
+                                      "type": "NamedTypeSpecifier"
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          "high": {
+                            "type": "Add",
+                            "operand": [
+                              {
+                                "type": "Add",
+                                "operand": [
+                                  {
+                                    "name": "ToDate",
+                                    "libraryName": "FHIRHelpers",
+                                    "type": "FunctionRef",
+                                    "operand": [
+                                      {
+                                        "path": "birthDate",
+                                        "type": "Property",
+                                        "source": {
+                                          "name": "Patient",
+                                          "type": "ExpressionRef"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "name": "ToQuantity",
+                                    "libraryName": "FHIRHelpers",
+                                    "type": "FunctionRef",
+                                    "operand": [
+                                      {
+                                        "strict": false,
+                                        "type": "As",
+                                        "operand": {
+                                          "path": "abatement",
+                                          "type": "Property",
+                                          "source": {
+                                            "name": "condition",
+                                            "type": "OperandRef"
+                                          }
+                                        },
+                                        "asTypeSpecifier": {
+                                          "name": "{http://hl7.org/fhir}Age",
+                                          "type": "NamedTypeSpecifier"
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": 1,
+                                "unit": "year",
+                                "type": "Quantity"
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "highClosedExpression": {
+                      "path": "highClosed",
+                      "type": "Property",
+                      "source": {
+                        "lowClosed": true,
+                        "highClosed": false,
+                        "type": "Interval",
+                        "low": {
+                          "type": "Add",
+                          "operand": [
+                            {
+                              "name": "ToDate",
+                              "libraryName": "FHIRHelpers",
+                              "type": "FunctionRef",
+                              "operand": [
+                                {
+                                  "path": "birthDate",
+                                  "type": "Property",
+                                  "source": {
+                                    "name": "Patient",
+                                    "type": "ExpressionRef"
+                                  }
+                                }
+                              ]
+                            },
+                            {
+                              "name": "ToQuantity",
+                              "libraryName": "FHIRHelpers",
+                              "type": "FunctionRef",
+                              "operand": [
+                                {
+                                  "strict": false,
+                                  "type": "As",
+                                  "operand": {
+                                    "path": "abatement",
+                                    "type": "Property",
+                                    "source": {
+                                      "name": "condition",
+                                      "type": "OperandRef"
+                                    }
+                                  },
+                                  "asTypeSpecifier": {
+                                    "name": "{http://hl7.org/fhir}Age",
+                                    "type": "NamedTypeSpecifier"
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "high": {
+                          "type": "Add",
+                          "operand": [
+                            {
+                              "type": "Add",
+                              "operand": [
+                                {
+                                  "name": "ToDate",
+                                  "libraryName": "FHIRHelpers",
+                                  "type": "FunctionRef",
+                                  "operand": [
+                                    {
+                                      "path": "birthDate",
+                                      "type": "Property",
+                                      "source": {
+                                        "name": "Patient",
+                                        "type": "ExpressionRef"
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "name": "ToQuantity",
+                                  "libraryName": "FHIRHelpers",
+                                  "type": "FunctionRef",
+                                  "operand": [
+                                    {
+                                      "strict": false,
+                                      "type": "As",
+                                      "operand": {
+                                        "path": "abatement",
+                                        "type": "Property",
+                                        "source": {
+                                          "name": "condition",
+                                          "type": "OperandRef"
+                                        }
+                                      },
+                                      "asTypeSpecifier": {
+                                        "name": "{http://hl7.org/fhir}Age",
+                                        "type": "NamedTypeSpecifier"
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "value": 1,
+                              "unit": "year",
+                              "type": "Quantity"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "else": {
+                    "type": "If",
+                    "condition": {
+                      "asType": "{urn:hl7-org:elm-types:r1}Boolean",
+                      "type": "As",
+                      "operand": {
+                        "type": "Is",
+                        "operand": {
+                          "path": "abatement",
+                          "type": "Property",
+                          "source": {
+                            "name": "condition",
+                            "type": "OperandRef"
+                          }
+                        },
+                        "isTypeSpecifier": {
+                          "name": "{http://hl7.org/fhir}Range",
+                          "type": "NamedTypeSpecifier"
+                        }
+                      }
+                    },
+                    "then": {
+                      "type": "Interval",
+                      "low": {
+                        "type": "ToDateTime",
+                        "operand": {
+                          "path": "low",
+                          "type": "Property",
+                          "source": {
+                            "lowClosed": true,
+                            "highClosed": false,
+                            "type": "Interval",
+                            "low": {
+                              "type": "Add",
+                              "operand": [
+                                {
+                                  "name": "ToDate",
+                                  "libraryName": "FHIRHelpers",
+                                  "type": "FunctionRef",
+                                  "operand": [
+                                    {
+                                      "path": "birthDate",
+                                      "type": "Property",
+                                      "source": {
+                                        "name": "Patient",
+                                        "type": "ExpressionRef"
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "name": "ToQuantity",
+                                  "libraryName": "FHIRHelpers",
+                                  "type": "FunctionRef",
+                                  "operand": [
+                                    {
+                                      "path": "low",
+                                      "type": "Property",
+                                      "source": {
+                                        "strict": false,
+                                        "type": "As",
+                                        "operand": {
+                                          "path": "abatement",
+                                          "type": "Property",
+                                          "source": {
+                                            "name": "condition",
+                                            "type": "OperandRef"
+                                          }
+                                        },
+                                        "asTypeSpecifier": {
+                                          "name": "{http://hl7.org/fhir}Range",
+                                          "type": "NamedTypeSpecifier"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            "high": {
+                              "type": "Add",
+                              "operand": [
+                                {
+                                  "type": "Add",
+                                  "operand": [
+                                    {
+                                      "name": "ToDate",
+                                      "libraryName": "FHIRHelpers",
+                                      "type": "FunctionRef",
+                                      "operand": [
+                                        {
+                                          "path": "birthDate",
+                                          "type": "Property",
+                                          "source": {
+                                            "name": "Patient",
+                                            "type": "ExpressionRef"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "name": "ToQuantity",
+                                      "libraryName": "FHIRHelpers",
+                                      "type": "FunctionRef",
+                                      "operand": [
+                                        {
+                                          "path": "high",
+                                          "type": "Property",
+                                          "source": {
+                                            "strict": false,
+                                            "type": "As",
+                                            "operand": {
+                                              "path": "abatement",
+                                              "type": "Property",
+                                              "source": {
+                                                "name": "condition",
+                                                "type": "OperandRef"
+                                              }
+                                            },
+                                            "asTypeSpecifier": {
+                                              "name": "{http://hl7.org/fhir}Range",
+                                              "type": "NamedTypeSpecifier"
+                                            }
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "value": 1,
+                                  "unit": "year",
+                                  "type": "Quantity"
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      "lowClosedExpression": {
+                        "path": "lowClosed",
+                        "type": "Property",
+                        "source": {
+                          "lowClosed": true,
+                          "highClosed": false,
+                          "type": "Interval",
+                          "low": {
+                            "type": "Add",
+                            "operand": [
+                              {
+                                "name": "ToDate",
+                                "libraryName": "FHIRHelpers",
+                                "type": "FunctionRef",
+                                "operand": [
+                                  {
+                                    "path": "birthDate",
+                                    "type": "Property",
+                                    "source": {
+                                      "name": "Patient",
+                                      "type": "ExpressionRef"
+                                    }
+                                  }
+                                ]
+                              },
+                              {
+                                "name": "ToQuantity",
+                                "libraryName": "FHIRHelpers",
+                                "type": "FunctionRef",
+                                "operand": [
+                                  {
+                                    "path": "low",
+                                    "type": "Property",
+                                    "source": {
+                                      "strict": false,
+                                      "type": "As",
+                                      "operand": {
+                                        "path": "abatement",
+                                        "type": "Property",
+                                        "source": {
+                                          "name": "condition",
+                                          "type": "OperandRef"
+                                        }
+                                      },
+                                      "asTypeSpecifier": {
+                                        "name": "{http://hl7.org/fhir}Range",
+                                        "type": "NamedTypeSpecifier"
+                                      }
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          "high": {
+                            "type": "Add",
+                            "operand": [
+                              {
+                                "type": "Add",
+                                "operand": [
+                                  {
+                                    "name": "ToDate",
+                                    "libraryName": "FHIRHelpers",
+                                    "type": "FunctionRef",
+                                    "operand": [
+                                      {
+                                        "path": "birthDate",
+                                        "type": "Property",
+                                        "source": {
+                                          "name": "Patient",
+                                          "type": "ExpressionRef"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "name": "ToQuantity",
+                                    "libraryName": "FHIRHelpers",
+                                    "type": "FunctionRef",
+                                    "operand": [
+                                      {
+                                        "path": "high",
+                                        "type": "Property",
+                                        "source": {
+                                          "strict": false,
+                                          "type": "As",
+                                          "operand": {
+                                            "path": "abatement",
+                                            "type": "Property",
+                                            "source": {
+                                              "name": "condition",
+                                              "type": "OperandRef"
+                                            }
+                                          },
+                                          "asTypeSpecifier": {
+                                            "name": "{http://hl7.org/fhir}Range",
+                                            "type": "NamedTypeSpecifier"
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": 1,
+                                "unit": "year",
+                                "type": "Quantity"
+                              }
+                            ]
+                          }
+                        }
+                      },
+                      "high": {
+                        "type": "ToDateTime",
+                        "operand": {
+                          "path": "high",
+                          "type": "Property",
+                          "source": {
+                            "lowClosed": true,
+                            "highClosed": false,
+                            "type": "Interval",
+                            "low": {
+                              "type": "Add",
+                              "operand": [
+                                {
+                                  "name": "ToDate",
+                                  "libraryName": "FHIRHelpers",
+                                  "type": "FunctionRef",
+                                  "operand": [
+                                    {
+                                      "path": "birthDate",
+                                      "type": "Property",
+                                      "source": {
+                                        "name": "Patient",
+                                        "type": "ExpressionRef"
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "name": "ToQuantity",
+                                  "libraryName": "FHIRHelpers",
+                                  "type": "FunctionRef",
+                                  "operand": [
+                                    {
+                                      "path": "low",
+                                      "type": "Property",
+                                      "source": {
+                                        "strict": false,
+                                        "type": "As",
+                                        "operand": {
+                                          "path": "abatement",
+                                          "type": "Property",
+                                          "source": {
+                                            "name": "condition",
+                                            "type": "OperandRef"
+                                          }
+                                        },
+                                        "asTypeSpecifier": {
+                                          "name": "{http://hl7.org/fhir}Range",
+                                          "type": "NamedTypeSpecifier"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            "high": {
+                              "type": "Add",
+                              "operand": [
+                                {
+                                  "type": "Add",
+                                  "operand": [
+                                    {
+                                      "name": "ToDate",
+                                      "libraryName": "FHIRHelpers",
+                                      "type": "FunctionRef",
+                                      "operand": [
+                                        {
+                                          "path": "birthDate",
+                                          "type": "Property",
+                                          "source": {
+                                            "name": "Patient",
+                                            "type": "ExpressionRef"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "name": "ToQuantity",
+                                      "libraryName": "FHIRHelpers",
+                                      "type": "FunctionRef",
+                                      "operand": [
+                                        {
+                                          "path": "high",
+                                          "type": "Property",
+                                          "source": {
+                                            "strict": false,
+                                            "type": "As",
+                                            "operand": {
+                                              "path": "abatement",
+                                              "type": "Property",
+                                              "source": {
+                                                "name": "condition",
+                                                "type": "OperandRef"
+                                              }
+                                            },
+                                            "asTypeSpecifier": {
+                                              "name": "{http://hl7.org/fhir}Range",
+                                              "type": "NamedTypeSpecifier"
+                                            }
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "value": 1,
+                                  "unit": "year",
+                                  "type": "Quantity"
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      "highClosedExpression": {
+                        "path": "highClosed",
+                        "type": "Property",
+                        "source": {
+                          "lowClosed": true,
+                          "highClosed": false,
+                          "type": "Interval",
+                          "low": {
+                            "type": "Add",
+                            "operand": [
+                              {
+                                "name": "ToDate",
+                                "libraryName": "FHIRHelpers",
+                                "type": "FunctionRef",
+                                "operand": [
+                                  {
+                                    "path": "birthDate",
+                                    "type": "Property",
+                                    "source": {
+                                      "name": "Patient",
+                                      "type": "ExpressionRef"
+                                    }
+                                  }
+                                ]
+                              },
+                              {
+                                "name": "ToQuantity",
+                                "libraryName": "FHIRHelpers",
+                                "type": "FunctionRef",
+                                "operand": [
+                                  {
+                                    "path": "low",
+                                    "type": "Property",
+                                    "source": {
+                                      "strict": false,
+                                      "type": "As",
+                                      "operand": {
+                                        "path": "abatement",
+                                        "type": "Property",
+                                        "source": {
+                                          "name": "condition",
+                                          "type": "OperandRef"
+                                        }
+                                      },
+                                      "asTypeSpecifier": {
+                                        "name": "{http://hl7.org/fhir}Range",
+                                        "type": "NamedTypeSpecifier"
+                                      }
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          "high": {
+                            "type": "Add",
+                            "operand": [
+                              {
+                                "type": "Add",
+                                "operand": [
+                                  {
+                                    "name": "ToDate",
+                                    "libraryName": "FHIRHelpers",
+                                    "type": "FunctionRef",
+                                    "operand": [
+                                      {
+                                        "path": "birthDate",
+                                        "type": "Property",
+                                        "source": {
+                                          "name": "Patient",
+                                          "type": "ExpressionRef"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "name": "ToQuantity",
+                                    "libraryName": "FHIRHelpers",
+                                    "type": "FunctionRef",
+                                    "operand": [
+                                      {
+                                        "path": "high",
+                                        "type": "Property",
+                                        "source": {
+                                          "strict": false,
+                                          "type": "As",
+                                          "operand": {
+                                            "path": "abatement",
+                                            "type": "Property",
+                                            "source": {
+                                              "name": "condition",
+                                              "type": "OperandRef"
+                                            }
+                                          },
+                                          "asTypeSpecifier": {
+                                            "name": "{http://hl7.org/fhir}Range",
+                                            "type": "NamedTypeSpecifier"
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": 1,
+                                "unit": "year",
+                                "type": "Quantity"
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "else": {
+                      "type": "If",
+                      "condition": {
+                        "asType": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "type": "As",
+                        "operand": {
+                          "type": "Is",
+                          "operand": {
+                            "path": "abatement",
+                            "type": "Property",
+                            "source": {
+                              "name": "condition",
+                              "type": "OperandRef"
+                            }
+                          },
+                          "isTypeSpecifier": {
+                            "name": "{http://hl7.org/fhir}boolean",
+                            "type": "NamedTypeSpecifier"
+                          }
+                        }
+                      },
+                      "then": {
+                        "lowClosed": true,
+                        "highClosed": false,
+                        "type": "Interval",
+                        "low": {
+                          "type": "End",
+                          "operand": {
+                            "name": "Normalize Interval",
+                            "type": "FunctionRef",
+                            "operand": [
+                              {
+                                "path": "onset",
+                                "type": "Property",
+                                "source": {
+                                  "name": "condition",
+                                  "type": "OperandRef"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        "high": {
+                          "name": "ToDateTime",
+                          "libraryName": "FHIRHelpers",
+                          "type": "FunctionRef",
+                          "operand": [
+                            {
+                              "path": "recordedDate",
+                              "type": "Property",
+                              "source": {
+                                "name": "condition",
+                                "type": "OperandRef"
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      "else": {
+                        "type": "As",
+                        "operand": {
+                          "type": "Null"
+                        },
+                        "asTypeSpecifier": {
+                          "type": "IntervalTypeSpecifier",
+                          "pointType": {
+                            "name": "{urn:hl7-org:elm-types:r1}DateTime",
+                            "type": "NamedTypeSpecifier"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "operand": [
+            {
+              "name": "condition",
+              "operandTypeSpecifier": {
+                "name": "{http://hl7.org/fhir}Condition",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "name": "Prevalence Period",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "expression": {
+            "lowClosed": true,
+            "highClosed": false,
+            "type": "Interval",
+            "low": {
+              "type": "Start",
+              "operand": {
+                "name": "Normalize Interval",
+                "type": "FunctionRef",
+                "operand": [
+                  {
+                    "path": "onset",
+                    "type": "Property",
+                    "source": {
+                      "name": "condition",
+                      "type": "OperandRef"
+                    }
+                  }
+                ]
+              }
+            },
+            "high": {
+              "type": "End",
+              "operand": {
+                "name": "Normalize Abatement",
+                "type": "FunctionRef",
+                "operand": [
+                  {
+                    "name": "condition",
+                    "type": "OperandRef"
+                  }
+                ]
+              }
+            }
+          },
+          "operand": [
+            {
+              "name": "condition",
+              "operandTypeSpecifier": {
+                "name": "{http://hl7.org/fhir}Condition",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "name": "GetId",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "expression": {
+            "type": "Last",
+            "source": {
+              "type": "Split",
+              "stringToSplit": {
+                "name": "uri",
+                "type": "OperandRef"
+              },
+              "separator": {
+                "valueType": "{urn:hl7-org:elm-types:r1}String",
+                "value": "/",
+                "type": "Literal"
+              }
+            }
+          },
+          "operand": [
+            {
+              "name": "uri",
+              "operandTypeSpecifier": {
+                "name": "{urn:hl7-org:elm-types:r1}String",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "name": "EncounterDiagnosis",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "expression": {
+            "type": "Query",
+            "source": [
+              {
+                "alias": "D",
+                "expression": {
+                  "path": "diagnosis",
+                  "type": "Property",
+                  "source": {
+                    "name": "Encounter",
+                    "type": "OperandRef"
+                  }
+                }
+              }
+            ],
+            "relationship": [],
+            "return": {
+              "expression": {
+                "type": "SingletonFrom",
+                "operand": {
+                  "type": "Query",
+                  "source": [
+                    {
+                      "alias": "C",
+                      "expression": {
+                        "dataType": "{http://hl7.org/fhir}Condition",
+                        "templateId": "http://hl7.org/fhir/StructureDefinition/Condition",
+                        "type": "Retrieve"
+                      }
+                    }
+                  ],
+                  "relationship": [],
+                  "where": {
+                    "type": "Equal",
+                    "operand": [
+                      {
+                        "name": "ToString",
+                        "libraryName": "FHIRHelpers",
+                        "type": "FunctionRef",
+                        "operand": [
+                          {
+                            "path": "id",
+                            "scope": "C",
+                            "type": "Property"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "GetId",
+                        "type": "FunctionRef",
+                        "operand": [
+                          {
+                            "name": "ToString",
+                            "libraryName": "FHIRHelpers",
+                            "type": "FunctionRef",
+                            "operand": [
+                              {
+                                "path": "reference",
+                                "type": "Property",
+                                "source": {
+                                  "path": "condition",
+                                  "scope": "D",
+                                  "type": "Property"
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "operand": [
+            {
+              "name": "Encounter",
+              "operandTypeSpecifier": {
+                "name": "{http://hl7.org/fhir}Encounter",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "name": "PrincipalDiagnosis",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "expression": {
+            "type": "Query",
+            "source": [
+              {
+                "alias": "PD",
+                "expression": {
+                  "type": "SingletonFrom",
+                  "operand": {
+                    "type": "Query",
+                    "source": [
+                      {
+                        "alias": "D",
+                        "expression": {
+                          "path": "diagnosis",
+                          "type": "Property",
+                          "source": {
+                            "name": "Encounter",
+                            "type": "OperandRef"
+                          }
+                        }
+                      }
+                    ],
+                    "relationship": [],
+                    "where": {
+                      "type": "Equal",
+                      "operand": [
+                        {
+                          "name": "ToInteger",
+                          "libraryName": "FHIRHelpers",
+                          "type": "FunctionRef",
+                          "operand": [
+                            {
+                              "path": "rank",
+                              "scope": "D",
+                              "type": "Property"
+                            }
+                          ]
+                        },
+                        {
+                          "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                          "value": "1",
+                          "type": "Literal"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            ],
+            "relationship": [],
+            "return": {
+              "expression": {
+                "type": "SingletonFrom",
+                "operand": {
+                  "type": "Query",
+                  "source": [
+                    {
+                      "alias": "C",
+                      "expression": {
+                        "dataType": "{http://hl7.org/fhir}Condition",
+                        "templateId": "http://hl7.org/fhir/StructureDefinition/Condition",
+                        "type": "Retrieve"
+                      }
+                    }
+                  ],
+                  "relationship": [],
+                  "where": {
+                    "type": "Equal",
+                    "operand": [
+                      {
+                        "name": "ToString",
+                        "libraryName": "FHIRHelpers",
+                        "type": "FunctionRef",
+                        "operand": [
+                          {
+                            "path": "id",
+                            "scope": "C",
+                            "type": "Property"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "GetId",
+                        "type": "FunctionRef",
+                        "operand": [
+                          {
+                            "name": "ToString",
+                            "libraryName": "FHIRHelpers",
+                            "type": "FunctionRef",
+                            "operand": [
+                              {
+                                "path": "reference",
+                                "type": "Property",
+                                "source": {
+                                  "path": "condition",
+                                  "scope": "PD",
+                                  "type": "Property"
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "operand": [
+            {
+              "name": "Encounter",
+              "operandTypeSpecifier": {
+                "name": "{http://hl7.org/fhir}Encounter",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "name": "GetLocation",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "expression": {
+            "type": "SingletonFrom",
+            "operand": {
+              "type": "Query",
+              "source": [
+                {
+                  "alias": "L",
+                  "expression": {
+                    "dataType": "{http://hl7.org/fhir}Location",
+                    "templateId": "http://hl7.org/fhir/StructureDefinition/Location",
+                    "type": "Retrieve"
+                  }
+                }
+              ],
+              "relationship": [],
+              "where": {
+                "type": "Equal",
+                "operand": [
+                  {
+                    "name": "ToString",
+                    "libraryName": "FHIRHelpers",
+                    "type": "FunctionRef",
+                    "operand": [
+                      {
+                        "path": "id",
+                        "scope": "L",
+                        "type": "Property"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "GetId",
+                    "type": "FunctionRef",
+                    "operand": [
+                      {
+                        "name": "ToString",
+                        "libraryName": "FHIRHelpers",
+                        "type": "FunctionRef",
+                        "operand": [
+                          {
+                            "path": "reference",
+                            "type": "Property",
+                            "source": {
+                              "name": "reference",
+                              "type": "OperandRef"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "operand": [
+            {
+              "name": "reference",
+              "operandTypeSpecifier": {
+                "name": "{http://hl7.org/fhir}Reference",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "name": "GetExtensions",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "expression": {
+            "type": "Query",
+            "source": [
+              {
+                "alias": "E",
+                "expression": {
+                  "path": "extension",
+                  "type": "Property",
+                  "source": {
+                    "name": "domainResource",
+                    "type": "OperandRef"
+                  }
+                }
+              }
+            ],
+            "relationship": [],
+            "where": {
+              "type": "Equal",
+              "operand": [
+                {
+                  "name": "ToString",
+                  "libraryName": "FHIRHelpers",
+                  "type": "FunctionRef",
+                  "operand": [
+                    {
+                      "path": "url",
+                      "scope": "E",
+                      "type": "Property"
+                    }
+                  ]
+                },
+                {
+                  "type": "Concatenate",
+                  "operand": [
+                    {
+                      "valueType": "{urn:hl7-org:elm-types:r1}String",
+                      "value": "http://hl7.org/fhir/us/qicore/StructureDefinition/",
+                      "type": "Literal"
+                    },
+                    {
+                      "name": "url",
+                      "type": "OperandRef"
+                    }
+                  ]
+                }
+              ]
+            },
+            "return": {
+              "expression": {
+                "name": "E",
+                "type": "AliasRef"
+              }
+            }
+          },
+          "operand": [
+            {
+              "name": "domainResource",
+              "operandTypeSpecifier": {
+                "name": "{http://hl7.org/fhir}DomainResource",
+                "type": "NamedTypeSpecifier"
+              }
+            },
+            {
+              "name": "url",
+              "operandTypeSpecifier": {
+                "name": "{urn:hl7-org:elm-types:r1}String",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "name": "GetExtension",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "expression": {
+            "type": "SingletonFrom",
+            "operand": {
+              "name": "GetExtensions",
+              "type": "FunctionRef",
+              "operand": [
+                {
+                  "name": "domainResource",
+                  "type": "OperandRef"
+                },
+                {
+                  "name": "url",
+                  "type": "OperandRef"
+                }
+              ]
+            }
+          },
+          "operand": [
+            {
+              "name": "domainResource",
+              "operandTypeSpecifier": {
+                "name": "{http://hl7.org/fhir}DomainResource",
+                "type": "NamedTypeSpecifier"
+              }
+            },
+            {
+              "name": "url",
+              "operandTypeSpecifier": {
+                "name": "{urn:hl7-org:elm-types:r1}String",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "name": "GetExtensions",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "expression": {
+            "type": "Query",
+            "source": [
+              {
+                "alias": "E",
+                "expression": {
+                  "path": "extension",
+                  "type": "Property",
+                  "source": {
+                    "name": "element",
+                    "type": "OperandRef"
+                  }
+                }
+              }
+            ],
+            "relationship": [],
+            "where": {
+              "type": "Equal",
+              "operand": [
+                {
+                  "name": "ToString",
+                  "libraryName": "FHIRHelpers",
+                  "type": "FunctionRef",
+                  "operand": [
+                    {
+                      "path": "url",
+                      "scope": "E",
+                      "type": "Property"
+                    }
+                  ]
+                },
+                {
+                  "name": "url",
+                  "type": "OperandRef"
+                }
+              ]
+            },
+            "return": {
+              "expression": {
+                "name": "E",
+                "type": "AliasRef"
+              }
+            }
+          },
+          "operand": [
+            {
+              "name": "element",
+              "operandTypeSpecifier": {
+                "name": "{http://hl7.org/fhir}Element",
+                "type": "NamedTypeSpecifier"
+              }
+            },
+            {
+              "name": "url",
+              "operandTypeSpecifier": {
+                "name": "{urn:hl7-org:elm-types:r1}String",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "name": "GetExtension",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "expression": {
+            "type": "SingletonFrom",
+            "operand": {
+              "name": "GetExtensions",
+              "type": "FunctionRef",
+              "operand": [
+                {
+                  "name": "element",
+                  "type": "OperandRef"
+                },
+                {
+                  "name": "url",
+                  "type": "OperandRef"
+                }
+              ]
+            }
+          },
+          "operand": [
+            {
+              "name": "element",
+              "operandTypeSpecifier": {
+                "name": "{http://hl7.org/fhir}Element",
+                "type": "NamedTypeSpecifier"
+              }
+            },
+            {
+              "name": "url",
+              "operandTypeSpecifier": {
+                "name": "{urn:hl7-org:elm-types:r1}String",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "name": "GetBaseExtensions",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "expression": {
+            "type": "Query",
+            "source": [
+              {
+                "alias": "E",
+                "expression": {
+                  "path": "extension",
+                  "type": "Property",
+                  "source": {
+                    "name": "domainResource",
+                    "type": "OperandRef"
+                  }
+                }
+              }
+            ],
+            "relationship": [],
+            "where": {
+              "type": "Equal",
+              "operand": [
+                {
+                  "name": "ToString",
+                  "libraryName": "FHIRHelpers",
+                  "type": "FunctionRef",
+                  "operand": [
+                    {
+                      "path": "url",
+                      "scope": "E",
+                      "type": "Property"
+                    }
+                  ]
+                },
+                {
+                  "type": "Concatenate",
+                  "operand": [
+                    {
+                      "valueType": "{urn:hl7-org:elm-types:r1}String",
+                      "value": "http://hl7.org/fhir/StructureDefinition/",
+                      "type": "Literal"
+                    },
+                    {
+                      "name": "url",
+                      "type": "OperandRef"
+                    }
+                  ]
+                }
+              ]
+            },
+            "return": {
+              "expression": {
+                "name": "E",
+                "type": "AliasRef"
+              }
+            }
+          },
+          "operand": [
+            {
+              "name": "domainResource",
+              "operandTypeSpecifier": {
+                "name": "{http://hl7.org/fhir}DomainResource",
+                "type": "NamedTypeSpecifier"
+              }
+            },
+            {
+              "name": "url",
+              "operandTypeSpecifier": {
+                "name": "{urn:hl7-org:elm-types:r1}String",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "name": "GetBaseExtension",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "expression": {
+            "type": "SingletonFrom",
+            "operand": {
+              "name": "GetBaseExtensions",
+              "type": "FunctionRef",
+              "operand": [
+                {
+                  "name": "domainResource",
+                  "type": "OperandRef"
+                },
+                {
+                  "name": "url",
+                  "type": "OperandRef"
+                }
+              ]
+            }
+          },
+          "operand": [
+            {
+              "name": "domainResource",
+              "operandTypeSpecifier": {
+                "name": "{http://hl7.org/fhir}DomainResource",
+                "type": "NamedTypeSpecifier"
+              }
+            },
+            {
+              "name": "url",
+              "operandTypeSpecifier": {
+                "name": "{urn:hl7-org:elm-types:r1}String",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "name": "GetProvenance",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "expression": {
+            "type": "SingletonFrom",
+            "operand": {
+              "dataType": "{http://hl7.org/fhir}Provenance",
+              "templateId": "http://hl7.org/fhir/StructureDefinition/Provenance",
+              "codeProperty": "target",
+              "type": "Retrieve",
+              "codes": {
+                "type": "ToList",
+                "operand": {
+                  "path": "id",
+                  "type": "Property",
+                  "source": {
+                    "name": "resource",
+                    "type": "OperandRef"
+                  }
+                }
+              }
+            }
+          },
+          "operand": [
+            {
+              "name": "resource",
+              "operandTypeSpecifier": {
+                "name": "{http://hl7.org/fhir}Resource",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "name": "GetMedicationCode",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "expression": {
+            "type": "If",
+            "condition": {
+              "asType": "{urn:hl7-org:elm-types:r1}Boolean",
+              "type": "As",
+              "operand": {
+                "type": "Is",
+                "operand": {
+                  "path": "medication",
+                  "type": "Property",
+                  "source": {
+                    "name": "request",
+                    "type": "OperandRef"
+                  }
+                },
+                "isTypeSpecifier": {
+                  "name": "{http://hl7.org/fhir}CodeableConcept",
+                  "type": "NamedTypeSpecifier"
+                }
+              }
+            },
+            "then": {
+              "strict": false,
+              "type": "As",
+              "operand": {
+                "path": "medication",
+                "type": "Property",
+                "source": {
+                  "name": "request",
+                  "type": "OperandRef"
+                }
+              },
+              "asTypeSpecifier": {
+                "name": "{http://hl7.org/fhir}CodeableConcept",
+                "type": "NamedTypeSpecifier"
+              }
+            },
+            "else": {
+              "path": "code",
+              "type": "Property",
+              "source": {
+                "type": "SingletonFrom",
+                "operand": {
+                  "type": "Query",
+                  "source": [
+                    {
+                      "alias": "M",
+                      "expression": {
+                        "dataType": "{http://hl7.org/fhir}Medication",
+                        "templateId": "http://hl7.org/fhir/StructureDefinition/Medication",
+                        "type": "Retrieve"
+                      }
+                    }
+                  ],
+                  "relationship": [],
+                  "where": {
+                    "type": "Equal",
+                    "operand": [
+                      {
+                        "name": "ToString",
+                        "libraryName": "FHIRHelpers",
+                        "type": "FunctionRef",
+                        "operand": [
+                          {
+                            "path": "id",
+                            "scope": "M",
+                            "type": "Property"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "GetId",
+                        "type": "FunctionRef",
+                        "operand": [
+                          {
+                            "name": "ToString",
+                            "libraryName": "FHIRHelpers",
+                            "type": "FunctionRef",
+                            "operand": [
+                              {
+                                "path": "reference",
+                                "type": "Property",
+                                "source": {
+                                  "strict": false,
+                                  "type": "As",
+                                  "operand": {
+                                    "path": "medication",
+                                    "type": "Property",
+                                    "source": {
+                                      "name": "request",
+                                      "type": "OperandRef"
+                                    }
+                                  },
+                                  "asTypeSpecifier": {
+                                    "name": "{http://hl7.org/fhir}Reference",
+                                    "type": "NamedTypeSpecifier"
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "operand": [
+            {
+              "name": "request",
+              "operandTypeSpecifier": {
+                "name": "{http://hl7.org/fhir}MedicationRequest",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/elm/queries/MATGlobalCommonFunctions.cql
+++ b/test/fixtures/elm/queries/MATGlobalCommonFunctions.cql
@@ -1,0 +1,283 @@
+library MATGlobalCommonFunctions version '5.0.000'
+
+using FHIR version '4.0.1'
+
+include FHIRHelpers version '4.0.1' called FHIRHelpers
+
+codesystem "LOINC": 'http://loinc.org'
+codesystem "SNOMEDCT": 'http://snomed.info/sct/731000124108'
+codesystem "RoleCode": 'http://hl7.org/fhir/v3/RoleCode'
+codesystem "Diagnosis Role": 'http://terminology.hl7.org/CodeSystem/diagnosis-role'
+codesystem "RequestIntent": 'http://terminology.hl7.org/CodeSystem/request-intent'
+codesystem "MedicationRequestCategory": 'http://terminology.hl7.org/CodeSystem/medicationrequest-category'
+codesystem "ConditionClinicalStatusCodes": 'http://terminology.hl7.org/CodeSystem/condition-clinical'
+codesystem "ConditionVerificationStatusCodes": 'http://terminology.hl7.org/CodeSystem/condition-verification'
+codesystem "AllergyIntoleranceClinicalStatusCodes": 'http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical'
+codesystem "AllergyIntoleranceVerificationStatusCodes": 'http://terminology.hl7.org/CodeSystem/allergyintolerance-verification'
+
+valueset "Encounter Inpatient": 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307'
+valueset "Emergency Department Visit": 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292'
+valueset "Observation Services": 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143'
+
+code "Birthdate": '21112-8' from "LOINC" display 'Birth date'
+code "Dead": '419099009' from "SNOMEDCT" display 'Dead'
+code "ER": 'ER' from "RoleCode" display 'Emergency room'
+code "ICU": 'ICU' from "RoleCode" display 'Intensive care unit'
+code "Billing": 'billing' from "Diagnosis Role" display 'Billing'
+
+// Condition Clinical Status Codes - Consider value sets for these
+code "active": 'active' from "ConditionClinicalStatusCodes"
+code "recurrence": 'recurrence' from "ConditionClinicalStatusCodes"
+code "relapse": 'relapse' from "ConditionClinicalStatusCodes"
+code "inactive": 'inactive' from "ConditionClinicalStatusCodes"
+code "remission": 'remission' from "ConditionClinicalStatusCodes"
+code "resolved": 'resolved' from "ConditionClinicalStatusCodes"
+
+// Condition Verification Status Codes - Consider value sets for these
+code "unconfirmed": 'unconfirmed' from ConditionVerificationStatusCodes
+code "provisional": 'provisional' from ConditionVerificationStatusCodes
+code "differential": 'differential' from ConditionVerificationStatusCodes
+code "confirmed": 'confirmed' from ConditionVerificationStatusCodes
+code "refuted": 'refuted' from ConditionVerificationStatusCodes
+code "entered-in-error": 'entered-in-error' from ConditionVerificationStatusCodes
+
+code "allergy-active": 'active' from "AllergyIntoleranceClinicalStatusCodes"
+code "allergy-inactive": 'inactive' from "AllergyIntoleranceClinicalStatusCodes"
+code "allergy-resolved": 'resolved' from "AllergyIntoleranceClinicalStatusCodes"
+
+// Allergy/Intolerance Verification Status Codes - Consider value sets for these
+code "allergy-unconfirmed": 'unconfirmed' from AllergyIntoleranceVerificationStatusCodes
+code "allergy-confirmed": 'confirmed' from AllergyIntoleranceVerificationStatusCodes
+code "allergy-refuted": 'refuted' from AllergyIntoleranceVerificationStatusCodes
+
+// MedicationRequest Category Codes
+code "Community": 'community' from "MedicationRequestCategory" display 'Community'
+code "Discharge": 'discharge' from "MedicationRequestCategory" display 'Discharge'
+
+parameter "Measurement Period" Interval<DateTime>
+  default Interval[@2019-01-01T00:00:00.0, @2020-01-01T00:00:00.0)
+
+context Patient
+
+define "Inpatient Encounter":
+	[Encounter: "Encounter Inpatient"] EncounterInpatient
+		where EncounterInpatient.status = 'finished'
+		    and "LengthInDays"(EncounterInpatient.period) <= 120
+			and EncounterInpatient.period ends during "Measurement Period"
+
+define function "ToDate"(Value DateTime):
+	DateTime(year from Value, month from Value, day from Value, 0, 0, 0, 0, timezoneoffset from Value)
+
+define function "CalendarAgeInDaysAt"(BirthDateTime DateTime, AsOf DateTime):
+	days between ToDate(BirthDateTime)and ToDate(AsOf)
+
+define function "CalendarAgeInDays"(BirthDateTime DateTime):
+	CalendarAgeInDaysAt(BirthDateTime, Today())
+
+define function "CalendarAgeInMonthsAt"(BirthDateTime DateTime, AsOf DateTime):
+	months between ToDate(BirthDateTime)and ToDate(AsOf)
+
+define function "CalendarAgeInMonths"(BirthDateTime DateTime):
+	CalendarAgeInMonthsAt(BirthDateTime, Today())
+
+define function "CalendarAgeInYearsAt"(BirthDateTime DateTime, AsOf DateTime):
+	years between ToDate(BirthDateTime)and ToDate(AsOf)
+
+define function "CalendarAgeInYears"(BirthDateTime DateTime):
+	CalendarAgeInYearsAt(BirthDateTime, Today())
+
+define function "LengthInDays"(Value Interval<DateTime>):
+	difference in days between start of Value and end of Value
+
+define function "ED Visit"(TheEncounter FHIR.Encounter):
+    singleton from (
+        [Encounter: "Emergency Department Visit"] EDVisit
+            where EDVisit.status = 'finished'
+                and EDVisit.period ends 1 hour or less on or before start of FHIRHelpers.ToInterval(TheEncounter.period)
+    )
+
+define function "Hospitalization"(TheEncounter FHIR.Encounter):
+	( "ED Visit"(TheEncounter) ) X
+    return
+        if X is null then TheEncounter.period
+        else Interval[start of FHIRHelpers.ToInterval(X.period), end of FHIRHelpers.ToInterval(TheEncounter.period)]
+
+define function "Hospitalization Locations"(TheEncounter FHIR.Encounter):
+	( "ED Visit"(TheEncounter) ) EDEncounter
+    return
+        if EDEncounter is null then TheEncounter.location
+        else flatten { EDEncounter.location, TheEncounter.location }
+
+define function "Hospitalization Length of Stay"(TheEncounter FHIR.Encounter):
+	LengthInDays("Hospitalization"(TheEncounter))
+
+define function "Hospital Admission Time"(TheEncounter FHIR.Encounter):
+	start of "Hospitalization"(TheEncounter)
+
+define function "Hospital Discharge Time"(TheEncounter FHIR.Encounter):
+	end of FHIRHelpers.ToInterval(TheEncounter.period)
+
+define function "Hospital Arrival Time"(TheEncounter FHIR.Encounter):
+	start of FHIRHelpers.ToInterval(First(
+	    ( "Hospitalization Locations"(TheEncounter) ) HospitalLocation
+			sort by start of FHIRHelpers.ToInterval(period)
+	).period)
+
+define function "HospitalizationWithObservation"(TheEncounter FHIR.Encounter):
+	TheEncounter Visit
+		let ObsVisit: Last([Encounter: "Observation Services"] LastObs
+				where LastObs.period ends 1 hour or less on or before start of Visit.period
+				sort by end of period
+			),
+			VisitStart: Coalesce(start of ObsVisit.period, start of Visit.period),
+			EDVisit: Last([Encounter: "Emergency Department Visit"] LastED
+				where LastED.period ends 1 hour or less on or before VisitStart
+				sort by end of period
+			)
+		return Interval[Coalesce(start of EDVisit.period, VisitStart), end of Visit.period]
+
+define function "HospitalizationWithObservationLengthofStay"(Encounter FHIR.Encounter):
+	"LengthInDays"("HospitalizationWithObservation"(Encounter))
+
+// TODO - fix these (must fetch Location resources and compare id to reference)
+/*define function "Hospital Departure Time"(TheEncounter FHIR.Encounter):
+	end of FHIRHelpers.ToInterval(Last(
+	    ( "Hospitalization Locations"(TheEncounter) ) HospitalLocation
+			sort by start of FHIRHelpers.ToInterval(period)
+	).period)
+
+define function "Emergency Department Arrival Time"(TheEncounter FHIR.Encounter):
+	start of FHIRHelpers.ToInterval((
+	    singleton from (
+	        ( "Hospitalization Locations"(TheEncounter) ) HospitalLocation
+				where HospitalLocation.type ~ "ER"
+		)
+	).period)
+
+define function "First Inpatient Intensive Care Unit"(TheEncounter FHIR.Encounter):
+	First(
+	    ( TheEncounter.location ) HospitalLocation
+			where HospitalLocation.type ~ "ICU"
+				and HospitalLocation.period during TheEncounter.period
+			sort by start of FHIRHelpers.ToInterval(period)
+	)*/
+
+/*
+*
+*    CQFMeasures Common Logic
+*
+*/
+
+define function "Normalize Interval"(choice Choice<FHIR.dateTime, FHIR.Period, FHIR.Timing, FHIR.instant, FHIR.string, FHIR.Age, FHIR.Range>):
+  case
+	  when choice is FHIR.dateTime then
+    	Interval[FHIRHelpers.ToDateTime(choice as FHIR.dateTime), FHIRHelpers.ToDateTime(choice as FHIR.dateTime)]
+		when choice is FHIR.Period then
+  		FHIRHelpers.ToInterval(choice as FHIR.Period)
+		when choice is FHIR.instant then
+			Interval[FHIRHelpers.ToDateTime(choice as FHIR.instant), FHIRHelpers.ToDateTime(choice as FHIR.instant)]
+		when choice is FHIR.Age then
+		  Interval[FHIRHelpers.ToDate(Patient.birthDate) + FHIRHelpers.ToQuantity(choice as FHIR.Age),
+			  FHIRHelpers.ToDate(Patient.birthDate) + FHIRHelpers.ToQuantity(choice as FHIR.Age) + 1 year)
+		when choice is FHIR.Range then
+		  Interval[FHIRHelpers.ToDate(Patient.birthDate) + FHIRHelpers.ToQuantity((choice as FHIR.Range).low),
+			  FHIRHelpers.ToDate(Patient.birthDate) + FHIRHelpers.ToQuantity((choice as FHIR.Range).high) + 1 year)
+		when choice is FHIR.Timing then
+		  Message(null as Interval<DateTime>, true, '1', 'Error', 'Cannot compute a single interval from a Timing type')
+    when choice is FHIR.string then
+      Message(null as Interval<DateTime>, true, '1', 'Error', 'Cannot compute an interval from a String value')
+		else
+			null as Interval<DateTime>
+	end
+
+define function "Normalize Abatement"(condition Condition):
+	if condition.abatement is FHIR.dateTime then
+	  Interval[FHIRHelpers.ToDateTime(condition.abatement as FHIR.dateTime), FHIRHelpers.ToDateTime(condition.abatement as FHIR.dateTime)]
+	else if condition.abatement is FHIR.Period then
+	  FHIRHelpers.ToInterval(condition.abatement as FHIR.Period)
+	else if condition.abatement is FHIR.string then
+    Message(null as Interval<DateTime>, true, '1', 'Error', 'Cannot compute an interval from a String value')
+	else if condition.abatement is FHIR.Age then
+		Interval[FHIRHelpers.ToDate(Patient.birthDate) + FHIRHelpers.ToQuantity(condition.abatement as FHIR.Age),
+			FHIRHelpers.ToDate(Patient.birthDate) + FHIRHelpers.ToQuantity(condition.abatement as FHIR.Age) + 1 year)
+	else if condition.abatement is FHIR.Range then
+	  Interval[FHIRHelpers.ToDate(Patient.birthDate) + FHIRHelpers.ToQuantity((condition.abatement as FHIR.Range).low),
+		  FHIRHelpers.ToDate(Patient.birthDate) + FHIRHelpers.ToQuantity((condition.abatement as FHIR.Range).high) + 1 year)
+	else if condition.abatement is FHIR.boolean then
+	  Interval[end of "Normalize Interval"(condition.onset), condition.recordedDate)
+	else null
+
+define function "Prevalence Period"(condition Condition):
+  Interval[start of "Normalize Interval"(condition.onset), end of "Normalize Abatement"(condition))
+
+define function "GetId"(uri String):
+	Last(Split(uri, '/'))
+
+
+define function "EncounterDiagnosis"(Encounter Encounter):
+  Encounter.diagnosis D
+    return singleton from ([Condition] C where C.id = "GetId"(D.condition.reference))
+
+// Returns the condition that is specified as the principal diagnosis for the encounter
+// TODO: BTR 2019-07-30: Shouldn't need the FHIRHelpers reference here, investigate
+define function "PrincipalDiagnosis"(Encounter Encounter):
+	(singleton from (Encounter.diagnosis D where FHIRHelpers.ToInteger(D.rank) = 1)) PD
+		return singleton from ([Condition] C where C.id = "GetId"(PD.condition.reference))
+
+// Returns the location for the given location reference
+define function GetLocation(reference Reference):
+  singleton from (
+    [Location] L where L.id = GetId(reference.reference)
+  )
+
+/*
+NOTE: Extensions are not the preferred approach, but are used as a way to access
+content that is defined by extensions but not yet surfaced in the
+CQL model info.
+*/
+define function "GetExtensions"(domainResource DomainResource, url String):
+  domainResource.extension E
+	  where E.url = ('http://hl7.org/fhir/us/qicore/StructureDefinition/' + url)
+		return E
+
+define function "GetExtension"(domainResource DomainResource, url String):
+  singleton from "GetExtensions"(domainResource, url)
+
+/*
+NOTE: Extensions are not the preferred approach, but are used as a way to access
+content that is defined by extensions but not yet surfaced in the
+CQL model info.
+*/
+define function "GetExtensions"(element Element, url String):
+  element.extension E
+	  where E.url = (url)
+		return E
+
+define function "GetExtension"(element Element, url String):
+  singleton from "GetExtensions"(element, url)
+
+/*
+NOTE: Extensions are not the preferred approach, but are used as a way to access
+content that is defined by extensions but not yet surfaced in the
+CQL model info.
+*/
+define function "GetBaseExtensions"(domainResource DomainResource, url String):
+  domainResource.extension E
+	  where E.url = ('http://hl7.org/fhir/StructureDefinition/' + url)
+		return E
+
+define function "GetBaseExtension"(domainResource DomainResource, url String):
+  singleton from "GetBaseExtensions"(domainResource, url)
+
+/*
+NOTE: Provenance is not the preferred approach, this is provided only as an illustration
+for what using Provenance could look like, and is not a tested pattern
+*/
+define function "GetProvenance"(resource Resource):
+  singleton from ([Provenance: target in resource.id])
+
+define function "GetMedicationCode"(request MedicationRequest):
+  if request.medication is CodeableConcept then
+	  request.medication as CodeableConcept
+	else
+	  (singleton from ([Medication] M where M.id = GetId((request.medication as Reference).reference))).code

--- a/test/queryFilters/interpretIncludedIn.test.ts
+++ b/test/queryFilters/interpretIncludedIn.test.ts
@@ -1,0 +1,130 @@
+import { getELMFixture } from '../helpers/testHelpers';
+import * as cql from 'cql-execution';
+import * as QueryFilter from '../../src/QueryFilterHelpers';
+import { ELMIncludedIn } from '../../src/types/ELMTypes';
+import { DuringFilter, UnknownFilter } from '../../src/types/QueryFilterTypes';
+
+// to use as a library parameter for tests
+const complexQueryELM = getELMFixture('elm/queries/ComplexQueries.json');
+const START_MP = cql.DateTime.fromJSDate(new Date('2019-01-01T00:00:00Z'), 0);
+const END_MP = cql.DateTime.fromJSDate(new Date('2020-01-01T00:00:00Z'), 0);
+const MP_INTERVAL = new cql.Interval(START_MP, END_MP, true, false);
+
+const INCLUDEDIN_MP: ELMIncludedIn = {
+  localId: '40',
+  locator: '33:11-33:45',
+  type: 'IncludedIn',
+  operand: [
+    {
+      name: 'ToInterval',
+      libraryName: 'FHIRHelpers',
+      type: 'FunctionRef',
+      operand: [
+        {
+          asType: '{http://hl7.org/fhir}Period',
+          type: 'As',
+          operand: {
+            localId: '38',
+            locator: '33:11-33:17',
+            path: 'onset',
+            scope: 'C',
+            type: 'Property'
+          }
+        }
+      ]
+    },
+    {
+      localId: '39',
+      locator: '33:26-33:45',
+      name: 'Measurement Period',
+      type: 'ParameterRef'
+    }
+  ]
+};
+
+// Comparing against another attribute on the same resource. currently not supported.
+const INCLUDEDIN_OTHER_ATTRIBUTE: ELMIncludedIn = {
+  localId: '40',
+  locator: '33:11-33:45',
+  type: 'IncludedIn',
+  operand: [
+    {
+      name: 'ToInterval',
+      libraryName: 'FHIRHelpers',
+      type: 'FunctionRef',
+      operand: [
+        {
+          asType: '{http://hl7.org/fhir}Period',
+          type: 'As',
+          operand: {
+            localId: '38',
+            locator: '33:11-33:17',
+            path: 'onset',
+            scope: 'C',
+            type: 'Property'
+          }
+        }
+      ]
+    },
+    {
+      name: 'ToInterval',
+      libraryName: 'FHIRHelpers',
+      type: 'FunctionRef',
+      operand: [
+        {
+          asType: '{http://hl7.org/fhir}Period',
+          type: 'As',
+          operand: {
+            localId: '38',
+            locator: '33:11-33:17',
+            path: 'abatement',
+            scope: 'C',
+            type: 'Property'
+          }
+        }
+      ]
+    }
+  ]
+};
+
+describe('interpretIncludedIn', () => {
+  test('valid parameter interval ref', () => {
+    const parameters = { 'Measurement Period': MP_INTERVAL };
+    const filter = QueryFilter.interpretIncludedIn(INCLUDEDIN_MP, complexQueryELM, parameters) as DuringFilter;
+    expect(filter.type).toEqual('during');
+    expect(filter.valuePeriod).toEqual({
+      start: '2019-01-01T00:00:00.000Z',
+      end: '2019-12-31T23:59:59.999Z'
+    });
+    expect(filter.alias).toEqual('C');
+    expect(filter.attribute).toEqual('onset');
+  });
+
+  test('invalid type parameter interval ref', () => {
+    const parameters = { 'Measurement Period': START_MP };
+    const filter = QueryFilter.interpretIncludedIn(INCLUDEDIN_MP, complexQueryELM, parameters) as UnknownFilter;
+    expect(filter.type).toEqual('unknown');
+    expect(filter.alias).toEqual('C');
+    expect(filter.attribute).toEqual('onset');
+  });
+
+  test('missing parameter interval ref', () => {
+    const parameters = {};
+    const filter = QueryFilter.interpretIncludedIn(INCLUDEDIN_MP, complexQueryELM, parameters) as UnknownFilter;
+    expect(filter.type).toEqual('unknown');
+    expect(filter.alias).toEqual('C');
+    expect(filter.attribute).toEqual('onset');
+  });
+
+  test('comparison between two attributes. not supported', () => {
+    const parameters = { 'Measurement Period': MP_INTERVAL };
+    const filter = QueryFilter.interpretIncludedIn(
+      INCLUDEDIN_OTHER_ATTRIBUTE,
+      complexQueryELM,
+      parameters
+    ) as UnknownFilter;
+    expect(filter.type).toEqual('unknown');
+    expect(filter.alias).toBeUndefined();
+    expect(filter.attribute).toBeUndefined();
+  });
+});

--- a/test/queryFilters/parseQueryInfo.test.ts
+++ b/test/queryFilters/parseQueryInfo.test.ts
@@ -1,7 +1,7 @@
-import { getELMFixture } from './helpers/testHelpers';
-import { parseQueryInfo } from '../src/QueryFilterHelpers';
+import { getELMFixture } from '../helpers/testHelpers';
+import { parseQueryInfo } from '../../src/QueryFilterHelpers';
 import * as cql from 'cql-execution';
-import { QueryInfo } from '../src/types/QueryFilterTypes';
+import { QueryInfo } from '../../src/types/QueryFilterTypes';
 
 const simpleQueryELM = getELMFixture('elm/queries/SimpleQueries.json');
 const complexQueryELM = getELMFixture('elm/queries/ComplexQueries.json');


### PR DESCRIPTION
# Summary
Initial implementations of parsing query filters into a simpler representation of what is expected of the resources in a query.

## New behavior
Parses the elm for the `where` part of the relevant queries into a simpler representation. This recursively walks through the ELM and interprets what it is able to.

## Code changes
- `src/Calculator.ts`, `src/Execution.ts`, `src/types/Calculator.ts`: Updates to return parameters used for calculation, similarly to how elm is returned now. This is so the parameters (i.e. Measurement Period) be used again for interval re-calculations in the filter parsing. There are additional changes here to call the filter parsing work to add to the information collected about `retrieves` for the gap reports.
- `src/QueryFilterHelpers.ts`: Static functions for parsing query information and filters. **This is the core of this PR.**
- `src/types/CQLExecution.d.ts`: Beefed up type defs for `cql-execution` for more pieces that were used by the filter parsing.
- `src/types/ELMTypes.ts`: Defined much more of the ELM structure for the expression types we use for parsing. The reference for these structures can be found here, https://cql.hl7.org/04-logicalspecification.html#expressions.
- `src/types/QueryFilterTypes.ts`: Typescript fefinitions for the filter representations that come out of the query filter parsing.

# Testing guidance
This works for EXM130. Running a gaps report with debugging on, you will see this new `queryInfo` structure on the retrieve data in the gaps.json debug. Other measures _shouldn't_ break. But filters that cannot parse will be indicated in the output as `{ type: 'unknown' }`.