### PR TITLE
Add parsing of detailed filters modeled onto dataRequirements

### DIFF
--- a/src/DataRequirementHelpers.ts
+++ b/src/DataRequirementHelpers.ts
@@ -1,6 +1,12 @@
 import { R4 } from '@ahryman40k/ts-fhir-types';
 import { EqualsFilter, InFilter, DuringFilter, AndFilter, AnyFilter } from './types/QueryFilterTypes';
 
+/**
+ * Take any nesting of base filters and AND filters and flatten into one list
+ *
+ * @param filter the root filter to flatten
+ * @returns a list of all filters used by this query at one level
+ */
 export function flattenFilters(filter: AnyFilter): AnyFilter[] {
   if (filter.type !== 'and') {
     return [filter];
@@ -14,6 +20,12 @@ export function flattenFilters(filter: AnyFilter): AnyFilter[] {
   }
 }
 
+/**
+ * Map an EqualsFilter or InFilter into a FHIR DataRequirement codeFilter
+ *
+ * @param filter the filter to translate
+ * @returns codeFilter list to be put on the DataRequirement
+ */
 export function generateDetailedCodeFilters(filter: EqualsFilter | InFilter): R4.IDataRequirement_CodeFilter[] {
   if (filter.type === 'equals') {
     const equalsFilter = filter as EqualsFilter;
@@ -49,6 +61,12 @@ export function generateDetailedCodeFilters(filter: EqualsFilter | InFilter): R4
   return [];
 }
 
+/**
+ * Map a during filter into a FHIR DataRequirement dateFilter
+ *
+ * @param filter the "during" filter to map
+ * @returns list with one entry for the dateFilter
+ */
 export function generateDetailedDateFilters(filter: DuringFilter): R4.IDataRequirement_DateFilter[] {
   return [
     {

--- a/src/DataRequirementHelpers.ts
+++ b/src/DataRequirementHelpers.ts
@@ -1,0 +1,59 @@
+import { R4 } from '@ahryman40k/ts-fhir-types';
+import { EqualsFilter, InFilter, DuringFilter, AndFilter, AnyFilter } from './types/QueryFilterTypes';
+
+export function flattenFilters(filter: AnyFilter): AnyFilter[] {
+  if (filter.type !== 'and') {
+    return [filter];
+  } else {
+    const a: AnyFilter[] = [];
+    (filter as AndFilter).children.forEach(c => {
+      a.push(...flattenFilters(c));
+    });
+
+    return a;
+  }
+}
+
+export function generateDetailedCodeFilters(filter: EqualsFilter | InFilter): R4.IDataRequirement_CodeFilter[] {
+  if (filter.type === 'equals') {
+    const equalsFilter = filter as EqualsFilter;
+    if (typeof equalsFilter.value === 'string')
+      return [
+        {
+          path: equalsFilter.attribute,
+          code: [{ code: equalsFilter.value }]
+        }
+      ];
+  } else if (filter.type === 'in') {
+    const inFilter = filter as InFilter;
+
+    if (inFilter.valueList?.every(v => typeof v === 'string')) {
+      return [
+        {
+          path: inFilter.attribute,
+          code: inFilter.valueList.map(v => ({
+            code: v as string
+          }))
+        }
+      ];
+    } else if (filter.valueCodingList) {
+      return [
+        {
+          path: filter.attribute,
+          code: filter.valueCodingList
+        }
+      ];
+    }
+  }
+
+  return [];
+}
+
+export function generateDetailedDateFilters(filter: DuringFilter): R4.IDataRequirement_DateFilter[] {
+  return [
+    {
+      path: filter.attribute,
+      valuePeriod: filter.valuePeriod
+    }
+  ];
+}

--- a/src/DataRequirementHelpers.ts
+++ b/src/DataRequirementHelpers.ts
@@ -24,54 +24,46 @@ export function flattenFilters(filter: AnyFilter): AnyFilter[] {
  * Map an EqualsFilter or InFilter into a FHIR DataRequirement codeFilter
  *
  * @param filter the filter to translate
- * @returns codeFilter list to be put on the DataRequirement
+ * @returns codeFilter to be put on the DataRequirement
  */
-export function generateDetailedCodeFilters(filter: EqualsFilter | InFilter): R4.IDataRequirement_CodeFilter[] {
+export function generateDetailedCodeFilter(filter: EqualsFilter | InFilter): R4.IDataRequirement_CodeFilter | null {
   if (filter.type === 'equals') {
     const equalsFilter = filter as EqualsFilter;
     if (typeof equalsFilter.value === 'string')
-      return [
-        {
-          path: equalsFilter.attribute,
-          code: [{ code: equalsFilter.value }]
-        }
-      ];
+      return {
+        path: equalsFilter.attribute,
+        code: [{ code: equalsFilter.value }]
+      };
   } else if (filter.type === 'in') {
     const inFilter = filter as InFilter;
 
     if (inFilter.valueList?.every(v => typeof v === 'string')) {
-      return [
-        {
-          path: inFilter.attribute,
-          code: inFilter.valueList.map(v => ({
-            code: v as string
-          }))
-        }
-      ];
+      return {
+        path: inFilter.attribute,
+        code: inFilter.valueList.map(v => ({
+          code: v as string
+        }))
+      };
     } else if (filter.valueCodingList) {
-      return [
-        {
-          path: filter.attribute,
-          code: filter.valueCodingList
-        }
-      ];
+      return {
+        path: filter.attribute,
+        code: filter.valueCodingList
+      };
     }
   }
 
-  return [];
+  return null;
 }
 
 /**
  * Map a during filter into a FHIR DataRequirement dateFilter
  *
  * @param filter the "during" filter to map
- * @returns list with one entry for the dateFilter
+ * @returns dateFilter for the dateFilter list of dataRequirement
  */
-export function generateDetailedDateFilters(filter: DuringFilter): R4.IDataRequirement_DateFilter[] {
-  return [
-    {
-      path: filter.attribute,
-      valuePeriod: filter.valuePeriod
-    }
-  ];
+export function generateDetailedDateFilter(filter: DuringFilter): R4.IDataRequirement_DateFilter {
+  return {
+    path: filter.attribute,
+    valuePeriod: filter.valuePeriod
+  };
 }

--- a/src/GapsInCareHelpers.ts
+++ b/src/GapsInCareHelpers.ts
@@ -204,7 +204,7 @@ function stackEntryString(entry: ExpressionStackEntry): string {
 }
 
 /**
- * Genereate FHIR GuidanceReponse resources for queries that are gaps
+ * Generate FHIR GuidanceResponse resources for queries that are gaps
  *
  * @param queries list of all queries that are gaps for this measure
  * @param measureURL fully qualified URL referencing the measure

--- a/src/GapsInCareHelpers.ts
+++ b/src/GapsInCareHelpers.ts
@@ -203,6 +203,14 @@ function stackEntryString(entry: ExpressionStackEntry): string {
   return JSON.stringify(entry);
 }
 
+/**
+ * Genereate FHIR GuidanceReponse resources for queries that are gaps
+ *
+ * @param queries list of all queries that are gaps for this measure
+ * @param measureURL fully qualified URL referencing the measure
+ * @param improvementNotation ImprovementNotation.POSITIVE or ImprovementNotation.NEGATIVE
+ * @returns list of FHIR GuidanceResponse resources with detailed gaps information
+ */
 export function generateGuidanceResponses(
   queries: DataTypeQuery[],
   measureURL: string,

--- a/src/GapsInCareHelpers.ts
+++ b/src/GapsInCareHelpers.ts
@@ -3,6 +3,8 @@ import { v4 as uuidv4 } from 'uuid';
 import { DataTypeQuery, DetailedPopulationGroupResult, ExpressionStackEntry } from './types/Calculator';
 import { ELM, ELMStatement } from './types/ELMTypes';
 import { FinalResult, ImprovementNotation, CareGapReasonCode, CareGapReasonCodeDisplay } from './types/Enums';
+import { flattenFilters, generateDetailedCodeFilters, generateDetailedDateFilters } from './DataRequirementHelpers';
+import { EqualsFilter, InFilter, DuringFilter } from './types/QueryFilterTypes';
 
 /**
  * Get all data types, and codes/valuesets used in Retrieve ELM expressions
@@ -201,20 +203,20 @@ function stackEntryString(entry: ExpressionStackEntry): string {
   return JSON.stringify(entry);
 }
 
-function generateGuidanceResponses(
+export function generateGuidanceResponses(
   queries: DataTypeQuery[],
   measureURL: string,
   improvementNotation: string
 ): R4.IGuidanceResponse[] {
   const guidanceResponses: R4.IGuidanceResponse[] = queries.map(q => {
-    const codeFilter: { path: 'code'; valueSet?: string; code?: [{ code: string; system: string }] } = {
+    const dataTypeCodeFilter: { path: 'code'; valueSet?: string; code?: [{ code: string; system: string }] } = {
       path: 'code'
     };
 
     if (q.valueSet) {
-      codeFilter.valueSet = q.valueSet;
+      dataTypeCodeFilter.valueSet = q.valueSet;
     } else if (q.code) {
-      codeFilter.code = [
+      dataTypeCodeFilter.code = [
         {
           code: q.code.code,
           system: q.code.system
@@ -223,6 +225,7 @@ function generateGuidanceResponses(
     }
 
     // TODO: update system to be full URL once defined
+    // TODO: include logic for other codes based on results of parsed queries
     const gapCoding: R4.ICoding =
       improvementNotation === ImprovementNotation.POSITIVE
         ? {
@@ -239,15 +242,33 @@ function generateGuidanceResponses(
     const gapStatus: R4.ICodeableConcept = {
       coding: [gapCoding]
     };
+
+    const dataRequirement: R4.IDataRequirement = {
+      type: q.dataType,
+      codeFilter: [{ ...dataTypeCodeFilter }]
+    };
+
+    if (q.queryInfo) {
+      const detailedFilters = flattenFilters(q.queryInfo.filter);
+
+      detailedFilters.forEach(df => {
+        if (df.type === 'equals' || df.type === 'in') {
+          dataRequirement.codeFilter?.push(...generateDetailedCodeFilters(df as EqualsFilter | InFilter));
+        } else if (df.type === 'during') {
+          const dateFilters = generateDetailedDateFilters(df as DuringFilter);
+          if (dataRequirement.dateFilter) {
+            dataRequirement.dateFilter.push(...dateFilters);
+          } else {
+            dataRequirement.dateFilter = dateFilters;
+          }
+        }
+      });
+    }
+
     const guidanceResponse: R4.IGuidanceResponse = {
       resourceType: 'GuidanceResponse',
       id: uuidv4(),
-      dataRequirement: [
-        {
-          type: q.dataType,
-          codeFilter: [{ ...codeFilter }]
-        }
-      ],
+      dataRequirement: [dataRequirement],
       reasonCode: [gapStatus],
       status: R4.GuidanceResponseStatusKind._dataRequired,
       moduleUri: measureURL

--- a/src/GapsInCareHelpers.ts
+++ b/src/GapsInCareHelpers.ts
@@ -3,7 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { DataTypeQuery, DetailedPopulationGroupResult, ExpressionStackEntry } from './types/Calculator';
 import { ELM, ELMStatement } from './types/ELMTypes';
 import { FinalResult, ImprovementNotation, CareGapReasonCode, CareGapReasonCodeDisplay } from './types/Enums';
-import { flattenFilters, generateDetailedCodeFilters, generateDetailedDateFilters } from './DataRequirementHelpers';
+import { flattenFilters, generateDetailedCodeFilter, generateDetailedDateFilter } from './DataRequirementHelpers';
 import { EqualsFilter, InFilter, DuringFilter } from './types/QueryFilterTypes';
 
 /**
@@ -261,13 +261,17 @@ export function generateGuidanceResponses(
 
       detailedFilters.forEach(df => {
         if (df.type === 'equals' || df.type === 'in') {
-          dataRequirement.codeFilter?.push(...generateDetailedCodeFilters(df as EqualsFilter | InFilter));
+          const cf = generateDetailedCodeFilter(df as EqualsFilter | InFilter);
+
+          if (cf !== null) {
+            dataRequirement.codeFilter?.push(cf);
+          }
         } else if (df.type === 'during') {
-          const dateFilters = generateDetailedDateFilters(df as DuringFilter);
+          const dateFilter = generateDetailedDateFilter(df as DuringFilter);
           if (dataRequirement.dateFilter) {
-            dataRequirement.dateFilter.push(...dateFilters);
+            dataRequirement.dateFilter.push(dateFilter);
           } else {
-            dataRequirement.dateFilter = dateFilters;
+            dataRequirement.dateFilter = [dateFilter];
           }
         }
       });

--- a/test/DataRequirementHelpers.test.ts
+++ b/test/DataRequirementHelpers.test.ts
@@ -18,7 +18,7 @@ describe('DataRequirementHelpers', () => {
       expect(flattenedFilters[0]).toEqual(equalsFilter);
     });
 
-    test('should flatten and filters', () => {
+    test('should flatten AND filters', () => {
       const equalsFilter0: EqualsFilter = {
         type: 'equals',
         alias: 'R',
@@ -127,7 +127,7 @@ describe('DataRequirementHelpers', () => {
       expect(DataRequirementHelpers.generateDetailedCodeFilter(inf)).toEqual(expectedCodeFilter);
     });
 
-    test('in filter with non-string list should be ignored', () => {
+    test('IN filter with non-string list should be ignored', () => {
       const inf: InFilter = {
         type: 'in',
         alias: 'R',
@@ -138,7 +138,7 @@ describe('DataRequirementHelpers', () => {
       expect(DataRequirementHelpers.generateDetailedCodeFilter(inf)).toBeNull();
     });
 
-    test('in filter should pass through valueCodingList', () => {
+    test('IN filter should pass through valueCodingList', () => {
       const inf: InFilter = {
         type: 'in',
         alias: 'R',

--- a/test/DataRequirementHelpers.test.ts
+++ b/test/DataRequirementHelpers.test.ts
@@ -1,0 +1,59 @@
+import * as DataRequirementHelpers from '../src/DataRequirementHelpers';
+import { AndFilter, EqualsFilter, DuringFilter } from '../src/types/QueryFilterTypes';
+
+describe('DataRequirementHelpers', () => {
+  test('should pass through standard equals filter', () => {
+    const equalsFilter: EqualsFilter = {
+      type: 'equals',
+      alias: 'R',
+      attribute: 'attr-0',
+      value: 'value-0'
+    };
+
+    const flattenedFilters = DataRequirementHelpers.flattenFilters(equalsFilter);
+
+    expect(flattenedFilters).toHaveLength(1);
+    expect(flattenedFilters).toEqual(expect.arrayContaining([expect.objectContaining({ ...equalsFilter })]));
+  });
+
+  test('should flatten and filters', () => {
+    const equalsFilter0: EqualsFilter = {
+      type: 'equals',
+      alias: 'R',
+      attribute: 'attr-0',
+      value: 'value-0'
+    };
+    const equalsFilter1: EqualsFilter = {
+      type: 'equals',
+      alias: 'R',
+      attribute: 'attr-1',
+      value: 'value-1'
+    };
+
+    const duringFilter: DuringFilter = {
+      type: 'during',
+      alias: 'R',
+      attribute: 'attr-3',
+      valuePeriod: {
+        start: '2021-01-01',
+        end: '2021-12-01'
+      }
+    };
+
+    const filter: AndFilter = {
+      type: 'and',
+      children: [equalsFilter0, duringFilter, equalsFilter1]
+    };
+
+    const flattenedFilters = DataRequirementHelpers.flattenFilters(filter);
+
+    expect(flattenedFilters).toHaveLength(3);
+    expect(flattenedFilters).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ ...equalsFilter0 }),
+        expect.objectContaining({ ...equalsFilter1 }),
+        expect.objectContaining({ ...duringFilter })
+      ])
+    );
+  });
+});

--- a/test/DataRequirementHelpers.test.ts
+++ b/test/DataRequirementHelpers.test.ts
@@ -1,59 +1,193 @@
 import * as DataRequirementHelpers from '../src/DataRequirementHelpers';
-import { AndFilter, EqualsFilter, DuringFilter } from '../src/types/QueryFilterTypes';
+import { AndFilter, EqualsFilter, DuringFilter, InFilter } from '../src/types/QueryFilterTypes';
+import { R4 } from '@ahryman40k/ts-fhir-types';
 
 describe('DataRequirementHelpers', () => {
-  test('should pass through standard equals filter', () => {
-    const equalsFilter: EqualsFilter = {
-      type: 'equals',
-      alias: 'R',
-      attribute: 'attr-0',
-      value: 'value-0'
-    };
+  describe('Flatten Filters', () => {
+    test('should pass through standard equals filter', () => {
+      const equalsFilter: EqualsFilter = {
+        type: 'equals',
+        alias: 'R',
+        attribute: 'attr-0',
+        value: 'value-0'
+      };
 
-    const flattenedFilters = DataRequirementHelpers.flattenFilters(equalsFilter);
+      const flattenedFilters = DataRequirementHelpers.flattenFilters(equalsFilter);
 
-    expect(flattenedFilters).toHaveLength(1);
-    expect(flattenedFilters).toEqual(expect.arrayContaining([expect.objectContaining({ ...equalsFilter })]));
+      expect(flattenedFilters).toHaveLength(1);
+      expect(flattenedFilters[0]).toEqual(equalsFilter);
+    });
+
+    test('should flatten and filters', () => {
+      const equalsFilter0: EqualsFilter = {
+        type: 'equals',
+        alias: 'R',
+        attribute: 'attr-0',
+        value: 'value-0'
+      };
+
+      const equalsFilter1: EqualsFilter = {
+        type: 'equals',
+        alias: 'R',
+        attribute: 'attr-1',
+        value: 'value-1'
+      };
+
+      const duringFilter: DuringFilter = {
+        type: 'during',
+        alias: 'R',
+        attribute: 'attr-3',
+        valuePeriod: {
+          start: '2021-01-01',
+          end: '2021-12-01'
+        }
+      };
+
+      const filter: AndFilter = {
+        type: 'and',
+        children: [equalsFilter0, duringFilter, equalsFilter1]
+      };
+
+      const flattenedFilters = DataRequirementHelpers.flattenFilters(filter);
+
+      expect(flattenedFilters).toHaveLength(3);
+      expect(flattenedFilters).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ ...equalsFilter0 }),
+          expect.objectContaining({ ...equalsFilter1 }),
+          expect.objectContaining({ ...duringFilter })
+        ])
+      );
+    });
   });
 
-  test('should flatten and filters', () => {
-    const equalsFilter0: EqualsFilter = {
-      type: 'equals',
-      alias: 'R',
-      attribute: 'attr-0',
-      value: 'value-0'
-    };
-    const equalsFilter1: EqualsFilter = {
-      type: 'equals',
-      alias: 'R',
-      attribute: 'attr-1',
-      value: 'value-1'
-    };
+  describe('Code Filters', () => {
+    test('should return null for non equals or codeFilter', () => {
+      const fakeFilter: any = {
+        type: 'and'
+      };
 
-    const duringFilter: DuringFilter = {
-      type: 'during',
-      alias: 'R',
-      attribute: 'attr-3',
-      valuePeriod: {
-        start: '2021-01-01',
-        end: '2021-12-01'
-      }
-    };
+      expect(DataRequirementHelpers.generateDetailedCodeFilter(fakeFilter)).toBeNull();
+    });
 
-    const filter: AndFilter = {
-      type: 'and',
-      children: [equalsFilter0, duringFilter, equalsFilter1]
-    };
+    test('should return null for equals filter on non-string', () => {
+      const ef: EqualsFilter = {
+        type: 'equals',
+        value: 10,
+        attribute: 'attr-1',
+        alias: 'R'
+      };
 
-    const flattenedFilters = DataRequirementHelpers.flattenFilters(filter);
+      expect(DataRequirementHelpers.generateDetailedCodeFilter(ef)).toBeNull();
+    });
 
-    expect(flattenedFilters).toHaveLength(3);
-    expect(flattenedFilters).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ ...equalsFilter0 }),
-        expect.objectContaining({ ...equalsFilter1 }),
-        expect.objectContaining({ ...duringFilter })
-      ])
-    );
+    test('equals filter should pull off attribute', () => {
+      const ef: EqualsFilter = {
+        type: 'equals',
+        alias: 'R',
+        attribute: 'attr-1',
+        value: 'value-1'
+      };
+
+      const expectedCodeFilter: R4.IDataRequirement_CodeFilter = {
+        path: 'attr-1',
+        code: [
+          {
+            code: 'value-1'
+          }
+        ]
+      };
+
+      expect(DataRequirementHelpers.generateDetailedCodeFilter(ef)).toEqual(expectedCodeFilter);
+    });
+
+    test('in filter should pull off all of valueList', () => {
+      const inf: InFilter = {
+        type: 'in',
+        alias: 'R',
+        attribute: 'attr-1',
+        valueList: ['value-1', 'value-2', 'value-3']
+      };
+
+      const expectedCodeFilter: R4.IDataRequirement_CodeFilter = {
+        path: 'attr-1',
+        code: [
+          {
+            code: 'value-1'
+          },
+          {
+            code: 'value-2'
+          },
+          {
+            code: 'value-3'
+          }
+        ]
+      };
+
+      expect(DataRequirementHelpers.generateDetailedCodeFilter(inf)).toEqual(expectedCodeFilter);
+    });
+
+    test('in filter with non-string list should be ignored', () => {
+      const inf: InFilter = {
+        type: 'in',
+        alias: 'R',
+        attribute: 'attr-1',
+        valueList: [10]
+      };
+
+      expect(DataRequirementHelpers.generateDetailedCodeFilter(inf)).toBeNull();
+    });
+
+    test('in filter should pass through valueCodingList', () => {
+      const inf: InFilter = {
+        type: 'in',
+        alias: 'R',
+        attribute: 'attr-1',
+        valueCodingList: [
+          {
+            system: 'system-1',
+            code: 'code-1',
+            display: 'display-code-1'
+          }
+        ]
+      };
+
+      const expectedCodeFilter: R4.IDataRequirement_CodeFilter = {
+        path: 'attr-1',
+        code: [
+          {
+            system: 'system-1',
+            code: 'code-1',
+            display: 'display-code-1'
+          }
+        ]
+      };
+
+      expect(DataRequirementHelpers.generateDetailedCodeFilter(inf)).toEqual(expectedCodeFilter);
+    });
+  });
+
+  describe('Date Filters', () => {
+    test('should pass through date filter', () => {
+      const df: DuringFilter = {
+        type: 'during',
+        alias: 'R',
+        attribute: 'attr-1',
+        valuePeriod: {
+          start: '2021-01-01',
+          end: '2021-12-31'
+        }
+      };
+
+      const expectedDateFilter: R4.IDataRequirement_DateFilter = {
+        path: 'attr-1',
+        valuePeriod: {
+          start: '2021-01-01',
+          end: '2021-12-31'
+        }
+      };
+
+      expect(DataRequirementHelpers.generateDetailedDateFilter(df)).toEqual(expectedDateFilter);
+    });
   });
 });

--- a/test/DataRequirementHelpers.test.ts
+++ b/test/DataRequirementHelpers.test.ts
@@ -101,7 +101,7 @@ describe('DataRequirementHelpers', () => {
       expect(DataRequirementHelpers.generateDetailedCodeFilter(ef)).toEqual(expectedCodeFilter);
     });
 
-    test('in filter should pull off all of valueList', () => {
+    test('IN filter should pull off all of valueList', () => {
       const inf: InFilter = {
         type: 'in',
         alias: 'R',

--- a/test/GapsInCareHelpers.test.ts
+++ b/test/GapsInCareHelpers.test.ts
@@ -528,7 +528,7 @@ describe('Guidance Response', () => {
     expect(gr.dataRequirement).toEqual(drWithAttributeFilter);
   });
 
-  test('should generate data requirement with in attribute codeFilter', () => {
+  test('should generate data requirement with "in" attribute codeFilter', () => {
     const drWithAttributeFilter: R4.IDataRequirement[] = [
       {
         type: 'Procedure',
@@ -579,7 +579,7 @@ describe('Guidance Response', () => {
     expect(gr.dataRequirement).toEqual(drWithAttributeFilter);
   });
 
-  test('should generate data requirement with in codings attribute codeFilter', () => {
+  test('should generate data requirement with "in" codings attribute codeFilter', () => {
     const drWithAttributeFilter: R4.IDataRequirement[] = [
       {
         type: 'Procedure',

--- a/test/GapsInCareHelpers.test.ts
+++ b/test/GapsInCareHelpers.test.ts
@@ -4,7 +4,8 @@ import {
   generateDetectedIssueResources,
   generateGapsInCareBundle,
   calculateNearMisses,
-  groupGapQueries
+  groupGapQueries,
+  generateGuidanceResponses
 } from '../src/GapsInCareHelpers';
 import { DataTypeQuery, DetailedPopulationGroupResult } from '../src/types/Calculator';
 import { FinalResult, ImprovementNotation } from '../src/types/Enums';
@@ -467,5 +468,299 @@ describe('FHIR Bundle Generation', () => {
         })
       );
     });
+  });
+});
+
+describe('Guidance Response', () => {
+  const baseQuery: DataTypeQuery = {
+    dataType: 'Procedure',
+    valueSet: 'http://example.com/test-vs',
+    retrieveHasResult: true,
+    parentQueryHasResult: false,
+    isNearMiss: true
+  };
+
+  test('should generate data requirement with equals attribute codeFilter', () => {
+    const drWithAttributeFilter: R4.IDataRequirement[] = [
+      {
+        type: 'Procedure',
+        codeFilter: [
+          {
+            path: 'code',
+            valueSet: 'http://example.com/test-vs'
+          },
+          {
+            path: 'status',
+            code: [
+              {
+                code: 'completed'
+              }
+            ]
+          }
+        ]
+      }
+    ];
+
+    const query: DataTypeQuery = {
+      ...baseQuery,
+      queryInfo: {
+        sources: [
+          {
+            alias: 'P',
+            resourceType: 'Procedure'
+          }
+        ],
+        filter: {
+          type: 'equals',
+          alias: 'P',
+          value: 'completed',
+          attribute: 'status'
+        }
+      }
+    };
+
+    const grs = generateGuidanceResponses([query], '', ImprovementNotation.POSITIVE);
+
+    expect(grs).toHaveLength(1);
+
+    const [gr] = grs;
+
+    expect(gr.dataRequirement).toEqual(drWithAttributeFilter);
+  });
+
+  test('should generate data requirement with in attribute codeFilter', () => {
+    const drWithAttributeFilter: R4.IDataRequirement[] = [
+      {
+        type: 'Procedure',
+        codeFilter: [
+          {
+            path: 'code',
+            valueSet: 'http://example.com/test-vs'
+          },
+          {
+            path: 'status',
+            code: [
+              {
+                code: 'completed'
+              },
+              {
+                code: 'amended'
+              }
+            ]
+          }
+        ]
+      }
+    ];
+
+    const query: DataTypeQuery = {
+      ...baseQuery,
+      queryInfo: {
+        sources: [
+          {
+            alias: 'P',
+            resourceType: 'Procedure'
+          }
+        ],
+        filter: {
+          type: 'in',
+          alias: 'P',
+          valueList: ['completed', 'amended'],
+          attribute: 'status'
+        }
+      }
+    };
+
+    const grs = generateGuidanceResponses([query], '', ImprovementNotation.POSITIVE);
+
+    expect(grs).toHaveLength(1);
+
+    const [gr] = grs;
+
+    expect(gr.dataRequirement).toEqual(drWithAttributeFilter);
+  });
+
+  test('should generate data requirement with in codings attribute codeFilter', () => {
+    const drWithAttributeFilter: R4.IDataRequirement[] = [
+      {
+        type: 'Procedure',
+        codeFilter: [
+          {
+            path: 'code',
+            valueSet: 'http://example.com/test-vs'
+          },
+          {
+            path: 'status',
+            code: [
+              {
+                code: 'completed',
+                system: 'http://example.com/system'
+              },
+              {
+                code: 'amended',
+                system: 'http://example.com/system'
+              }
+            ]
+          }
+        ]
+      }
+    ];
+
+    const query: DataTypeQuery = {
+      ...baseQuery,
+      queryInfo: {
+        sources: [
+          {
+            alias: 'P',
+            resourceType: 'Procedure'
+          }
+        ],
+        filter: {
+          type: 'in',
+          alias: 'P',
+          valueCodingList: [
+            {
+              code: 'completed',
+              system: 'http://example.com/system'
+            },
+            {
+              code: 'amended',
+              system: 'http://example.com/system'
+            }
+          ],
+          attribute: 'status'
+        }
+      }
+    };
+
+    const grs = generateGuidanceResponses([query], '', ImprovementNotation.POSITIVE);
+
+    expect(grs).toHaveLength(1);
+
+    const [gr] = grs;
+
+    expect(gr.dataRequirement).toEqual(drWithAttributeFilter);
+  });
+
+  test('should generate data requirement with dateFilter', () => {
+    const drWithDate: R4.IDataRequirement[] = [
+      {
+        type: 'Procedure',
+        codeFilter: [
+          {
+            path: 'code',
+            valueSet: 'http://example.com/test-vs'
+          }
+        ],
+        dateFilter: [
+          {
+            path: 'performed.end',
+            valuePeriod: {
+              start: '2009-12-31',
+              end: '2019-12-31'
+            }
+          }
+        ]
+      }
+    ];
+
+    const query: DataTypeQuery = {
+      ...baseQuery,
+      queryInfo: {
+        sources: [
+          {
+            alias: 'P',
+            resourceType: 'Procedure'
+          }
+        ],
+        filter: {
+          type: 'during',
+          alias: 'P',
+          attribute: 'performed.end',
+          valuePeriod: {
+            start: '2009-12-31',
+            end: '2019-12-31'
+          }
+        }
+      }
+    };
+
+    const grs = generateGuidanceResponses([query], '', ImprovementNotation.POSITIVE);
+
+    expect(grs).toHaveLength(1);
+
+    const [gr] = grs;
+
+    expect(gr.dataRequirement).toEqual(drWithDate);
+  });
+
+  test('should generate combo data requirement with codeFilter and dateFilter', () => {
+    const drWithDateAndCode: R4.IDataRequirement[] = [
+      {
+        type: 'Procedure',
+        codeFilter: [
+          {
+            path: 'code',
+            valueSet: 'http://example.com/test-vs'
+          },
+          {
+            path: 'status',
+            code: [
+              {
+                code: 'completed'
+              }
+            ]
+          }
+        ],
+        dateFilter: [
+          {
+            path: 'performed.end',
+            valuePeriod: {
+              start: '2009-12-31',
+              end: '2019-12-31'
+            }
+          }
+        ]
+      }
+    ];
+
+    const query: DataTypeQuery = {
+      ...baseQuery,
+      queryInfo: {
+        sources: [
+          {
+            alias: 'P',
+            resourceType: 'Procedure'
+          }
+        ],
+        filter: {
+          type: 'and',
+          children: [
+            {
+              type: 'equals',
+              alias: 'P',
+              value: 'completed',
+              attribute: 'status'
+            },
+            {
+              type: 'during',
+              alias: 'P',
+              attribute: 'performed.end',
+              valuePeriod: {
+                start: '2009-12-31',
+                end: '2019-12-31'
+              }
+            }
+          ]
+        }
+      }
+    };
+
+    const grs = generateGuidanceResponses([query], '', ImprovementNotation.POSITIVE);
+
+    expect(grs).toHaveLength(1);
+
+    const [gr] = grs;
+
+    expect(gr.dataRequirement).toEqual(drWithDateAndCode);
   });
 });


### PR DESCRIPTION
# Summary

This PR adds modeling of parsed queryFilters in the form of additional codeFilters (`equals` and `in`) and dateFilters (`during`).

This PR does _not_ include support for smartly modeling the reasonCode based on the failed filter. That is a separate task.

## New behavior

The `dataRequirement` for each `GuidanceResponse` resource could now have additional `codeFilter` entries or a new `dateFilter`, based on what is happening in the query.

For EXM130, there will be another `codeFilter` for `status` for each `GuidanceResponse`, as well as a `dateFilter` for each one, indicating when a specific attribute's performed/effective period should be during.

## Code changes

* New DataRequirementsHelpers file for flattening the queryInfo `and`s and generator functions for additional code or date filters
* Update GuidanceResponse generation to iterate over queryInfo and generate new filters appropraitely
* Unit tests for the above 2

# Testing guidance

* Usual sanity checks
* Behavior can be demonstrated with EXM130 and EXM124 showcasing the new dataRequirement modeling. Other measures should not break but may not have additional info
