### PR TITLE
Refactor gaps code to separate ELM parsing logic

### DIFF
--- a/src/GapsInCareHelpers.ts
+++ b/src/GapsInCareHelpers.ts
@@ -291,7 +291,7 @@ export function generateGapsInCareBundle(
  * @param retrieves numerator queries from a call to findRetrieves
  * @param improvementNotation string indicating positive or negative improvement notation for the measure being used
  * @param detailedResult result from calculation to look up clause values
- * @return mapped list of queries with near miss info if relevant
+ * @return mapped list of queries with reason detail info if relevant
  */
 export function calculateReasonDetail(
   retrieves: GapsDataTypeQuery[],
@@ -359,7 +359,7 @@ export function calculateReasonDetail(
         });
       }
 
-      // If no specific near miss reasons found, default is missing
+      // If no specific reason details found, default is missing
       if (reasonDetail.hasReasonDetail && reasonDetail.reasonCodes.length === 0) {
         reasonDetail.reasonCodes = [CareGapReasonCode.MISSING];
       }

--- a/src/GapsInCareHelpers.ts
+++ b/src/GapsInCareHelpers.ts
@@ -286,7 +286,7 @@ export function generateGapsInCareBundle(
 }
 
 /**
- * Add near miss data to each DataTypeQuery passed in
+ * Add reason detail data to each DataTypeQuery passed in
  *
  * @param retrieves numerator queries from a call to findRetrieves
  * @param improvementNotation string indicating positive or negative improvement notation for the measure being used

--- a/src/helpers/RetrievesHelper.ts
+++ b/src/helpers/RetrievesHelper.ts
@@ -1,0 +1,100 @@
+import { ELM, ELMStatement } from '../types/ELMTypes';
+import { DataTypeQuery, ExpressionStackEntry } from '../types/Calculator';
+
+/**
+ * Get all data types, and codes/valuesets used in Query ELM expressions
+ *
+ * @param elm main ELM library with expressions to traverse
+ * @param deps list of any dependent ELM libraries included in the main ELM
+ * @param expr expression to find queries under (usually numerator for gaps in care)
+ * @param queryLocalId keeps track of latest id of query statements for lookup later
+ * @returns query info for each ELM retrieve
+ */
+export function findRetrieves(
+  elm: ELM,
+  deps: ELM[],
+  expr: ELMStatement,
+  queryLocalId?: string,
+  expressionStack: ExpressionStackEntry[] = []
+) {
+  const results: DataTypeQuery[] = [];
+
+  // Push this expression onto the stack of processed expressions
+  if (expr.localId && expr.type) {
+    expressionStack.push({
+      libraryName: elm.library.identifier.id,
+      localId: expr.localId,
+      type: expr.type
+    });
+  }
+
+  // Base case, get data type and code/valueset off the expression
+  if (expr.type === 'Retrieve' && expr.dataType) {
+    // If present, strip off HL7 prefix to data type
+    const dataType = expr.dataType.replace(/^(\{http:\/\/hl7.org\/fhir\})?/, '');
+
+    if (expr.codes?.type === 'ValueSetRef') {
+      const valueSet = elm.library.valueSets?.def.find(v => v.name === expr.codes.name);
+      if (valueSet) {
+        results.push({
+          dataType,
+          valueSet: valueSet.id,
+          queryLocalId,
+          retrieveLocalId: expr.localId,
+          libraryName: elm.library.identifier.id,
+          expressionStack: [...expressionStack]
+        });
+      }
+    } else if (
+      expr.codes.type === 'CodeRef' ||
+      (expr.codes.type === 'ToList' && expr.codes.operand?.type === 'CodeRef')
+    ) {
+      // ToList promotions have the CodeRef on the operand
+      const codeName = expr.codes.type === 'CodeRef' ? expr.codes.name : expr.codes.operand.name;
+      const code = elm.library.codes?.def.find(c => c.name === codeName);
+      if (code) {
+        results.push({
+          dataType,
+          code: {
+            system: code.codeSystem.name,
+            code: code.id
+          },
+          queryLocalId,
+          retrieveLocalId: expr.localId,
+          libraryName: elm.library.identifier.id,
+          expressionStack: [...expressionStack]
+        });
+      }
+    }
+  } else if (expr.type === 'Query') {
+    // Queries have the source array containing the expressions
+    expr.source?.forEach(s => {
+      results.push(...findRetrieves(elm, deps, s.expression, expr.localId, [...expressionStack]));
+    });
+  } else if (expr.type === 'ExpressionRef') {
+    // Find expression in dependent library
+    if (expr.libraryName) {
+      const matchingLib = deps.find(d => d.library.identifier.id === expr.libraryName);
+      const exprRef = matchingLib?.library.statements.def.find(e => e.name === expr.name);
+      if (matchingLib && exprRef) {
+        results.push(...findRetrieves(matchingLib, deps, exprRef.expression, queryLocalId, [...expressionStack]));
+      }
+    } else {
+      // Find expression in current library
+      const exprRef = elm.library.statements.def.find(d => d.name === expr.name);
+      if (exprRef) {
+        results.push(...findRetrieves(elm, deps, exprRef.expression, queryLocalId, [...expressionStack]));
+      }
+    }
+  } else if (expr.operand) {
+    // Operand can be array or object. Recurse on either
+    if (Array.isArray(expr.operand)) {
+      expr.operand.forEach(e => {
+        results.push(...findRetrieves(elm, deps, e, queryLocalId, [...expressionStack]));
+      });
+    } else {
+      results.push(...findRetrieves(elm, deps, expr.operand, queryLocalId, [...expressionStack]));
+    }
+  }
+  return results;
+}

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -218,17 +218,17 @@ export interface GapsDataTypeQuery extends DataTypeQuery {
   parentQueryHasResult?: boolean;
   /** Info about query and how it is filtered. */
   queryInfo?: QueryInfo;
-  /** Info about the near miss query */
+  /** Info about the reason detail query */
   reasonDetail?: ReasonDetail;
 }
 
 /**
- * Detailed information about a near-miss query
+ * Detailed information about a reason detail query
  */
 export interface ReasonDetail {
-  /** whether or not the query is a near miss */
+  /** whether or not the query has a reason detail */
   hasReasonDetail: boolean;
-  /** codes that represent the causes of the near miss */
+  /** codes that represent the causes of the reason detail */
   reasonCodes: CareGapReasonCode[];
 }
 

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -201,10 +201,6 @@ export interface DataTypeQuery {
     system: string;
     code: string;
   };
-  /** whether or not the retrieve was truthy */
-  retrieveHasResult?: boolean;
-  /** whether or not the entire query was truthy */
-  parentQueryHasResult?: boolean;
   /** localId in ELM for the retrieve statement */
   retrieveLocalId?: string;
   /** localId in ELM for the query statement */
@@ -213,18 +209,25 @@ export interface DataTypeQuery {
   libraryName?: string;
   /** stack of expressions traversed during calculation */
   expressionStack?: ExpressionStackEntry[];
+}
+
+export interface GapsDataTypeQuery extends DataTypeQuery {
+  /** whether or not the retrieve was truthy */
+  retrieveHasResult?: boolean;
+  /** whether or not the entire query was truthy */
+  parentQueryHasResult?: boolean;
   /** Info about query and how it is filtered. */
   queryInfo?: QueryInfo;
   /** Info about the near miss query */
-  nearMissInfo?: NearMissInfo;
+  reasonDetail?: ReasonDetail;
 }
 
 /**
  * Detailed information about a near-miss query
  */
-export interface NearMissInfo {
+export interface ReasonDetail {
   /** whether or not the query is a near miss */
-  isNearMiss: boolean;
+  hasReasonDetail: boolean;
   /** codes that represent the causes of the near miss */
   reasonCodes: CareGapReasonCode[];
 }

--- a/test/RetrievesHelper.test.ts
+++ b/test/RetrievesHelper.test.ts
@@ -1,0 +1,141 @@
+import { getELMFixture } from './helpers/testHelpers';
+import { findRetrieves } from '../src/helpers/RetrievesHelper';
+import { DataTypeQuery } from '../src/types/Calculator';
+
+const simpleQueryELM = getELMFixture('elm/queries/SimpleQueries.json');
+const simpleQueryELMDependency = getELMFixture('elm/queries/SimpleQueriesDependency.json');
+
+const EXPECTED_VS_RETRIEVE_RESULTS: DataTypeQuery[] = [
+  {
+    dataType: 'Condition',
+    valueSet: 'http://example.com/test-vs',
+    retrieveLocalId: '14',
+    queryLocalId: undefined,
+    libraryName: 'SimpleQueries',
+    expressionStack: [
+      {
+        localId: '14',
+        libraryName: 'SimpleQueries',
+        type: 'Retrieve'
+      }
+    ]
+  }
+];
+
+const EXPECTED_VS_QUERY_RESULTS: DataTypeQuery[] = [
+  {
+    dataType: 'Condition',
+    valueSet: 'http://example.com/test-vs',
+    retrieveLocalId: '18',
+    queryLocalId: '24',
+    libraryName: 'SimpleQueries',
+    expressionStack: [
+      {
+        localId: '24',
+        libraryName: 'SimpleQueries',
+        type: 'Query'
+      },
+      {
+        localId: '18',
+        libraryName: 'SimpleQueries',
+        type: 'Retrieve'
+      }
+    ]
+  }
+];
+
+const EXPECTED_CODE_RESULTS: DataTypeQuery[] = [
+  {
+    dataType: 'Procedure',
+    code: {
+      system: 'EXAMPLE',
+      code: 'test'
+    },
+    retrieveLocalId: '16',
+    queryLocalId: undefined,
+    libraryName: 'SimpleQueries',
+    expressionStack: [
+      {
+        localId: '16',
+        libraryName: 'SimpleQueries',
+        type: 'Retrieve'
+      }
+    ]
+  }
+];
+
+const EXPECTED_EXPRESSIONREF_RESULTS: DataTypeQuery[] = [
+  {
+    dataType: 'Condition',
+    valueSet: 'http://example.com/test-vs',
+    retrieveLocalId: '14',
+    queryLocalId: undefined,
+    libraryName: 'SimpleQueries',
+    expressionStack: [
+      {
+        localId: '26',
+        libraryName: 'SimpleQueries',
+        type: 'ExpressionRef'
+      },
+      {
+        localId: '14',
+        libraryName: 'SimpleQueries',
+        type: 'Retrieve'
+      }
+    ]
+  }
+];
+
+const EXPECTED_DEPENDENCY_RESULTS: DataTypeQuery[] = [
+  {
+    dataType: 'Condition',
+    valueSet: 'http://example.com/test-vs-2',
+    retrieveLocalId: '4',
+    queryLocalId: undefined,
+    libraryName: 'SimpleDep',
+    expressionStack: [
+      {
+        localId: '29',
+        libraryName: 'SimpleQueries',
+        type: 'ExpressionRef'
+      },
+      {
+        localId: '4',
+        libraryName: 'SimpleDep',
+        type: 'Retrieve'
+      }
+    ]
+  }
+];
+
+describe('Find Numerator Queries', () => {
+  test('simple valueset lookup', () => {
+    const valueSetExpr = simpleQueryELM.library.statements.def[0]; // expression for valueset lookup
+    const results = findRetrieves(simpleQueryELM, [simpleQueryELMDependency], valueSetExpr.expression);
+    expect(results).toEqual(EXPECTED_VS_RETRIEVE_RESULTS);
+  });
+
+  test('simple code lookup', () => {
+    const codeExpr = simpleQueryELM.library.statements.def[1]; // expression for code lookup
+    const results = findRetrieves(simpleQueryELM, [simpleQueryELMDependency], codeExpr.expression);
+    expect(results).toEqual(EXPECTED_CODE_RESULTS);
+  });
+
+  test('simple aliased query', () => {
+    const queryExpr = simpleQueryELM.library.statements.def[2]; // expression with aliased query
+    const results = findRetrieves(simpleQueryELM, [simpleQueryELMDependency], queryExpr.expression);
+    expect(results).toEqual(EXPECTED_VS_QUERY_RESULTS);
+  });
+
+  test('simple expression ref', () => {
+    const expressionRef = simpleQueryELM.library.statements.def[3]; // expression with local expression ref
+    const results = findRetrieves(simpleQueryELM, [simpleQueryELMDependency], expressionRef.expression);
+    expect(results).toEqual(EXPECTED_EXPRESSIONREF_RESULTS);
+  });
+
+  test('dependent library expression ref', () => {
+    const expressionRefDependency = simpleQueryELM.library.statements.def[4]; // expression with expression ref in dependent library
+    const results = findRetrieves(simpleQueryELM, [simpleQueryELMDependency], expressionRefDependency.expression);
+    expect(results).toEqual(EXPECTED_DEPENDENCY_RESULTS);
+  });
+});


### PR DESCRIPTION
# Summary

All code in this PR ~pear~ pair programmed with @okeefm.

This PR separates out the logic of Gaps that parses the ELM for queries into its own helper. This new function just returns the info for the retrieves (i.e. DataType and code/valueset used). For data requirements, we will be able to re-use this helper.

## New behavior

None

## Code changes

* `RetrievesHelper.ts` now has a function that just parses elm for data types and valuesets/codes (no reliance on execution results)
* `GapsInCareHelpers.ts` now calls the helper from `RetrievesHelper` and does additional iteration to lookup clause results
  * This is done in order to add `retrieveHasResult` and `parentQueryHasResult` properties to the queries.
* Modified base `DataTypeQuery` interface to not include `retrieveHasResult` and `parentQueryHasResult`
  * Added sub-interface `GapsDataTypeQuery` that extends from `DataTypeQuery` and adds those two properties
* Added test for `RetrievesHelper`
  * Essentially just a modified version of the tests formerly used in `GapsInCareHelpers`
* Modified `GapsInCareHelpers` tests to properly test the new logic for processing base queries
* Renamed any uses of "Near Miss" to "Reason Detail"

# Testing guidance

Usual checks, visual inspection. Ensure gaps in care functionality is unchanged 
