### PR TITLE
Reason code parsing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: artiomtr/jest-coverage-report-action@v1.1
         with:
-          github_token: ${{ secrets.ACCESS_TOKEN_CI }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           threshold: 60
 
   integration_test:

--- a/src/Calculator.ts
+++ b/src/Calculator.ts
@@ -317,7 +317,7 @@ export async function calculateGapsInCare(
           }
         });
 
-        retrieves = GapsInCareHelpers.calculateNearMisses(retrieves, improvementNotation);
+        retrieves = GapsInCareHelpers.calculateNearMisses(retrieves, improvementNotation, dr);
 
         const detectedIssues = GapsInCareHelpers.generateDetectedIssueResources(
           retrieves,

--- a/src/DataRequirementHelpers.ts
+++ b/src/DataRequirementHelpers.ts
@@ -64,6 +64,6 @@ export function generateDetailedCodeFilter(filter: EqualsFilter | InFilter): R4.
 export function generateDetailedDateFilter(filter: DuringFilter): R4.IDataRequirement_DateFilter {
   return {
     path: filter.attribute,
-    valuePeriod: filter.valuePeriod
+    valuePeriod: { start: filter.valuePeriod.start, end: filter.valuePeriod.end }
   };
 }

--- a/src/GapsInCareHelpers.ts
+++ b/src/GapsInCareHelpers.ts
@@ -1,10 +1,10 @@
 import { R4 } from '@ahryman40k/ts-fhir-types';
 import { v4 as uuidv4 } from 'uuid';
-import { DataTypeQuery, DetailedPopulationGroupResult, ExpressionStackEntry } from './types/Calculator';
+import { DataTypeQuery, DetailedPopulationGroupResult, ExpressionStackEntry, NearMissInfo } from './types/Calculator';
 import { ELM, ELMStatement } from './types/ELMTypes';
 import { FinalResult, ImprovementNotation, CareGapReasonCode, CareGapReasonCodeDisplay } from './types/Enums';
 import { flattenFilters, generateDetailedCodeFilter, generateDetailedDateFilter } from './DataRequirementHelpers';
-import { EqualsFilter, InFilter, DuringFilter } from './types/QueryFilterTypes';
+import { EqualsFilter, InFilter, DuringFilter, AnyFilter } from './types/QueryFilterTypes';
 
 /**
  * Get all data types, and codes/valuesets used in Retrieve ELM expressions
@@ -232,23 +232,36 @@ export function generateGuidanceResponses(
       ];
     }
 
+    let gapCoding: R4.ICoding[];
+
     // TODO: update system to be full URL once defined
-    // TODO: include logic for other codes based on results of parsed queries
-    const gapCoding: R4.ICoding =
-      improvementNotation === ImprovementNotation.POSITIVE
-        ? {
-            system: 'CareGapReasonCodeSystem',
-            code: CareGapReasonCode.MISSING,
-            display: CareGapReasonCodeDisplay[CareGapReasonCode.MISSING]
-          }
-        : {
-            system: 'CareGapReasonCodeSystem',
-            code: CareGapReasonCode.PRESENT,
-            display: CareGapReasonCodeDisplay[CareGapReasonCode.PRESENT]
-          };
+    if (q.nearMissInfo?.isNearMiss && q.nearMissInfo.reasonCodes) {
+      gapCoding = q.nearMissInfo.reasonCodes.map(c => ({
+        system: 'CareGapReasonCodeSystem',
+        code: c,
+        display: CareGapReasonCodeDisplay[c]
+      }));
+    } else {
+      gapCoding =
+        improvementNotation === ImprovementNotation.POSITIVE
+          ? [
+              {
+                system: 'CareGapReasonCodeSystem',
+                code: CareGapReasonCode.MISSING,
+                display: CareGapReasonCodeDisplay[CareGapReasonCode.MISSING]
+              }
+            ]
+          : [
+              {
+                system: 'CareGapReasonCodeSystem',
+                code: CareGapReasonCode.PRESENT,
+                display: CareGapReasonCodeDisplay[CareGapReasonCode.PRESENT]
+              }
+            ];
+    }
 
     const gapStatus: R4.ICodeableConcept = {
-      coding: [gapCoding]
+      coding: gapCoding
     };
 
     const dataRequirement: R4.IDataRequirement = {
@@ -355,16 +368,90 @@ export function generateGapsInCareBundle(
  *
  * @param retrieves numerator queries from a call to findRetrieves
  * @param improvementNotation string indicating positive or negative improvement notation for the measure being used
+ * @param detailedResult result from calculation to look up clause values
+ * @return mapped list of queries with near miss info if relevant
  */
-export function calculateNearMisses(retrieves: DataTypeQuery[], improvementNotation: string): DataTypeQuery[] {
+export function calculateNearMisses(
+  retrieves: DataTypeQuery[],
+  improvementNotation: string,
+  detailedResult?: DetailedPopulationGroupResult
+): DataTypeQuery[] {
   return retrieves.map(r => {
-    let isNearMiss;
+    let nearMissInfo: NearMissInfo;
     if (improvementNotation === ImprovementNotation.POSITIVE) {
-      isNearMiss = r.retrieveHasResult && !r.parentQueryHasResult;
+      nearMissInfo = {
+        isNearMiss: r.retrieveHasResult === true && r.parentQueryHasResult === false,
+        reasonCodes: []
+      };
+
+      if (nearMissInfo.isNearMiss && r.queryInfo && detailedResult?.clauseResults) {
+        const flattenedFilters = flattenFilters(r.queryInfo.filter);
+
+        flattenedFilters.forEach(f => {
+          // Separate interval handling for 'during' filters
+          if (f.type === 'during') {
+            const duringFilter = f as DuringFilter;
+            const resources = detailedResult.clauseResults?.find(cr => cr.localId === r.retrieveLocalId);
+
+            if (duringFilter.valuePeriod.interval && resources) {
+              const path = duringFilter.attribute.split('.');
+
+              // Access desired property of FHIRObject
+              resources.raw.forEach((r: any) => {
+                let desiredAttr = r;
+                path.forEach(key => {
+                  desiredAttr = desiredAttr[key];
+                });
+
+                // Use DateOutOfRange code if data point is outside of the desired interval
+                const isAttrContainedInInterval = duringFilter.valuePeriod.interval?.contains(desiredAttr.value);
+
+                if (isAttrContainedInInterval === false) {
+                  nearMissInfo.reasonCodes?.push(CareGapReasonCode.DATEOUTOFRANGE);
+                }
+              });
+            }
+          } else {
+            // TODO: This logic is not perfect, and can be corrupted by multiple resources spanning truthy values for all filters
+            // For non-during filters, look up clause result by localId
+            const clauseResult = detailedResult.clauseResults?.find(
+              cr => cr.libraryName === r.libraryName && cr.localId === f.localId
+            );
+
+            // False clause means this specific filter was falsy
+            if (clauseResult && clauseResult.final === FinalResult.FALSE) {
+              const code = getGapReasonCode(f);
+              if (code !== null) {
+                nearMissInfo.reasonCodes?.push(code);
+              }
+            }
+          }
+        });
+      }
+
+      // If no specific near miss reasons found, default is missing
+      if (nearMissInfo.isNearMiss && nearMissInfo.reasonCodes?.length === 0) {
+        nearMissInfo.reasonCodes = [CareGapReasonCode.MISSING];
+      }
     } else {
       // TODO: this can probably be expanded to address negative improvement cases, but it will be a bit more complicated
-      isNearMiss = false;
+      nearMissInfo = {
+        isNearMiss: false
+      };
     }
-    return { ...r, isNearMiss };
+    return { ...r, nearMissInfo };
   });
+}
+
+function getGapReasonCode(filter: AnyFilter): CareGapReasonCode | null {
+  switch (filter.type) {
+    case 'equals':
+    case 'in':
+      return CareGapReasonCode.INVALIDATTRIBUTE;
+    case 'during':
+      return CareGapReasonCode.DATEOUTOFRANGE;
+    default:
+      console.warn(`unknown reasonCode mapping for filter type ${filter.type}`);
+      return null;
+  }
 }

--- a/src/GapsInCareHelpers.ts
+++ b/src/GapsInCareHelpers.ts
@@ -391,7 +391,9 @@ export function calculateNearMisses(
           // Separate interval handling for 'during' filters
           if (f.type === 'during') {
             const duringFilter = f as DuringFilter;
-            const resources = detailedResult.clauseResults?.find(cr => cr.localId === r.retrieveLocalId);
+            const resources = detailedResult.clauseResults?.find(
+              cr => cr.libraryName === r.libraryName && cr.localId === r.retrieveLocalId
+            );
 
             if (duringFilter.valuePeriod.interval && resources) {
               const path = duringFilter.attribute.split('.');
@@ -400,6 +402,10 @@ export function calculateNearMisses(
               resources.raw.forEach((r: any) => {
                 let desiredAttr = r;
                 path.forEach(key => {
+                  if (desiredAttr.value?.isDateTime) {
+                    return;
+                  }
+
                   desiredAttr = desiredAttr[key];
                 });
 

--- a/src/QueryFilterHelpers.ts
+++ b/src/QueryFilterHelpers.ts
@@ -611,6 +611,7 @@ export function executeIntervalELM(
 ): {
   start?: string;
   end?: string;
+  interval?: cql.Interval;
 } | null {
   // make sure the interval created based on property usage from the query source
   const propRefInInterval = findPropertyUsage(intervalExpr, undefined);
@@ -626,7 +627,8 @@ export function executeIntervalELM(
   if (interval != null && interval.start() != null && interval.end() != null) {
     return {
       start: interval.start().toString().replace('+00:00', 'Z'),
-      end: interval.end().toString().replace('+00:00', 'Z')
+      end: interval.end().toString().replace('+00:00', 'Z'),
+      interval
     };
   } else {
     return null;

--- a/src/types/CQLExecution.d.ts
+++ b/src/types/CQLExecution.d.ts
@@ -31,6 +31,7 @@ declare module 'cql-execution' {
     high: any;
     start(): DateTime;
     end(): DateTime;
+    contains(item: any, precision?: any): boolean;
   }
 
   export class Code {

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -224,7 +224,7 @@ export interface NearMissInfo {
   /** whether or not the query is a near miss */
   isNearMiss: boolean;
   /** codes that represent the causes of the near miss */
-  reasonCodes?: CareGapReasonCode[];
+  reasonCodes: CareGapReasonCode[];
 }
 
 /**

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -1,5 +1,5 @@
 import { R4 } from '@ahryman40k/ts-fhir-types';
-import { PopulationType, FinalResult, Relevance } from './Enums';
+import { PopulationType, FinalResult, Relevance, CareGapReasonCode } from './Enums';
 import * as cql from './CQLTypes';
 import { ELM } from './ELMTypes';
 import { QueryInfo } from './QueryFilterTypes';
@@ -213,8 +213,18 @@ export interface DataTypeQuery {
   expressionStack?: ExpressionStackEntry[];
   /** Info about query and how it is filtered. */
   queryInfo?: QueryInfo;
-  /** boolean determining whether a data type query is considered a "near miss" */
-  isNearMiss?: boolean;
+  /** Info about the near miss query */
+  nearMissInfo?: NearMissInfo;
+}
+
+/**
+ * Detailed information about a near-miss query
+ */
+export interface NearMissInfo {
+  /** whether or not the query is a near miss */
+  isNearMiss: boolean;
+  /** codes that represent the causes of the near miss */
+  reasonCodes?: CareGapReasonCode[];
 }
 
 /**

--- a/src/types/Enums.ts
+++ b/src/types/Enums.ts
@@ -96,6 +96,7 @@ export enum ImprovementNotation {
 export enum CareGapReasonCode {
   MISSING = 'Missing',
   PRESENT = 'Present',
+  INVALIDATTRIBUTE = 'InvalidAttribute',
   DATEOUTOFRANGE = 'DateOutOfRange',
   VALUEOUTOFRANGE = 'ValueOutOfRange',
   COUNTOUTOFRANGE = 'CountOutOfRange'
@@ -109,5 +110,6 @@ export const CareGapReasonCodeDisplay = {
   [CareGapReasonCode.PRESENT]: 'Data element was found',
   [CareGapReasonCode.DATEOUTOFRANGE]: 'Key date was not in the expected range',
   [CareGapReasonCode.VALUEOUTOFRANGE]: 'Value was not in the expected range',
-  [CareGapReasonCode.COUNTOUTOFRANGE]: 'Count of data elements was not in the expected range'
+  [CareGapReasonCode.COUNTOUTOFRANGE]: 'Count of data elements was not in the expected range',
+  [CareGapReasonCode.INVALIDATTRIBUTE]: 'Attribute on the data element did not equal desired value'
 };

--- a/src/types/QueryFilterTypes.ts
+++ b/src/types/QueryFilterTypes.ts
@@ -1,4 +1,5 @@
 import { R4 } from '@ahryman40k/ts-fhir-types';
+import * as cql from 'cql-execution';
 
 /** Any type of query filter. */
 export type AnyFilter =
@@ -82,6 +83,7 @@ export interface DuringFilter extends AttributeFilter {
   valuePeriod: {
     start?: string;
     end?: string;
+    interval?: cql.Interval;
   };
 }
 

--- a/test/helpers/queryFilterTestHelpers.ts
+++ b/test/helpers/queryFilterTestHelpers.ts
@@ -1,0 +1,12 @@
+import { DuringFilter } from '../../src/types/QueryFilterTypes';
+
+export function removeIntervalFromFilter(filter: DuringFilter): DuringFilter {
+  const { valuePeriod, ...rest } = filter;
+  return {
+    ...rest,
+    valuePeriod: {
+      start: valuePeriod.start,
+      end: valuePeriod.end
+    }
+  };
+}

--- a/test/queryFilters/interpretIn.test.ts
+++ b/test/queryFilters/interpretIn.test.ts
@@ -300,6 +300,9 @@ const FUNCTION_REF_IN_INTERVAL = {
 describe('interpretIn', () => {
   test('Property starts during two years before end of MP', () => {
     const filter = QueryFilter.interpretIn(IN_STARTS_CALC_AGAINST_MP, complexQueryELM, EXEC_PARAMS) as DuringFilter;
+    if (filter.valuePeriod.interval) {
+      delete filter.valuePeriod.interval;
+    }
     expect(filter.type).toEqual('during');
     expect(filter.valuePeriod).toEqual({
       start: '2017-12-31T23:59:59.999Z',

--- a/test/queryFilters/parseQueryInfo.test.ts
+++ b/test/queryFilters/parseQueryInfo.test.ts
@@ -1,7 +1,8 @@
 import { getELMFixture } from '../helpers/testHelpers';
 import { parseQueryInfo } from '../../src/QueryFilterHelpers';
 import * as cql from 'cql-execution';
-import { QueryInfo } from '../../src/types/QueryFilterTypes';
+import { QueryInfo, DuringFilter, AndFilter } from '../../src/types/QueryFilterTypes';
+import { removeIntervalFromFilter } from '../helpers/queryFilterTestHelpers';
 
 const simpleQueryELM = getELMFixture('elm/queries/SimpleQueries.json');
 const complexQueryELM = getELMFixture('elm/queries/ComplexQueries.json');
@@ -221,6 +222,16 @@ describe('Parse Query Info', () => {
     }
     const queryLocalId = statement.expression.localId;
     const queryInfo = parseQueryInfo(complexQueryELM, queryLocalId, PARAMETERS);
+
+    const filter = queryInfo.filter as AndFilter;
+
+    filter.children = filter.children.map(f => {
+      if (f.type === 'during') {
+        return removeIntervalFromFilter(f as DuringFilter);
+      }
+      return f;
+    });
+
     expect(queryInfo).toEqual(EXPECTED_ENC_TWO_YEAR_BEFORE_END_OF_MP);
   });
 


### PR DESCRIPTION
# Summary

This PR adds additional parsing of `queryInfo` for Gaps to try to identify the proper `reasonCode`(s) to use in the `GuidanceResponse` resources.

The only supported codes currently are `IncorrectAttribute` (e.g. status was supposed to be "final" but isn't), and `DateOutOfRange` (e.g. procedure needed to be performed sometime in 2020 but wasn't).

These reasonCodes only apply for near misses, as any other gaps will result in code "Missing" or "Present" since the retrieve portion of the whole query will be false in that case.

## New behavior

`GuidanceResponse` output for gaps could now have `IncorrectAttribute` or `DateOutOfRange` reasonCodes

## Code changes

* Update near miss structure to include reason code if applicable
* Update near miss function to handle dates and attributes by checking interval contains and clause results respectively
* Update during filter parsing to return the constructed cql interval back to be able to utilize `contains`
* Add tests for new functionality
* Update some query filter tests to properly handle assertions with the newly returned `interval` from during filter parsing
* ....
* ...
* ...
* Update CI to use GITHUB_TOKEN lol

# Testing guidance

To see the new modeling, run gaps for EXM130 with [this patient](https://github.com/DBCG/connectathon/blob/master/fhir401/bundles/measure/EXM130-7.3.000/EXM130-7.3.000-files/tests-denom-EXM130-bundle.json) who has a procedure but the performed period is outside of the desired range.

Ensure that other measures don't break. (E.g. EXM124 should still produce missing for all its gaps if none of them have an attribute/timing mismatch)
