### PR TITLE
Query Filters Patient Data "CalendarAgeInYearsAt" case.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,17 +15,16 @@
       }
     },
     "@babel/cli": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.12.1.tgz",
-      "integrity": "sha512-eRJREyrfAJ2r42Iaxe8h3v6yyj1wu9OyosaUHW6UImjGf9ahGL9nsFNh7OCopvtcPL8WnEo7tp78wrZaZ6vG9g==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.14.5.tgz",
+      "integrity": "sha512-poegjhRvXHWO0EAsnYajwYZuqcz7gyfxwfaecUESxDujrqOivf3zrjFbub8IJkrqEaz3fvJWh001EzxBub54fg==",
       "requires": {
-        "@nicolo-ribaudo/chokidar-2": "^2.1.8",
+        "@nicolo-ribaudo/chokidar-2": "2.1.8-no-fsevents.2",
         "chokidar": "^3.4.0",
         "commander": "^4.0.1",
         "convert-source-map": "^1.1.0",
         "fs-readdir-recursive": "^1.1.0",
         "glob": "^7.0.0",
-        "lodash": "^4.17.19",
         "make-dir": "^2.1.0",
         "slash": "^2.0.0",
         "source-map": "^0.5.0"
@@ -1687,34 +1686,22 @@
       }
     },
     "@nicolo-ribaudo/chokidar-2": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8.tgz",
-      "integrity": "sha512-FohwULwAebCUKi/akMFyGi7jfc7JXTeMHzKxuP3umRd9mK/2Y7/SMBSI2jX+YLopPXi+PF9l307NmpfxTdCegA==",
+      "version": "2.1.8-no-fsevents.2",
+      "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.2.tgz",
+      "integrity": "sha512-Fb8WxUFOBQVl+CX4MWet5o7eCc6Pj04rXIwVKZ6h1NnqTo45eOQW6aWyhG25NIODvWFwTDMwBsYxrQ3imxpetg==",
       "optional": true,
       "requires": {
-        "chokidar": "2.1.8"
-      },
-      "dependencies": {
-        "chokidar": {
-          "version": "2.1.8",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
-          "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
-          "optional": true,
-          "requires": {
-            "anymatch": "^2.0.0",
-            "async-each": "^1.0.1",
-            "braces": "^2.3.2",
-            "fsevents": "^1.2.7",
-            "glob-parent": "^3.1.0",
-            "inherits": "^2.0.3",
-            "is-binary-path": "^1.0.0",
-            "is-glob": "^4.0.0",
-            "normalize-path": "^3.0.0",
-            "path-is-absolute": "^1.0.0",
-            "readdirp": "^2.2.1",
-            "upath": "^1.1.1"
-          }
-        }
+        "anymatch": "^2.0.0",
+        "async-each": "^1.0.1",
+        "braces": "^2.3.2",
+        "glob-parent": "^5.1.2",
+        "inherits": "^2.0.3",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^4.0.0",
+        "normalize-path": "^3.0.0",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.2.1",
+        "upath": "^1.1.1"
       }
     },
     "@sinonjs/commons": {
@@ -2432,15 +2419,6 @@
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
       "optional": true
     },
-    "bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "optional": true,
-      "requires": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2484,15 +2462,15 @@
       "dev": true
     },
     "browserslist": {
-      "version": "4.14.7",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.7.tgz",
-      "integrity": "sha512-BSVRLCeG3Xt/j/1cCGj1019Wbty0H+Yvu2AOuZSuoaUWn3RatbL33Cxk+Q4jRMRAbOm0p7SLravLjpnT6s0vzQ==",
+      "version": "4.16.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
+      "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
       "requires": {
-        "caniuse-lite": "^1.0.30001157",
-        "colorette": "^1.2.1",
-        "electron-to-chromium": "^1.3.591",
+        "caniuse-lite": "^1.0.30001219",
+        "colorette": "^1.2.2",
+        "electron-to-chromium": "^1.3.723",
         "escalade": "^3.1.1",
-        "node-releases": "^1.1.66"
+        "node-releases": "^1.1.71"
       }
     },
     "bs-logger": {
@@ -2557,9 +2535,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001157",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001157.tgz",
-      "integrity": "sha512-gOerH9Wz2IRZ2ZPdMfBvyOi3cjaz4O4dgNwPGzx8EhqAs4+2IL/O+fJsbt+znSigujoZG8bVcIAUM/I/E5K3MA=="
+      "version": "1.0.30001237",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001237.tgz",
+      "integrity": "sha512-pDHgRndit6p1NR2GhzMbQ6CkRrp4VKuSsqbcLeOQppYPKOYkKT/6ZvZDvKJUqcmtyWIAHuZq3SVS2vc1egCZzw=="
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -2593,25 +2571,25 @@
       "dev": true
     },
     "chokidar": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
-      "integrity": "sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
+      "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
       "optional": true,
       "requires": {
-        "anymatch": "~3.1.1",
+        "anymatch": "~3.1.2",
         "braces": "~3.0.2",
-        "fsevents": "~2.1.2",
-        "glob-parent": "~5.1.0",
+        "fsevents": "~2.3.2",
+        "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
-        "readdirp": "~3.5.0"
+        "readdirp": "~3.6.0"
       },
       "dependencies": {
         "anymatch": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
-          "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+          "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
           "optional": true,
           "requires": {
             "normalize-path": "^3.0.0",
@@ -2619,9 +2597,9 @@
           }
         },
         "binary-extensions": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
-          "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+          "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
           "optional": true
         },
         "braces": {
@@ -2642,21 +2620,6 @@
             "to-regex-range": "^5.0.1"
           }
         },
-        "fsevents": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-          "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
-          "optional": true
-        },
-        "glob-parent": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-          "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
-          "optional": true,
-          "requires": {
-            "is-glob": "^4.0.1"
-          }
-        },
         "is-binary-path": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -2673,9 +2636,9 @@
           "optional": true
         },
         "readdirp": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
-          "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+          "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
           "optional": true,
           "requires": {
             "picomatch": "^2.2.1"
@@ -2771,9 +2734,9 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "colorette": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
-      "integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw=="
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+      "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w=="
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -3092,9 +3055,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.595",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.595.tgz",
-      "integrity": "sha512-JpaBIhdBkF9FLG7x06ONfe0f5bxPrxRcq0X+Sc8vsCt+OPWIzxOD+qM71NEHLGbDfN9Q6hbtHRv4/dnvcOxo6g=="
+      "version": "1.3.752",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.752.tgz",
+      "integrity": "sha512-2Tg+7jSl3oPxgsBsWKh5H83QazTkmWG/cnNwJplmyZc7KcN61+I10oUgaXSVk/NwfvN3BdkKDR4FYuRBQQ2v0A=="
     },
     "emitter-component": {
       "version": "1.1.1",
@@ -3311,9 +3274,9 @@
           "dev": true
         },
         "glob-parent": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-          "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
           "dev": true,
           "requires": {
             "is-glob": "^4.0.1"
@@ -3723,12 +3686,6 @@
         "flat-cache": "^2.0.1"
       }
     },
-    "file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "optional": true
-    },
     "fill-range": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -3828,14 +3785,10 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
-      "version": "1.2.13",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
-      "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-      "optional": true,
-      "requires": {
-        "bindings": "^1.5.0",
-        "nan": "^2.12.1"
-      }
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "optional": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -3918,24 +3871,12 @@
       }
     },
     "glob-parent": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "optional": true,
       "requires": {
-        "is-glob": "^3.1.0",
-        "path-dirname": "^1.0.0"
-      },
-      "dependencies": {
-        "is-glob": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-          "optional": true,
-          "requires": {
-            "is-extglob": "^2.1.0"
-          }
-        }
+        "is-glob": "^4.0.1"
       }
     },
     "globals": {
@@ -6230,12 +6171,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
-    "nan": {
-      "version": "2.14.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
-      "optional": true
-    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -6311,9 +6246,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.66",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.66.tgz",
-      "integrity": "sha512-JHEQ1iWPGK+38VLB2H9ef2otU4l8s3yAMt9Xf934r6+ojCYDMHPMqvCc9TnzfeFSP1QEOeU6YZEd3+De0LTCgg=="
+      "version": "1.1.73",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.73.tgz",
+      "integrity": "sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg=="
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -6525,12 +6460,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
-    },
-    "path-dirname": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
-      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
-      "optional": true
     },
     "path-exists": {
       "version": "4.0.0",
@@ -8117,9 +8046,9 @@
       }
     },
     "ws": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.0.tgz",
-      "integrity": "sha512-kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ==",
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
       "dev": true
     },
     "xml-name-validator": {

--- a/src/QueryFilterHelpers.ts
+++ b/src/QueryFilterHelpers.ts
@@ -752,18 +752,16 @@ export function interpretGreaterOrEqual(
               type: 'unknown',
               alias: propRef.scope,
               attribute: propRef.path,
-              localId: greaterOrEqualExpr.localId
+              localId: greaterOrEqualExpr.localId,
+              notes: "Compares against the patient's birthDate. But patient did not have birthDate."
             };
           }
         }
       }
     } else {
-      return interpretFunctionRef(functionRef);
+      return { type: 'unknown' };
     }
   }
-  //    check if the parameters are sensical and determine the resource attribute. handle start/end of
-  //    look at patient data and second param to determine date that would satisfy the inequality.
-  //    return DuringInterval with one side open
 
   return { type: 'unknown' };
 }

--- a/src/QueryFilterHelpers.ts
+++ b/src/QueryFilterHelpers.ts
@@ -22,7 +22,8 @@ import {
   ELMIsNull,
   ELMUnaryExpression,
   ELMInterval,
-  ELMCodeSystem
+  ELMCodeSystem,
+  ELMGreaterOrEqual
 } from './types/ELMTypes';
 import {
   AndFilter,
@@ -176,6 +177,8 @@ export function interpretExpression(expression: ELMExpression, library: ELM, par
       return interpretIn(expression as ELMIn, library, parameters);
     case 'Not':
       return interpretNot(expression as ELMNot);
+    case 'GreaterOrEqual':
+      return interpretGreaterOrEqual(expression as ELMGreaterOrEqual, library, parameters);
     default:
       console.error(`Don't know how to parse ${expression.type} expression.`);
       // Look for a property (source attribute) usage in the expression tree. This can denote an
@@ -644,4 +647,22 @@ export function executeIntervalELM(
   } else {
     return null;
   }
+}
+
+export function interpretGreaterOrEqual(
+  greaterOrEqualExpr: ELMGreaterOrEqual,
+  library: ELM,
+  parameters: any
+): AnyFilter {
+  // look at first param if it is function ref to calendar age in years at.
+  if (greaterOrEqualExpr.operand[0].type === 'FunctionRef') {
+    const functionRef = greaterOrEqualExpr.operand[0] as ELMFunctionRef;
+    if (functionRef.name === 'CalendarAgeInYearsAt' && functionRef.libraryName === 'Global') {
+    }
+  }
+  //    check if the parameters are sensical and determine the resource attribute. handle start/end of
+  //    look at patient data and second param to determine date that would satisfy the inequality.
+  //    return DuringInterval with one side open
+
+  return { type: 'unknown' };
 }

--- a/src/QueryFilterHelpers.ts
+++ b/src/QueryFilterHelpers.ts
@@ -23,7 +23,10 @@ import {
   ELMUnaryExpression,
   ELMInterval,
   ELMCodeSystem,
-  ELMGreaterOrEqual
+  ELMGreaterOrEqual,
+  ELMToDateTime,
+  ELMStart,
+  ELMEnd
 } from './types/ELMTypes';
 import {
   AndFilter,
@@ -48,17 +51,18 @@ import {
  * @param parameters The parameters used for calculation so they could be reused for re-calculating small bits for CQL.
  *                    "Measurement Period" is the only supported parameter at the moment as it is the only parameter
  *                    seen in eCQMs.
+ * @param patient The patient resource.
  * @returns Information about the query and how it is filtered.
  */
 export function parseQueryInfo(
   library: ELM,
-  queryLocalId?: string,
-  parameters: { [key: string]: any } = {}
+  queryLocalId: string | undefined,
+  parameters: { [key: string]: any } = {},
+  patient: R4.IPatient
 ): QueryInfo {
   if (!queryLocalId) {
     throw new Error('QueryLocalId was not provided');
   }
-
   const expression = findClauseInLibrary(library, queryLocalId);
   if (expression?.type == 'Query') {
     const query = expression as ELMQuery;
@@ -68,7 +72,7 @@ export function parseQueryInfo(
       filter: { type: 'truth' }
     };
     if (query.where) {
-      const whereInfo = interpretExpression(query.where, library, parameters);
+      const whereInfo = interpretExpression(query.where, library, parameters, patient);
       queryInfo.filter = whereInfo;
     }
     return queryInfo;
@@ -159,18 +163,24 @@ function parseDataType(retrieve: ELMRetrieve): string {
  * @param expression The ELM expression/clause to attempt to interpret into a filter.
  * @param library The ELM library, in case it is needed for calculating intervals.
  * @param parameters The parameters used for calculation.
+ * @param patient The patient resource.
  * @returns The simpler Filter representation of this clause.
  */
-export function interpretExpression(expression: ELMExpression, library: ELM, parameters: any): AnyFilter {
+export function interpretExpression(
+  expression: ELMExpression,
+  library: ELM,
+  parameters: any,
+  patient: R4.IPatient
+): AnyFilter {
   switch (expression.type) {
     case 'Equal':
       return interpretEqual(expression as ELMEqual);
     case 'Equivalent':
       return interpretEquivalent(expression as ELMEquivalent, library);
     case 'And':
-      return interpretAnd(expression as ELMAnd, library, parameters);
+      return interpretAnd(expression as ELMAnd, library, parameters, patient);
     case 'Or':
-      return interpretOr(expression as ELMOr, library, parameters);
+      return interpretOr(expression as ELMOr, library, parameters, patient);
     case 'IncludedIn':
       return interpretIncludedIn(expression as ELMIncludedIn, library, parameters);
     case 'In':
@@ -178,7 +188,7 @@ export function interpretExpression(expression: ELMExpression, library: ELM, par
     case 'Not':
       return interpretNot(expression as ELMNot);
     case 'GreaterOrEqual':
-      return interpretGreaterOrEqual(expression as ELMGreaterOrEqual, library, parameters);
+      return interpretGreaterOrEqual(expression as ELMGreaterOrEqual, library, parameters, patient);
     default:
       console.error(`Don't know how to parse ${expression.type} expression.`);
       // Look for a property (source attribute) usage in the expression tree. This can denote an
@@ -233,19 +243,20 @@ export function findPropertyUsage(expression: any, unknownLocalId?: string): Unk
  * @param andExpression The and expression to interpret.
  * @param library The library the elm is in.
  * @param parameters The original calculation parameters.
+ * @param patient The patient resource.
  * @returns The filter tree for this and expression.
  */
-export function interpretAnd(andExpression: ELMAnd, library: ELM, parameters: any): AndFilter {
+export function interpretAnd(andExpression: ELMAnd, library: ELM, parameters: any, patient: R4.IPatient): AndFilter {
   const andInfo: AndFilter = { type: 'and', children: [] };
   if (andExpression.operand[0].type == 'And') {
-    andInfo.children.push(...interpretAnd(andExpression.operand[0] as ELMAnd, library, parameters).children);
+    andInfo.children.push(...interpretAnd(andExpression.operand[0] as ELMAnd, library, parameters, patient).children);
   } else {
-    andInfo.children.push(interpretExpression(andExpression.operand[0], library, parameters));
+    andInfo.children.push(interpretExpression(andExpression.operand[0], library, parameters, patient));
   }
   if (andExpression.operand[1].type == 'And') {
-    andInfo.children.push(...interpretAnd(andExpression.operand[1] as ELMAnd, library, parameters).children);
+    andInfo.children.push(...interpretAnd(andExpression.operand[1] as ELMAnd, library, parameters, patient).children);
   } else {
-    andInfo.children.push(interpretExpression(andExpression.operand[1], library, parameters));
+    andInfo.children.push(interpretExpression(andExpression.operand[1], library, parameters, patient));
   }
   andInfo.children = andInfo.children.filter(filter => filter?.type !== 'truth');
   return andInfo;
@@ -257,19 +268,20 @@ export function interpretAnd(andExpression: ELMAnd, library: ELM, parameters: an
  * @param orExpression The or expression to interpret.
  * @param library The library the elm is in.
  * @param parameters The original calculation parameters.
+ * @param patient The patient resource.
  * @returns The filter tree for this or expression.
  */
-export function interpretOr(orExpression: ELMOr, library: ELM, parameters: any): OrFilter {
+export function interpretOr(orExpression: ELMOr, library: ELM, parameters: any, patient: R4.IPatient): OrFilter {
   const orInfo: OrFilter = { type: 'or', children: [] };
   if (orExpression.operand[0].type == 'Or') {
-    orInfo.children.push(...interpretOr(orExpression.operand[0] as ELMOr, library, parameters).children);
+    orInfo.children.push(...interpretOr(orExpression.operand[0] as ELMOr, library, parameters, patient).children);
   } else {
-    orInfo.children.push(interpretExpression(orExpression.operand[0], library, parameters));
+    orInfo.children.push(interpretExpression(orExpression.operand[0], library, parameters, patient));
   }
   if (orExpression.operand[1].type == 'Or') {
-    orInfo.children.push(...interpretOr(orExpression.operand[1] as ELMOr, library, parameters).children);
+    orInfo.children.push(...interpretOr(orExpression.operand[1] as ELMOr, library, parameters, patient).children);
   } else {
-    orInfo.children.push(interpretExpression(orExpression.operand[1], library, parameters));
+    orInfo.children.push(interpretExpression(orExpression.operand[1], library, parameters, patient));
   }
   orInfo.children = orInfo.children.filter(filter => filter?.type !== 'truth');
   return orInfo;
@@ -649,15 +661,104 @@ export function executeIntervalELM(
   }
 }
 
+interface CalendarAgeInYearsAtRef extends ELMFunctionRef {
+  name: 'CalendarAgeInYearsAt';
+  libraryName: 'Global';
+  operand: [CalendarAgeInYearsDateTime, ELMFunctionRef | ELMProperty | ELMStart | ELMEnd];
+}
+
+interface CalendarAgeInYearsDateTime extends ELMToDateTime {
+  operand: ELMFunctionRef;
+}
+
 export function interpretGreaterOrEqual(
   greaterOrEqualExpr: ELMGreaterOrEqual,
   library: ELM,
-  parameters: any
+  parameters: any,
+  patient: R4.IPatient
 ): AnyFilter {
   // look at first param if it is function ref to calendar age in years at.
   if (greaterOrEqualExpr.operand[0].type === 'FunctionRef') {
     const functionRef = greaterOrEqualExpr.operand[0] as ELMFunctionRef;
     if (functionRef.name === 'CalendarAgeInYearsAt' && functionRef.libraryName === 'Global') {
+      const calAgeRef = functionRef as CalendarAgeInYearsAtRef;
+      // ensure the first operand is the patient birthdate.
+      if (
+        calAgeRef.operand[0].type === 'ToDateTime' &&
+        calAgeRef.operand[0].operand.type === 'FunctionRef' &&
+        calAgeRef.operand[0].operand.name === 'ToDate' &&
+        calAgeRef.operand[0].operand.operand[0].type === 'Property' &&
+        (calAgeRef.operand[0].operand.operand[0] as ELMProperty).path === 'birthDate'
+      ) {
+        // figure out what the attribute on the property is
+        const attrExpr = calAgeRef.operand[1];
+        let propRef: ELMProperty | null = null;
+        if (attrExpr.type === 'FunctionRef') {
+          propRef = interpretFunctionRef(attrExpr as ELMFunctionRef);
+        } else if (attrExpr.type === 'Property') {
+          propRef = attrExpr;
+        } else if (attrExpr.type === 'Start' || attrExpr.type === 'End') {
+          const suffix = attrExpr.type === 'End' ? '.end' : '.start';
+          if (attrExpr.operand.type == 'FunctionRef') {
+            propRef = interpretFunctionRef(attrExpr.operand as ELMFunctionRef);
+          } else if (attrExpr.operand.type == 'Property') {
+            propRef = attrExpr.operand as ELMProperty;
+          }
+          if (propRef) {
+            propRef = {
+              type: 'Property',
+              path: propRef?.path + suffix,
+              scope: propRef?.scope,
+              localId: propRef?.localId,
+              locator: propRef?.locator,
+              source: propRef?.source
+            };
+          }
+        }
+
+        // if propRef is defined that means we found the attribute on the source resource
+        if (propRef == null) {
+          console.warn('Could not resolve the property referenced in CalendarAgeInYearsAt');
+          return { type: 'unknown' };
+        }
+
+        if (greaterOrEqualExpr.operand[1].type === 'Literal') {
+          const years = (greaterOrEqualExpr.operand[1] as ELMLiteral).value as number;
+          if (patient.birthDate) {
+            // parse birthdate and wipe out hours, minutes, seconds, and miliseconds and add
+            // the number of years.
+            const birthDate = cql.DateTime.parse(patient.birthDate);
+            birthDate.hour = 0;
+            birthDate.minute = 0;
+            birthDate.second = 0;
+            birthDate.millisecond = 0;
+            birthDate.timezoneOffset = 0;
+            const birthDateOffset = birthDate.add(years, cql.DateTime.Unit.YEAR);
+            const period = {
+              start: birthDateOffset.toString().replace('+00:00', 'Z'),
+              interval: new cql.Interval(birthDateOffset, null, true, false)
+            };
+            return {
+              type: 'during',
+              alias: propRef.scope as string,
+              attribute: propRef.path,
+              valuePeriod: period,
+              localId: greaterOrEqualExpr.localId,
+              notes: `Compares against the patient's birthDate (${years} years)`
+            };
+          } else {
+            console.warn('Patient data had no birthDate');
+            return {
+              type: 'unknown',
+              alias: propRef.scope,
+              attribute: propRef.path,
+              localId: greaterOrEqualExpr.localId
+            };
+          }
+        }
+      }
+    } else {
+      return interpretFunctionRef(functionRef);
     }
   }
   //    check if the parameters are sensical and determine the resource attribute. handle start/end of

--- a/src/types/CQLExecution.d.ts
+++ b/src/types/CQLExecution.d.ts
@@ -22,7 +22,27 @@ declare module 'cql-execution' {
 
   export class DateTime {
     static fromJSDate(date: Date, timezoneOffset: number): any;
+    static parse(string: string): DateTime;
+    year: number;
+    month: number;
+    day: number;
+    hour: number;
+    minute: number;
+    second: number;
+    millisecond: number;
+    timezoneOffset: number | undefined;
     toString(): string;
+    add(offset: number, field: string): DateTime;
+    static Unit: {
+      YEAR: 'year';
+      MONTH: 'month';
+      WEEK: 'week';
+      DAY: 'day';
+      HOUR: 'hour';
+      MINUTE: 'minute';
+      SECOND: 'second';
+      MILLISECOND: 'millisecond';
+    };
   }
 
   export class Interval {

--- a/src/types/ELMTypes.ts
+++ b/src/types/ELMTypes.ts
@@ -176,6 +176,7 @@ export type AnyELMExpression =
   | ELMQuery
   | ELMAs
   | ELMEqual
+  | ELMGreaterOrEqual
   | ELMEquivalent
   | ELMAnd
   | ELMOr
@@ -273,6 +274,10 @@ export interface ELMUnaryExpression extends ELMExpression {
 
 export interface ELMEqual extends ELMBinaryExpression {
   type: 'Equal';
+}
+
+export interface ELMGreaterOrEqual extends ELMBinaryExpression {
+  type: 'GreaterOrEqual';
 }
 
 export interface ELMEquivalent extends ELMBinaryExpression {

--- a/src/types/ELMTypes.ts
+++ b/src/types/ELMTypes.ts
@@ -194,6 +194,7 @@ export type AnyELMExpression =
   | ELMAliasRef
   | ELMConceptRef
   | ELMLiteral
+  | ELMQuantity
   | ELMInterval
   | ELMList
   | ELMTuple;
@@ -364,6 +365,12 @@ export interface ELMLiteral extends ELMExpression {
   type: 'Literal';
   valueType: string;
   value?: string | number;
+}
+
+export interface ELMQuantity extends ELMExpression {
+  type: 'Quantity';
+  unit?: string;
+  value?: number;
 }
 
 export interface ELMInterval extends ELMExpression {

--- a/src/types/ELMTypes.ts
+++ b/src/types/ELMTypes.ts
@@ -186,6 +186,7 @@ export type AnyELMExpression =
   | ELMIn
   | ELMEnd
   | ELMStart
+  | ELMToDateTime
   | ELMExpressionRef
   | ELMFunctionRef
   | ELMParameterRef
@@ -319,6 +320,10 @@ export interface ELMStart extends ELMUnaryExpression {
   type: 'Start';
 }
 
+export interface ELMToDateTime extends ELMUnaryExpression {
+  type: 'ToDateTime';
+}
+
 interface ELMIExpressionRef extends ELMExpression {
   name: string;
   libraryName?: string;
@@ -331,7 +336,7 @@ export interface ELMExpressionRef extends ELMIExpressionRef {
 export interface ELMFunctionRef extends ELMIExpressionRef {
   type: 'FunctionRef';
   signature?: [any];
-  operand: [AnyELMExpression];
+  operand: AnyELMExpression[];
 }
 
 export interface ELMParameterRef extends ELMIExpressionRef {

--- a/src/types/QueryFilterTypes.ts
+++ b/src/types/QueryFilterTypes.ts
@@ -39,6 +39,7 @@ export interface SourceInfo {
 export interface Filter {
   type: string;
   localId?: string;
+  notes?: string;
 }
 
 /**

--- a/test/fixtures/elm/queries/ExtraQueries.cql
+++ b/test/fixtures/elm/queries/ExtraQueries.cql
@@ -65,6 +65,9 @@ define "Function call in Interval":
   [Encounter: "test-vs"] Enc
     where "Interval From Period"(Enc.period) in Interval[@2019-01-01T00:00:00.0, @2020-01-01T00:00:00.0)
 
+define "GreaterThanOrEqual Birthdate at start of Observation":
+	[Observation: "test-vs"] HPVTest
+    where Global."CalendarAgeInYearsAt"(FHIRHelpers.ToDate(Patient.birthDate), start of Global."Normalize Interval"(HPVTest.effective))>= 30
 
 define function "A Function"(period Interval<DateTime>):
   start of period

--- a/test/fixtures/elm/queries/ExtraQueries.cql
+++ b/test/fixtures/elm/queries/ExtraQueries.cql
@@ -69,6 +69,10 @@ define "GreaterThanOrEqual Birthdate at start of Observation":
 	[Observation: "test-vs"] HPVTest
     where Global."CalendarAgeInYearsAt"(FHIRHelpers.ToDate(Patient.birthDate), start of Global."Normalize Interval"(HPVTest.effective))>= 30
 
+define "GreaterThanOrEqual Observation Value":
+  [Observation: "test-vs"] Test
+    where Test.value >= 2 'mg'
+
 define function "A Function"(period Interval<DateTime>):
   start of period
 

--- a/test/fixtures/elm/queries/ExtraQueries.json
+++ b/test/fixtures/elm/queries/ExtraQueries.json
@@ -20,7 +20,7 @@
       {
         "type": "Annotation",
         "s": {
-          "r": "135",
+          "r": "152",
           "s": [
             {
               "value": [
@@ -1347,7 +1347,7 @@
         },
         {
           "localId": "63",
-          "locator": "69:1-70:17",
+          "locator": "72:1-73:17",
           "name": "A Function",
           "context": "Patient",
           "accessLevel": "Public",
@@ -1429,11 +1429,11 @@
           ],
           "expression": {
             "localId": "62",
-            "locator": "70:3-70:17",
+            "locator": "73:3-73:17",
             "type": "Start",
             "operand": {
               "localId": "61",
-              "locator": "70:12-70:17",
+              "locator": "73:12-73:17",
               "name": "period",
               "type": "OperandRef"
             }
@@ -1443,11 +1443,11 @@
               "name": "period",
               "operandTypeSpecifier": {
                 "localId": "60",
-                "locator": "69:37-69:54",
+                "locator": "72:37-72:54",
                 "type": "IntervalTypeSpecifier",
                 "pointType": {
                   "localId": "59",
-                  "locator": "69:46-69:53",
+                  "locator": "72:46-72:53",
                   "name": "{urn:hl7-org:elm-types:r1}DateTime",
                   "type": "NamedTypeSpecifier"
                 }
@@ -1717,7 +1717,7 @@
         },
         {
           "localId": "75",
-          "locator": "72:1-73:6",
+          "locator": "75:1-76:6",
           "name": "Passthrough",
           "context": "Patient",
           "accessLevel": "Public",
@@ -1774,7 +1774,7 @@
           ],
           "expression": {
             "localId": "74",
-            "locator": "73:3-73:6",
+            "locator": "76:3-76:6",
             "name": "cond",
             "type": "OperandRef"
           },
@@ -1783,7 +1783,7 @@
               "name": "cond",
               "operandTypeSpecifier": {
                 "localId": "73",
-                "locator": "72:36-72:44",
+                "locator": "75:36-75:44",
                 "name": "{http://hl7.org/fhir}Condition",
                 "type": "NamedTypeSpecifier"
               }
@@ -2904,7 +2904,7 @@
         },
         {
           "localId": "121",
-          "locator": "75:1-76:37",
+          "locator": "78:1-79:37",
           "name": "Interval From Period",
           "context": "Patient",
           "accessLevel": "Public",
@@ -2999,7 +2999,7 @@
           ],
           "expression": {
             "localId": "120",
-            "locator": "76:3-76:37",
+            "locator": "79:3-79:37",
             "name": "Normalize Interval",
             "libraryName": "Global",
             "type": "FunctionRef",
@@ -3008,7 +3008,7 @@
                 "type": "As",
                 "operand": {
                   "localId": "119",
-                  "locator": "76:31-76:36",
+                  "locator": "79:31-79:36",
                   "name": "period",
                   "type": "OperandRef"
                 },
@@ -3053,7 +3053,7 @@
               "name": "period",
               "operandTypeSpecifier": {
                 "localId": "117",
-                "locator": "75:47-75:57",
+                "locator": "78:47-78:57",
                 "name": "{http://hl7.org/fhir}Period",
                 "type": "NamedTypeSpecifier"
               }
@@ -3356,6 +3356,388 @@
                       }
                     }
                   }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "localId": "145",
+          "locator": "68:1-70:140",
+          "name": "GreaterThanOrEqual Birthdate at start of Observation",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "145",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"GreaterThanOrEqual Birthdate at start of Observation\"",
+                      ":\n\t"
+                    ]
+                  },
+                  {
+                    "r": "144",
+                    "s": [
+                      {
+                        "s": [
+                          {
+                            "r": "130",
+                            "s": [
+                              {
+                                "r": "129",
+                                "s": [
+                                  {
+                                    "r": "129",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "[",
+                                          "Observation",
+                                          ": "
+                                        ]
+                                      },
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"test-vs\""
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "]"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "HPVTest"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "\n    "
+                        ]
+                      },
+                      {
+                        "r": "143",
+                        "s": [
+                          {
+                            "value": [
+                              "where "
+                            ]
+                          },
+                          {
+                            "r": "143",
+                            "s": [
+                              {
+                                "r": "141",
+                                "s": [
+                                  {
+                                    "r": "131",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "Global"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "."
+                                    ]
+                                  },
+                                  {
+                                    "r": "141",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "\"CalendarAgeInYearsAt\"",
+                                          "("
+                                        ]
+                                      },
+                                      {
+                                        "r": "135",
+                                        "s": [
+                                          {
+                                            "r": "132",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "FHIRHelpers"
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              "."
+                                            ]
+                                          },
+                                          {
+                                            "r": "135",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "ToDate",
+                                                  "("
+                                                ]
+                                              },
+                                              {
+                                                "r": "134",
+                                                "s": [
+                                                  {
+                                                    "r": "133",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "Patient"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "value": [
+                                                      "."
+                                                    ]
+                                                  },
+                                                  {
+                                                    "r": "134",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "birthDate"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  ")"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          ", "
+                                        ]
+                                      },
+                                      {
+                                        "r": "140",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "start of "
+                                            ]
+                                          },
+                                          {
+                                            "r": "139",
+                                            "s": [
+                                              {
+                                                "r": "136",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "Global"
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  "."
+                                                ]
+                                              },
+                                              {
+                                                "r": "139",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "\"Normalize Interval\"",
+                                                      "("
+                                                    ]
+                                                  },
+                                                  {
+                                                    "r": "138",
+                                                    "s": [
+                                                      {
+                                                        "r": "137",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "HPVTest"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "value": [
+                                                          "."
+                                                        ]
+                                                      },
+                                                      {
+                                                        "r": "138",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "effective"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "value": [
+                                                      ")"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          ")"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "r": "142",
+                                "value": [
+                                  ">=",
+                                  " ",
+                                  "30"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "144",
+            "locator": "69:2-70:140",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "130",
+                "locator": "69:2-69:33",
+                "alias": "HPVTest",
+                "expression": {
+                  "localId": "129",
+                  "locator": "69:2-69:25",
+                  "dataType": "{http://hl7.org/fhir}Observation",
+                  "templateId": "http://hl7.org/fhir/StructureDefinition/Observation",
+                  "codeProperty": "code",
+                  "codeComparator": "in",
+                  "type": "Retrieve",
+                  "codes": {
+                    "locator": "69:16-69:24",
+                    "name": "test-vs",
+                    "type": "ValueSetRef"
+                  }
+                }
+              }
+            ],
+            "relationship": [],
+            "where": {
+              "localId": "143",
+              "locator": "70:5-70:140",
+              "type": "GreaterOrEqual",
+              "operand": [
+                {
+                  "localId": "141",
+                  "locator": "70:11-70:135",
+                  "name": "CalendarAgeInYearsAt",
+                  "libraryName": "Global",
+                  "type": "FunctionRef",
+                  "operand": [
+                    {
+                      "type": "ToDateTime",
+                      "operand": {
+                        "localId": "135",
+                        "locator": "70:41-70:77",
+                        "name": "ToDate",
+                        "libraryName": "FHIRHelpers",
+                        "type": "FunctionRef",
+                        "operand": [
+                          {
+                            "localId": "134",
+                            "locator": "70:60-70:76",
+                            "path": "birthDate",
+                            "type": "Property",
+                            "source": {
+                              "localId": "133",
+                              "locator": "70:60-70:66",
+                              "name": "Patient",
+                              "type": "ExpressionRef"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "localId": "140",
+                      "locator": "70:80-70:134",
+                      "type": "Start",
+                      "operand": {
+                        "localId": "139",
+                        "locator": "70:89-70:134",
+                        "name": "Normalize Interval",
+                        "libraryName": "Global",
+                        "type": "FunctionRef",
+                        "operand": [
+                          {
+                            "localId": "138",
+                            "locator": "70:117-70:133",
+                            "path": "effective",
+                            "scope": "HPVTest",
+                            "type": "Property"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                {
+                  "localId": "142",
+                  "locator": "70:139-70:140",
+                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                  "value": "30",
+                  "type": "Literal"
                 }
               ]
             }

--- a/test/fixtures/elm/queries/ExtraQueries.json
+++ b/test/fixtures/elm/queries/ExtraQueries.json
@@ -20,7 +20,7 @@
       {
         "type": "Annotation",
         "s": {
-          "r": "152",
+          "r": "160",
           "s": [
             {
               "value": [
@@ -1347,7 +1347,7 @@
         },
         {
           "localId": "63",
-          "locator": "72:1-73:17",
+          "locator": "76:1-77:17",
           "name": "A Function",
           "context": "Patient",
           "accessLevel": "Public",
@@ -1429,11 +1429,11 @@
           ],
           "expression": {
             "localId": "62",
-            "locator": "73:3-73:17",
+            "locator": "77:3-77:17",
             "type": "Start",
             "operand": {
               "localId": "61",
-              "locator": "73:12-73:17",
+              "locator": "77:12-77:17",
               "name": "period",
               "type": "OperandRef"
             }
@@ -1443,11 +1443,11 @@
               "name": "period",
               "operandTypeSpecifier": {
                 "localId": "60",
-                "locator": "72:37-72:54",
+                "locator": "76:37-76:54",
                 "type": "IntervalTypeSpecifier",
                 "pointType": {
                   "localId": "59",
-                  "locator": "72:46-72:53",
+                  "locator": "76:46-76:53",
                   "name": "{urn:hl7-org:elm-types:r1}DateTime",
                   "type": "NamedTypeSpecifier"
                 }
@@ -1717,7 +1717,7 @@
         },
         {
           "localId": "75",
-          "locator": "75:1-76:6",
+          "locator": "79:1-80:6",
           "name": "Passthrough",
           "context": "Patient",
           "accessLevel": "Public",
@@ -1774,7 +1774,7 @@
           ],
           "expression": {
             "localId": "74",
-            "locator": "76:3-76:6",
+            "locator": "80:3-80:6",
             "name": "cond",
             "type": "OperandRef"
           },
@@ -1783,7 +1783,7 @@
               "name": "cond",
               "operandTypeSpecifier": {
                 "localId": "73",
-                "locator": "75:36-75:44",
+                "locator": "79:36-79:44",
                 "name": "{http://hl7.org/fhir}Condition",
                 "type": "NamedTypeSpecifier"
               }
@@ -2904,7 +2904,7 @@
         },
         {
           "localId": "121",
-          "locator": "78:1-79:37",
+          "locator": "82:1-83:37",
           "name": "Interval From Period",
           "context": "Patient",
           "accessLevel": "Public",
@@ -2999,7 +2999,7 @@
           ],
           "expression": {
             "localId": "120",
-            "locator": "79:3-79:37",
+            "locator": "83:3-83:37",
             "name": "Normalize Interval",
             "libraryName": "Global",
             "type": "FunctionRef",
@@ -3008,7 +3008,7 @@
                 "type": "As",
                 "operand": {
                   "localId": "119",
-                  "locator": "79:31-79:36",
+                  "locator": "83:31-83:36",
                   "name": "period",
                   "type": "OperandRef"
                 },
@@ -3053,7 +3053,7 @@
               "name": "period",
               "operandTypeSpecifier": {
                 "localId": "117",
-                "locator": "78:47-78:57",
+                "locator": "82:47-82:57",
                 "name": "{http://hl7.org/fhir}Period",
                 "type": "NamedTypeSpecifier"
               }
@@ -3738,6 +3738,209 @@
                   "valueType": "{urn:hl7-org:elm-types:r1}Integer",
                   "value": "30",
                   "type": "Literal"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "localId": "153",
+          "locator": "72:1-74:30",
+          "name": "GreaterThanOrEqual Observation Value",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "153",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"GreaterThanOrEqual Observation Value\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "152",
+                    "s": [
+                      {
+                        "s": [
+                          {
+                            "r": "147",
+                            "s": [
+                              {
+                                "r": "146",
+                                "s": [
+                                  {
+                                    "r": "146",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "[",
+                                          "Observation",
+                                          ": "
+                                        ]
+                                      },
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"test-vs\""
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "]"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "Test"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "\n    "
+                        ]
+                      },
+                      {
+                        "r": "151",
+                        "s": [
+                          {
+                            "value": [
+                              "where "
+                            ]
+                          },
+                          {
+                            "r": "151",
+                            "s": [
+                              {
+                                "r": "149",
+                                "s": [
+                                  {
+                                    "r": "148",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "Test"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "."
+                                    ]
+                                  },
+                                  {
+                                    "r": "149",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "value"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  ">=",
+                                  " "
+                                ]
+                              },
+                              {
+                                "r": "150",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "2 ",
+                                      "'mg'"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "152",
+            "locator": "73:3-74:30",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "147",
+                "locator": "73:3-73:31",
+                "alias": "Test",
+                "expression": {
+                  "localId": "146",
+                  "locator": "73:3-73:26",
+                  "dataType": "{http://hl7.org/fhir}Observation",
+                  "templateId": "http://hl7.org/fhir/StructureDefinition/Observation",
+                  "codeProperty": "code",
+                  "codeComparator": "in",
+                  "type": "Retrieve",
+                  "codes": {
+                    "locator": "73:17-73:25",
+                    "name": "test-vs",
+                    "type": "ValueSetRef"
+                  }
+                }
+              }
+            ],
+            "relationship": [],
+            "where": {
+              "localId": "151",
+              "locator": "74:5-74:30",
+              "type": "GreaterOrEqual",
+              "operand": [
+                {
+                  "name": "ToQuantity",
+                  "libraryName": "FHIRHelpers",
+                  "type": "FunctionRef",
+                  "operand": [
+                    {
+                      "asType": "{http://hl7.org/fhir}Quantity",
+                      "type": "As",
+                      "operand": {
+                        "localId": "149",
+                        "locator": "74:11-74:20",
+                        "path": "value",
+                        "scope": "Test",
+                        "type": "Property"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "localId": "150",
+                  "locator": "74:25-74:30",
+                  "value": 2,
+                  "unit": "mg",
+                  "type": "Quantity"
                 }
               ]
             }

--- a/test/queryFilters/interpretExpression.test.ts
+++ b/test/queryFilters/interpretExpression.test.ts
@@ -1,9 +1,15 @@
 import { getELMFixture } from '../helpers/testHelpers';
 import * as QueryFilter from '../../src/QueryFilterHelpers';
 import { ELMFunctionRef } from '../../src/types/ELMTypes';
+import { R4 } from '@ahryman40k/ts-fhir-types';
 
 // to use as a library parameter for tests
 const complexQueryELM = getELMFixture('elm/queries/ComplexQueries.json');
+
+const PATIENT: R4.IPatient = {
+  resourceType: 'Patient',
+  birthDate: '1988-09-08'
+};
 
 describe('interpretExpression', () => {
   test('unknown expression type with property ref', () => {
@@ -27,7 +33,7 @@ describe('interpretExpression', () => {
       ]
     };
 
-    expect(QueryFilter.interpretExpression(functionRef, complexQueryELM, {})).toEqual({
+    expect(QueryFilter.interpretExpression(functionRef, complexQueryELM, {}, PATIENT)).toEqual({
       type: 'unknown',
       attribute: 'onset',
       alias: 'C'
@@ -54,7 +60,7 @@ describe('interpretExpression', () => {
       ]
     };
 
-    expect(QueryFilter.interpretExpression(functionRef, complexQueryELM, {})).toEqual({
+    expect(QueryFilter.interpretExpression(functionRef, complexQueryELM, {}, PATIENT)).toEqual({
       type: 'unknown'
     });
   });

--- a/test/queryFilters/interpretGreaterOrEqual.test.ts
+++ b/test/queryFilters/interpretGreaterOrEqual.test.ts
@@ -1,0 +1,106 @@
+import { getELMFixture } from '../helpers/testHelpers';
+import * as QueryFilter from '../../src/QueryFilterHelpers';
+import { ELMGreaterOrEqual } from '../../src/types/ELMTypes';
+import { R4 } from '@ahryman40k/ts-fhir-types';
+import { DuringFilter } from '../../src/types/QueryFilterTypes';
+import { removeIntervalFromFilter } from '../helpers/queryFilterTestHelpers';
+
+// to use as a library parameter for tests
+const EXTRA_QUERIES_ELM = getELMFixture('elm/queries/ExtraQueries.json');
+
+/** From ExtraQueries.cql "GreaterThanOrEqual Birthdate at start of Observation": */
+const GREATEROREQUAL_BIRTHDATE: ELMGreaterOrEqual = {
+  localId: '143',
+  locator: '70:5-70:140',
+  type: 'GreaterOrEqual',
+  operand: [
+    {
+      localId: '141',
+      locator: '70:11-70:135',
+      name: 'CalendarAgeInYearsAt',
+      libraryName: 'Global',
+      type: 'FunctionRef',
+      operand: [
+        {
+          type: 'ToDateTime',
+          operand: {
+            localId: '135',
+            locator: '70:41-70:77',
+            name: 'ToDate',
+            libraryName: 'FHIRHelpers',
+            type: 'FunctionRef',
+            operand: [
+              {
+                localId: '134',
+                locator: '70:60-70:76',
+                path: 'birthDate',
+                type: 'Property',
+                source: {
+                  localId: '133',
+                  locator: '70:60-70:66',
+                  name: 'Patient',
+                  type: 'ExpressionRef'
+                }
+              }
+            ]
+          }
+        },
+        {
+          localId: '140',
+          locator: '70:80-70:134',
+          type: 'Start',
+          operand: {
+            localId: '139',
+            locator: '70:89-70:134',
+            name: 'Normalize Interval',
+            libraryName: 'Global',
+            type: 'FunctionRef',
+            operand: [
+              {
+                localId: '138',
+                locator: '70:117-70:133',
+                path: 'effective',
+                scope: 'HPVTest',
+                type: 'Property'
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      localId: '142',
+      locator: '70:139-70:140',
+      valueType: '{urn:hl7-org:elm-types:r1}Integer',
+      value: '30',
+      type: 'Literal'
+    }
+  ]
+};
+
+const PATIENT: R4.IPatient = {
+  resourceType: 'Patient',
+  birthDate: '1988-09-08'
+};
+
+describe('interpretGreaterOrEqual', () => {
+  test('Start of parameter after 30th birthday', () => {
+    let filter: DuringFilter = QueryFilter.interpretGreaterOrEqual(
+      GREATEROREQUAL_BIRTHDATE,
+      EXTRA_QUERIES_ELM,
+      {},
+      PATIENT
+    ) as DuringFilter;
+    filter = removeIntervalFromFilter(filter);
+    expect(filter).toEqual({
+      type: 'during',
+      alias: 'HPVTest',
+      attribute: 'effective.start',
+      valuePeriod: {
+        start: '2018-09-08T00:00:00.000Z'
+      },
+      localId: '143',
+      notes: "Compares against the patient's birthDate (30 years)"
+    });
+  });
+});

--- a/test/queryFilters/interpretGreaterOrEqual.test.ts
+++ b/test/queryFilters/interpretGreaterOrEqual.test.ts
@@ -2,14 +2,14 @@ import { getELMFixture } from '../helpers/testHelpers';
 import * as QueryFilter from '../../src/QueryFilterHelpers';
 import { ELMGreaterOrEqual } from '../../src/types/ELMTypes';
 import { R4 } from '@ahryman40k/ts-fhir-types';
-import { DuringFilter } from '../../src/types/QueryFilterTypes';
+import { DuringFilter, UnknownFilter } from '../../src/types/QueryFilterTypes';
 import { removeIntervalFromFilter } from '../helpers/queryFilterTestHelpers';
 
 // to use as a library parameter for tests
 const EXTRA_QUERIES_ELM = getELMFixture('elm/queries/ExtraQueries.json');
 
-/** From ExtraQueries.cql "GreaterThanOrEqual Birthdate at start of Observation": */
-const GREATEROREQUAL_BIRTHDATE: ELMGreaterOrEqual = {
+/** From ExtraQueries.cql "GreaterThanOrEqual Birthdate at start of Observation" */
+const GREATEROREQUAL_BIRTHDATE_START: ELMGreaterOrEqual = {
   localId: '143',
   locator: '70:5-70:140',
   type: 'GreaterOrEqual',
@@ -78,15 +78,218 @@ const GREATEROREQUAL_BIRTHDATE: ELMGreaterOrEqual = {
   ]
 };
 
+/** Modified From ExtraQueries.cql "GreaterThanOrEqual Birthdate at start of Observation" to look at end of observation */
+const GREATEROREQUAL_BIRTHDATE_END: ELMGreaterOrEqual = {
+  localId: '143',
+  locator: '70:5-70:140',
+  type: 'GreaterOrEqual',
+  operand: [
+    {
+      localId: '141',
+      locator: '70:11-70:135',
+      name: 'CalendarAgeInYearsAt',
+      libraryName: 'Global',
+      type: 'FunctionRef',
+      operand: [
+        {
+          type: 'ToDateTime',
+          operand: {
+            localId: '135',
+            locator: '70:41-70:77',
+            name: 'ToDate',
+            libraryName: 'FHIRHelpers',
+            type: 'FunctionRef',
+            operand: [
+              {
+                localId: '134',
+                locator: '70:60-70:76',
+                path: 'birthDate',
+                type: 'Property',
+                source: {
+                  localId: '133',
+                  locator: '70:60-70:66',
+                  name: 'Patient',
+                  type: 'ExpressionRef'
+                }
+              }
+            ]
+          }
+        },
+        {
+          localId: '140',
+          locator: '70:80-70:134',
+          type: 'End',
+          operand: {
+            localId: '139',
+            locator: '70:89-70:134',
+            name: 'Normalize Interval',
+            libraryName: 'Global',
+            type: 'FunctionRef',
+            operand: [
+              {
+                localId: '138',
+                locator: '70:117-70:133',
+                path: 'effective',
+                scope: 'HPVTest',
+                type: 'Property'
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      localId: '142',
+      locator: '70:139-70:140',
+      valueType: '{urn:hl7-org:elm-types:r1}Integer',
+      value: '30',
+      type: 'Literal'
+    }
+  ]
+};
+
+/** Modified From ExtraQueries.cql "GreaterThanOrEqual Birthdate at start of Observation" to do something unexpected with sending the birthdate through NormalizeInterval */
+const GREATEROREQUAL_BIRTHDATE_UNEXPECTED_OPERAND: ELMGreaterOrEqual = {
+  localId: '143',
+  locator: '70:5-70:140',
+  type: 'GreaterOrEqual',
+  operand: [
+    {
+      localId: '141',
+      locator: '70:11-70:135',
+      name: 'CalendarAgeInYearsAt',
+      libraryName: 'Global',
+      type: 'FunctionRef',
+      operand: [
+        {
+          type: 'FunctionRef',
+          name: 'NormalizeInterval',
+          libraryName: 'global',
+          operand: [
+            {
+              localId: '135',
+              locator: '70:41-70:77',
+              name: 'ToDate',
+              libraryName: 'FHIRHelpers',
+              type: 'FunctionRef',
+              operand: [
+                {
+                  localId: '134',
+                  locator: '70:60-70:76',
+                  path: 'birthDate',
+                  type: 'Property',
+                  source: {
+                    localId: '133',
+                    locator: '70:60-70:66',
+                    name: 'Patient',
+                    type: 'ExpressionRef'
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          localId: '140',
+          locator: '70:80-70:134',
+          type: 'Start',
+          operand: {
+            localId: '139',
+            locator: '70:89-70:134',
+            name: 'Normalize Interval',
+            libraryName: 'Global',
+            type: 'FunctionRef',
+            operand: [
+              {
+                localId: '138',
+                locator: '70:117-70:133',
+                path: 'effective',
+                scope: 'HPVTest',
+                type: 'Property'
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      localId: '142',
+      locator: '70:139-70:140',
+      valueType: '{urn:hl7-org:elm-types:r1}Integer',
+      value: '30',
+      type: 'Literal'
+    }
+  ]
+};
+
+/** From ExtraQueries.cql "GreaterThanOrEqual Obeservation Value": */
+const GREATEROREQUAL_VALUE: ELMGreaterOrEqual = {
+  localId: '151',
+  locator: '74:5-74:30',
+  type: 'GreaterOrEqual',
+  operand: [
+    {
+      name: 'ToQuantity',
+      libraryName: 'FHIRHelpers',
+      type: 'FunctionRef',
+      operand: [
+        {
+          asType: '{http://hl7.org/fhir}Quantity',
+          type: 'As',
+          operand: {
+            localId: '149',
+            locator: '74:11-74:20',
+            path: 'value',
+            scope: 'Test',
+            type: 'Property'
+          }
+        }
+      ]
+    },
+    {
+      localId: '150',
+      locator: '74:25-74:30',
+      value: 2,
+      unit: 'mg',
+      type: 'Quantity'
+    }
+  ]
+};
+
+/** Modified from ExtraQueries.cql "GreaterThanOrEqual Obeservation Value" to compare a literal to a quantity. This is to test unexpected first operand. */
+const GREATEROREQUAL_LITERAL_TO_VALUE: ELMGreaterOrEqual = {
+  localId: '151',
+  locator: '74:5-74:30',
+  type: 'GreaterOrEqual',
+  operand: [
+    {
+      type: 'Literal',
+      valueType: 'decimal',
+      value: 3
+    },
+    {
+      localId: '150',
+      locator: '74:25-74:30',
+      value: 2,
+      unit: 'mg',
+      type: 'Quantity'
+    }
+  ]
+};
+
 const PATIENT: R4.IPatient = {
   resourceType: 'Patient',
   birthDate: '1988-09-08'
 };
 
+const PATIENT_NO_BIRTHDATE: R4.IPatient = {
+  resourceType: 'Patient'
+};
+
 describe('interpretGreaterOrEqual', () => {
   test('Start of parameter after 30th birthday', () => {
     let filter: DuringFilter = QueryFilter.interpretGreaterOrEqual(
-      GREATEROREQUAL_BIRTHDATE,
+      GREATEROREQUAL_BIRTHDATE_START,
       EXTRA_QUERIES_ELM,
       {},
       PATIENT
@@ -101,6 +304,82 @@ describe('interpretGreaterOrEqual', () => {
       },
       localId: '143',
       notes: "Compares against the patient's birthDate (30 years)"
+    });
+  });
+
+  test('End of parameter after 30th birthday', () => {
+    let filter: DuringFilter = QueryFilter.interpretGreaterOrEqual(
+      GREATEROREQUAL_BIRTHDATE_END,
+      EXTRA_QUERIES_ELM,
+      {},
+      PATIENT
+    ) as DuringFilter;
+    filter = removeIntervalFromFilter(filter);
+    expect(filter).toEqual({
+      type: 'during',
+      alias: 'HPVTest',
+      attribute: 'effective.end',
+      valuePeriod: {
+        start: '2018-09-08T00:00:00.000Z'
+      },
+      localId: '143',
+      notes: "Compares against the patient's birthDate (30 years)"
+    });
+  });
+
+  test('patient has no birthdate results in unknown with a note', () => {
+    const filter: UnknownFilter = QueryFilter.interpretGreaterOrEqual(
+      GREATEROREQUAL_BIRTHDATE_START,
+      EXTRA_QUERIES_ELM,
+      {},
+      PATIENT_NO_BIRTHDATE
+    ) as UnknownFilter;
+
+    expect(filter).toEqual({
+      type: 'unknown',
+      alias: 'HPVTest',
+      attribute: 'effective.start',
+      localId: '143',
+      notes: "Compares against the patient's birthDate. But patient did not have birthDate."
+    });
+  });
+
+  test('Unexpected operands in CalendarAgeInYearsAt gracefully fail', () => {
+    const filter: UnknownFilter = QueryFilter.interpretGreaterOrEqual(
+      GREATEROREQUAL_BIRTHDATE_UNEXPECTED_OPERAND,
+      EXTRA_QUERIES_ELM,
+      {},
+      PATIENT
+    ) as UnknownFilter;
+
+    expect(filter).toEqual({
+      type: 'unknown'
+    });
+  });
+
+  test('literal to quantity comparison is unexpected ELM should gracefully fail', () => {
+    const filter: UnknownFilter = QueryFilter.interpretGreaterOrEqual(
+      GREATEROREQUAL_LITERAL_TO_VALUE,
+      EXTRA_QUERIES_ELM,
+      {},
+      PATIENT
+    ) as UnknownFilter;
+
+    expect(filter).toEqual({
+      type: 'unknown'
+    });
+  });
+
+  test('attribute quantity comparison - not supported yet', () => {
+    const filter: UnknownFilter = QueryFilter.interpretGreaterOrEqual(
+      GREATEROREQUAL_VALUE,
+      EXTRA_QUERIES_ELM,
+      {},
+      PATIENT
+    ) as UnknownFilter;
+
+    expect(filter).toEqual({
+      type: 'unknown'
     });
   });
 });

--- a/test/queryFilters/parseQueryInfo.test.ts
+++ b/test/queryFilters/parseQueryInfo.test.ts
@@ -3,6 +3,7 @@ import { parseQueryInfo } from '../../src/QueryFilterHelpers';
 import * as cql from 'cql-execution';
 import { QueryInfo, DuringFilter, AndFilter } from '../../src/types/QueryFilterTypes';
 import { removeIntervalFromFilter } from '../helpers/queryFilterTestHelpers';
+import { R4 } from '@ahryman40k/ts-fhir-types';
 
 const simpleQueryELM = getELMFixture('elm/queries/SimpleQueries.json');
 const complexQueryELM = getELMFixture('elm/queries/ComplexQueries.json');
@@ -178,16 +179,21 @@ const EXPECTED_CODE_OR_STARTS_DURING_MP_OR_NOT_NULL: QueryInfo = {
   }
 };
 
+const PATIENT: R4.IPatient = {
+  resourceType: 'Patient',
+  birthDate: '1988-09-08'
+};
+
 describe('Parse Query Info', () => {
   test('simple valueset with id check', () => {
     const queryLocalId = simpleQueryELM.library.statements.def[2].expression.localId; // expression with aliased query
-    const queryInfo = parseQueryInfo(simpleQueryELM, queryLocalId, PARAMETERS);
+    const queryInfo = parseQueryInfo(simpleQueryELM, queryLocalId, PARAMETERS, PATIENT);
     expect(queryInfo).toEqual(EXPECTED_VS_WITH_ID_CHECK_QUERY);
   });
 
   test('simple valueset with id check with no parameters passed in', () => {
     const queryLocalId = simpleQueryELM.library.statements.def[2].expression.localId; // expression with aliased query
-    const queryInfo = parseQueryInfo(simpleQueryELM, queryLocalId);
+    const queryInfo = parseQueryInfo(simpleQueryELM, queryLocalId, undefined, PATIENT);
     expect(queryInfo).toEqual(EXPECTED_VS_WITH_ID_CHECK_QUERY);
   });
 
@@ -197,7 +203,7 @@ describe('Parse Query Info', () => {
       fail('Could not find statement.');
     }
     const queryLocalId = statement.expression.localId;
-    const queryInfo = parseQueryInfo(complexQueryELM, queryLocalId, PARAMETERS);
+    const queryInfo = parseQueryInfo(complexQueryELM, queryLocalId, PARAMETERS, PATIENT);
     expect(queryInfo).toEqual(EXPECTED_CODE_AND_STARTS_DURING_MP);
   });
 
@@ -209,7 +215,7 @@ describe('Parse Query Info', () => {
       fail('Could not find statement.');
     }
     const queryLocalId = statement.expression.localId;
-    const queryInfo = parseQueryInfo(complexQueryELM, queryLocalId, PARAMETERS);
+    const queryInfo = parseQueryInfo(complexQueryELM, queryLocalId, PARAMETERS, PATIENT);
     expect(queryInfo).toEqual(EXPECTED_STATUS_VALUE_EXISTS_DURING_MP);
   });
 
@@ -221,7 +227,7 @@ describe('Parse Query Info', () => {
       fail('Could not find statement.');
     }
     const queryLocalId = statement.expression.localId;
-    const queryInfo = parseQueryInfo(complexQueryELM, queryLocalId, PARAMETERS);
+    const queryInfo = parseQueryInfo(complexQueryELM, queryLocalId, PARAMETERS, PATIENT);
 
     const filter = queryInfo.filter as AndFilter;
 
@@ -243,13 +249,13 @@ describe('Parse Query Info', () => {
       fail('Could not find statement.');
     }
     const queryLocalId = statement.expression.localId;
-    const queryInfo = parseQueryInfo(complexQueryELM, queryLocalId, PARAMETERS);
+    const queryInfo = parseQueryInfo(complexQueryELM, queryLocalId, PARAMETERS, PATIENT);
     expect(queryInfo).toEqual(EXPECTED_CODE_OR_STARTS_DURING_MP_OR_NOT_NULL);
   });
 
   test('incorrect localid should throw error', () => {
     expect(() => {
-      parseQueryInfo(simpleQueryELM, '360', PARAMETERS);
+      parseQueryInfo(simpleQueryELM, '360', PARAMETERS, PATIENT);
     }).toThrow('Clause 360 in SimpleQueries was not a Query or not found.');
   });
 });


### PR DESCRIPTION
# Summary

Implements parsing of ELM GreaterOrEqual cases when it is used to compare a datetime on a resource against the patient's age at that time. This brings support for EXM124. https://jira.mitre.org/browse/TACOSTRAT-570

This also updates NPM dependencies with security concerns.

## New behavior
- Passes the Patient resource into the detailed query filters parsing.
- Can parse GreaterOrEqual expressions when they compare patient age at the time of an event. This returns a 'during' filter with an interval that starts at the time of the expected offset. ex. "..AgeAt.." >= 30 becomes an interval filter that starts on the patient's 30th birthday.

## Code changes
- Moved patient resource fetching earlier in the gaps report process.
- Pass the patient resource into the query filter parsing.
- Parsing code for GreaterOrEqual.
- ELMType additions for GreaterOrEqual, ToDateTime and Quantity.
- Added optional `notes` field to all QueryFilters for that may be helpful in reports.
- Updated NPM dependencies to resolve security concerns.

# Testing guidance
- Test gaps report creation with a EXM124 denominator patient. There should be no `'unknown'` filters in the gaps.json debug output and there should be a GuidanceResponse with a dateFilter that starts 30 years after the patient's birthdate.