### PR TITLE
Initial DataRequirements function

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ const rawResults = await Calculator.calculateRaw(measureBundle, patientBundles, 
 const detailedResults = await Calculator.calculate(measureBundle, patientBundles, options); // Get detailed population results for each patient
 const measureReports = await Calculator.calculateMeasureReports(measureBundle, patientBundles, options); // Get individual FHIR MeasureReports for each patient
 const gapsInCare = await Calculator.calculateGapsInCare(measureBundle, patientBundles, options); // Get gaps in care for each patient, if present
+const dataRequirements = Calculator.calculateGapsInCare(measureBundle); // Get data requirements for a given measure (in a bundle)
 ```
 
 #### Require
@@ -55,6 +56,7 @@ const rawResults = await Calculator.calculateRaw(measureBundle, patientBundles, 
 const detailedResults = await Calculator.calculate(measureBundle, patientBundles, options); // Get detailed population results for each patient
 const measureReports = await Calculator.calculateMeasureReports(measureBundle, patientBundles, options); // Get individual FHIR MeasureReports for each patient
 const gapsInCare = await Calculator.calculateGapsInCare(measureBundle, patientBundles, options); // Get gaps in care for each patient, if present
+const dataRequirements = Calculator.calculateGapsInCare(measureBundle); // Get data requirements for a given measure (in a bundle)
 ```
 
 #### Calculation Options
@@ -83,7 +85,7 @@ Usage: fqm-execution [options]
 
 Options:
   -d, --debug                                 enable debug output (default: false)
-  -o, --output-type <type>                    type of output, "raw", "detailed", "reports", "gaps" (default: "detailed")
+  -o, --output-type <type>                    type of output, "raw", "detailed", "reports", "gaps", "dataRequirements" (default: "detailed")
   -r, --report-type <type>                    type of MeasureReport (only for output type "reports"): "summary" or "individual" (default: "individual")
   -m, --measure-bundle <measure-bundle>       path to measure bundle
   -p, --patient-bundles <patient-bundles...>  paths to patient bundle

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ const rawResults = await Calculator.calculateRaw(measureBundle, patientBundles, 
 const detailedResults = await Calculator.calculate(measureBundle, patientBundles, options); // Get detailed population results for each patient
 const measureReports = await Calculator.calculateMeasureReports(measureBundle, patientBundles, options); // Get individual FHIR MeasureReports for each patient
 const gapsInCare = await Calculator.calculateGapsInCare(measureBundle, patientBundles, options); // Get gaps in care for each patient, if present
-const dataRequirements = Calculator.calculateGapsInCare(measureBundle); // Get data requirements for a given measure (in a bundle)
+const dataRequirements = Calculator.calculateDataRequirements(measureBundle); // Get data requirements for a given measure (in a bundle)
 ```
 
 #### Require
@@ -56,7 +56,7 @@ const rawResults = await Calculator.calculateRaw(measureBundle, patientBundles, 
 const detailedResults = await Calculator.calculate(measureBundle, patientBundles, options); // Get detailed population results for each patient
 const measureReports = await Calculator.calculateMeasureReports(measureBundle, patientBundles, options); // Get individual FHIR MeasureReports for each patient
 const gapsInCare = await Calculator.calculateGapsInCare(measureBundle, patientBundles, options); // Get gaps in care for each patient, if present
-const dataRequirements = Calculator.calculateGapsInCare(measureBundle); // Get data requirements for a given measure (in a bundle)
+const dataRequirements = Calculator.calculateDataRequirements(measureBundle); // Get data requirements for a given measure (in a bundle)
 ```
 
 #### Calculation Options

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fqm-execution",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1840,6 +1840,12 @@
       "integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
       "dev": true
     },
+    "@types/lodash": {
+      "version": "4.14.170",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.170.tgz",
+      "integrity": "sha512-bpcvu/MKHHeYX+qeEN8GE7DIravODWdACVA1ctevD8CN24RhPZIKMn9ntfAsrvLfSX3cR5RrBKAbYm9bGs0A+Q==",
+      "dev": true
+    },
     "@types/node": {
       "version": "14.14.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.7.tgz",
@@ -2107,7 +2113,8 @@
     "arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
     },
     "argparse": {
       "version": "1.0.10",
@@ -2509,7 +2516,8 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
     },
     "cache-base": {
       "version": "1.0.1",
@@ -2871,7 +2879,8 @@
     "create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -3037,7 +3046,8 @@
     "diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true
     },
     "diff-sequences": {
       "version": "26.6.2",
@@ -6100,7 +6110,8 @@
     "make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "makeerror": {
       "version": "1.0.11",
@@ -7272,6 +7283,7 @@
       "version": "0.5.19",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
       "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -7280,7 +7292,8 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
         }
       }
     },
@@ -7710,6 +7723,7 @@
       "version": "9.1.1",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
       "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+      "dev": true,
       "requires": {
         "arg": "^4.1.0",
         "create-require": "^1.1.0",
@@ -8194,7 +8208,8 @@
     "yn": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fqm-execution",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "FHIR Quality Measure Execution",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -18,12 +18,14 @@
     "cql-exec-fhir": "1.5.0-beta.1",
     "cql-execution": "^2.2.0",
     "handlebars": "^4.7.7",
+    "lodash": "^4.17.21",
     "moment": "^2.29.0",
     "uuid": "^8.3.1"
   },
   "devDependencies": {
     "@types/handlebars": "^4.1.0",
     "@types/jest": "^26.0.5",
+    "@types/lodash": "^4.14.170",
     "@types/node": "^14.0.23",
     "@types/uuid": "^8.3.0",
     "@typescript-eslint/eslint-plugin": "^3.2.0",

--- a/src/Calculator.ts
+++ b/src/Calculator.ts
@@ -430,10 +430,10 @@ export async function calculateGapsInCare(
 
 export function calculateDataRequirements(
   measureBundle: R4.IBundle
-): { results: R4.ILibrary; debugOutput?: DebugOutput }  {
+): { results: R4.ILibrary; debugOutput?: DebugOutput } {
   // Extract the library ELM, and the id of the root library, from the measure bundle
   const { cqls, rootLibIdentifier, elmJSONs } = MeasureHelpers.extractLibrariesFromBundle(measureBundle);
-  const rootLib = elmJSONs.find( ej => ej.library.identifier == rootLibIdentifier);
+  const rootLib = elmJSONs.find(ej => ej.library.identifier == rootLibIdentifier);
 
   // We need a root library to run dataRequirements properly. If we don't have one, error out.
   if (!rootLib?.library) {
@@ -441,26 +441,22 @@ export function calculateDataRequirements(
   }
 
   // get the retrieves for every statement in the root library
-  const allRetrieves = rootLib.library.statements.def.flatMap((statement) => {
+  const allRetrieves = rootLib.library.statements.def.flatMap(statement => {
     if (statement.expression && statement.name != 'Patient') {
-      const retrieves = RetrievesHelper.findRetrieves(
-        rootLib,
-        elmJSONs,
-        statement.expression
-      );
+      const retrieves = RetrievesHelper.findRetrieves(rootLib, elmJSONs, statement.expression);
       return retrieves;
     } else {
       return [];
     }
   });
   const uniqueRetrieves = uniqWith(allRetrieves, isEqual);
-  const results: R4.ILibrary = { 
+  const results: R4.ILibrary = {
     resourceType: 'Library',
     type: { coding: [{ code: 'module-definition', system: 'http://terminology.hl7.org/CodeSystem/library-type' }] },
     dataRequirement: []
   };
 
-  uniqueRetrieves.forEach((retrieve) => {
+  uniqueRetrieves.forEach(retrieve => {
     results.dataRequirement?.push({
       type: retrieve.dataType,
       codeFilter: [
@@ -471,8 +467,8 @@ export function calculateDataRequirements(
     });
   });
 
-  return { 
-    results: results, 
+  return {
+    results: results,
     debugOutput: {
       cql: cqls,
       elm: elmJSONs,

--- a/src/Calculator.ts
+++ b/src/Calculator.ts
@@ -461,6 +461,7 @@ export function calculateDataRequirements(
       type: retrieve.dataType,
       codeFilter: [
         {
+          path: retrieve.path,
           valueSet: retrieve.valueSet
         }
       ]

--- a/src/Calculator.ts
+++ b/src/Calculator.ts
@@ -456,7 +456,7 @@ export function calculateDataRequirements(
   const uniqueRetrieves = uniqWith(allRetrieves, isEqual);
   const results: R4.ILibrary = { 
     resourceType: 'Library',
-    type: { coding: [{ code: 'logic-library', system: 'http://terminology.hl7.org/CodeSystem/library-type' }] },
+    type: { coding: [{ code: 'module-definition', system: 'http://terminology.hl7.org/CodeSystem/library-type' }] },
     dataRequirement: []
   };
 

--- a/src/CalculatorHelpers.ts
+++ b/src/CalculatorHelpers.ts
@@ -1,6 +1,6 @@
 import { R4 } from '@ahryman40k/ts-fhir-types';
 import { DetailedPopulationGroupResult, EpisodeResults, PopulationResult, StratifierResult } from './types/Calculator';
-import * as MeasureHelpers from './MeasureHelpers';
+import * as MeasureHelpers from './helpers/MeasureHelpers';
 import { getResult, hasResult, setResult, createOrSetResult } from './ResultsHelpers';
 import { ELM, ELMStatement } from './types/ELMTypes';
 import { PopulationType } from './types/Enums';

--- a/src/Execution.ts
+++ b/src/Execution.ts
@@ -4,12 +4,12 @@ import { CalculationOptions, RawExecutionData, DebugOutput } from './types/Calcu
 // import { PatientSource } from 'cql-exec-fhir';
 import cql from 'cql-execution';
 import { PatientSource } from 'cql-exec-fhir';
-import { ELM, ELMIdentifier } from './types/ELMTypes';
 import { parseTimeStringAsUTC, valueSetsForCodeService, getMissingDependentValuesets } from './helpers/ValueSetHelper';
-import { codeableConceptToPopulationType, isValidLibraryURL } from './MeasureHelpers';
+import { codeableConceptToPopulationType } from './helpers/MeasureHelpers';
 import { PopulationType } from './types/Enums';
 import { generateELMJSONFunction } from './CalculatorHelpers';
 import { ValueSetResolver } from './helpers/ValueSetResolver';
+import * as MeasureHelpers from './helpers/MeasureHelpers';
 
 export async function execute(
   measureBundle: R4.IBundle,
@@ -18,12 +18,8 @@ export async function execute(
   debugObject?: DebugOutput
 ): Promise<RawExecutionData> {
   // Determine "root" library by looking at which lib is referenced by populations, and pull out the ELM
-  const measureEntry = measureBundle.entry?.find(e => e.resource?.resourceType === 'Measure') as R4.IBundle_Entry;
-  const measure = measureEntry.resource as R4.IMeasure;
-  if (measure?.library === undefined) {
-    // TODO: handle no library case
-    return { errorMessage: 'library not identified in measure' };
-  }
+  const measure = MeasureHelpers.extractMeasureFromBundle(measureBundle);
+
   // check for any missing valuesets
   let valueSets: R4.IValueSet[] = [];
   const missingVS = getMissingDependentValuesets(measureBundle);
@@ -53,61 +49,7 @@ export async function execute(
   });
   const vsMap = valueSetsForCodeService(valueSets);
 
-  const rootLibRef = measure?.library[0];
-  let rootLibId: string;
-  if (isValidLibraryURL(rootLibRef)) rootLibId = rootLibRef;
-  else rootLibId = rootLibRef.substring(rootLibRef.indexOf('/') + 1);
-
-  const libraries: R4.ILibrary[] = [];
-  const elmJSONs: ELM[] = [];
-  const cqls: { name: string; cql: string }[] = [];
-  let rootLibIdentifer: ELMIdentifier = {
-    id: '',
-    version: ''
-  };
-  measureBundle.entry?.forEach(e => {
-    if (e.resource?.resourceType == 'Library') {
-      const library = e.resource as R4.ILibrary;
-      libraries.push(library);
-      const elmsEncoded = library.content?.filter(a => a.contentType === 'application/elm+json');
-      elmsEncoded?.forEach(elmEncoded => {
-        if (elmEncoded.data) {
-          const decoded = Buffer.from(elmEncoded.data, 'base64').toString('binary');
-          const elm = JSON.parse(decoded) as ELM;
-          if (library.url == rootLibId) {
-            rootLibIdentifer = elm.library.identifier;
-          } else if (library.id === rootLibId) {
-            rootLibIdentifer = elm.library.identifier;
-          }
-          if (elm.library?.includes?.def) {
-            elm.library.includes.def = elm.library.includes.def.map(def => {
-              def.path = def.path.substring(def.path.lastIndexOf('/') + 1);
-
-              return def;
-            });
-          }
-          elmJSONs.push(elm);
-        }
-      });
-
-      const cqlsEncoded = library.content?.filter(a => a.contentType === 'text/cql');
-      cqlsEncoded?.forEach(elmEncoded => {
-        if (elmEncoded.data) {
-          const decoded = Buffer.from(elmEncoded.data, 'base64').toString('binary');
-          const cql = {
-            name: library.name || library.id || 'unknown library',
-            cql: decoded
-          };
-          cqls.push(cql);
-        }
-      });
-    }
-  });
-
-  // TODO: throw an error here if we can't find the root lib
-  if (rootLibIdentifer.id === '') {
-    return { errorMessage: 'no library' };
-  }
+  const { cqls, rootLibIdentifier, elmJSONs } = MeasureHelpers.extractLibrariesFromBundle(measureBundle);
 
   // Measure datetime stuff
   let start;
@@ -137,7 +79,7 @@ export async function execute(
           population => codeableConceptToPopulationType(population.code) === PopulationType.MSRPOPL
         );
         if (msrPop?.criteria?.expression && obsrvPop.criteria?.expression) {
-          const mainLib = elmJSONs.find(elm => elm.library.identifier.id === rootLibIdentifer.id);
+          const mainLib = elmJSONs.find(elm => elm.library.identifier.id === rootLibIdentifier.id);
           if (mainLib) {
             mainLib.library.statements.def.push(
               generateELMJSONFunction(obsrvPop.criteria.expression, msrPop.criteria.expression)
@@ -151,7 +93,7 @@ export async function execute(
   const parameters = { 'Measurement Period': new cql.Interval(startCql, endCql) };
   const executionDateTime = cql.DateTime.fromJSDate(new Date(), 0);
   const rep = new cql.Repository(elmJSONs);
-  const lib = rep.resolve(rootLibIdentifer.id, rootLibIdentifer.version);
+  const lib = rep.resolve(rootLibIdentifier.id, rootLibIdentifier.version);
   const executor = new cql.Executor(lib, codeService, parameters);
   const results = executor.exec(patientSource, executionDateTime);
 
@@ -167,5 +109,5 @@ export async function execute(
     debugObject.rawResults = results;
   }
 
-  return { rawResults: results, elmLibraries: elmJSONs, mainLibraryName: rootLibIdentifer.id, parameters: parameters };
+  return { rawResults: results, elmLibraries: elmJSONs, mainLibraryName: rootLibIdentifier.id, parameters: parameters };
 }

--- a/src/GapsInCareHelpers.ts
+++ b/src/GapsInCareHelpers.ts
@@ -8,7 +8,11 @@ import {
   ReasonDetail
 } from './types/Calculator';
 import { FinalResult, ImprovementNotation, CareGapReasonCode, CareGapReasonCodeDisplay } from './types/Enums';
-import { flattenFilters, generateDetailedCodeFilter, generateDetailedDateFilter } from './DataRequirementHelpers';
+import {
+  flattenFilters,
+  generateDetailedCodeFilter,
+  generateDetailedDateFilter
+} from './helpers/DataRequirementHelpers';
 import { EqualsFilter, InFilter, DuringFilter, AnyFilter } from './types/QueryFilterTypes';
 
 /**

--- a/src/MeasureReportBuilder.ts
+++ b/src/MeasureReportBuilder.ts
@@ -7,6 +7,7 @@ import {
 } from './types/Calculator';
 import { PopulationType, MeasureScoreType, AggregationType } from './types/Enums';
 import { v4 as uuidv4 } from 'uuid';
+import * as MeasureHelpers from './helpers/MeasureHelpers';
 
 export default class MeasureReportBuilder {
   report: R4.IMeasureReport;
@@ -24,8 +25,7 @@ export default class MeasureReportBuilder {
       resourceType: 'MeasureReport'
     };
     this.measureBundle = measureBundle;
-    const measureEntry = this.measureBundle.entry?.find(e => e.resource?.resourceType === 'Measure');
-    this.measure = measureEntry?.resource as R4.IMeasure;
+    this.measure = MeasureHelpers.extractMeasureFromBundle(measureBundle);
     this.scoringCode =
       this.measure.scoring?.coding?.find(c => c.system === 'http://hl7.org/fhir/measure-scoring')?.code || '';
     this.options = options;

--- a/src/QueryFilterHelpers.ts
+++ b/src/QueryFilterHelpers.ts
@@ -21,7 +21,8 @@ import {
   ELMNot,
   ELMIsNull,
   ELMUnaryExpression,
-  ELMInterval
+  ELMInterval,
+  ELMCodeSystem
 } from './types/ELMTypes';
 import {
   AndFilter,
@@ -416,7 +417,9 @@ export function getCodesInConcept(name: string, library: ELM): R4.ICoding[] {
       if (code) {
         codes.push({
           code: code?.id,
-          system: library.library.codeSystems.def.find((systemRef: any) => code?.codeSystem.name === systemRef.name).id
+          system: library.library.codeSystems?.def.find(
+            (systemRef: ELMCodeSystem) => code?.codeSystem.name === systemRef.name
+          )?.id
         });
       }
     });

--- a/src/QueryFilterHelpers.ts
+++ b/src/QueryFilterHelpers.ts
@@ -48,7 +48,15 @@ import {
  *                    seen in eCQMs.
  * @returns Information about the query and how it is filtered.
  */
-export function parseQueryInfo(library: ELM, queryLocalId: string, parameters: { [key: string]: any } = {}): QueryInfo {
+export function parseQueryInfo(
+  library: ELM,
+  queryLocalId?: string,
+  parameters: { [key: string]: any } = {}
+): QueryInfo {
+  if (!queryLocalId) {
+    throw new Error('QueryLocalId was not provided');
+  }
+
   const expression = findClauseInLibrary(library, queryLocalId);
   if (expression?.type == 'Query') {
     const query = expression as ELMQuery;

--- a/src/ResultsHelpers.ts
+++ b/src/ResultsHelpers.ts
@@ -1,4 +1,4 @@
-import * as MeasureHelpers from './MeasureHelpers';
+import * as MeasureHelpers from './helpers/MeasureHelpers';
 import * as ELMDependencyHelper from './ELMDependencyHelper';
 import { ELM, LibraryDependencyInfo } from './types/ELMTypes';
 import * as cql from './types/CQLTypes';

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,7 +23,10 @@ program
   )
   .option('-r, --report-type <report-type>', 'type of report, "individual", "summary", "subject-list"')
   .requiredOption('-m, --measure-bundle <measure-bundle>', 'path to measure bundle')
-  .option('-p, --patient-bundles <patient-bundles...>', 'paths to patient bundles. Required unless output type is dataRequirements')
+  .option(
+    '-p, --patient-bundles <patient-bundles...>',
+    'paths to patient bundles. Required unless output type is dataRequirements'
+  )
   .option(
     '-s, --measurement-period-start <date>',
     'start date for the measurement period, in YYYY-MM-DD format (defaults to the start date defined in the Measure, or 2019-01-01 if not set there)',
@@ -72,7 +75,7 @@ const measureBundle = parseBundle(path.resolve(program.measureBundle));
 
 let patientBundles: R4.IBundle[];
 if (program.outputType !== 'dataRequirements') {
-  // Since patient bundles are no longer a mandatory CLI option, we should check if we were given any before 
+  // Since patient bundles are no longer a mandatory CLI option, we should check if we were given any before
   if (!program.patientBundles) {
     console.error(`Patient bundle is a required option when output type is "${program.outputType}"`);
     program.help();

--- a/src/helpers/DataRequirementHelpers.ts
+++ b/src/helpers/DataRequirementHelpers.ts
@@ -1,5 +1,6 @@
 import { R4 } from '@ahryman40k/ts-fhir-types';
-import { EqualsFilter, InFilter, DuringFilter, AndFilter, AnyFilter } from './types/QueryFilterTypes';
+import { DataTypeQuery } from '../types/Calculator';
+import { EqualsFilter, InFilter, DuringFilter, AndFilter, AnyFilter } from '../types/QueryFilterTypes';
 
 /**
  * Take any nesting of base filters and AND filters and flatten into one list
@@ -66,4 +67,39 @@ export function generateDetailedDateFilter(filter: DuringFilter): R4.IDataRequir
     path: filter.attribute,
     valuePeriod: { start: filter.valuePeriod.start, end: filter.valuePeriod.end }
   };
+}
+
+/**
+ * Given a DataTypeQuery object, create a DataRequirement object that represents the data
+ * that would be requested from a FHIR server for that query.
+ * Currently supports
+ * @param retrieve a DataTypeQuery that represents a retrieve for a FHIR Resource with certain attributes
+ * @returns R4.IDataRequirement with as much attribute data as we can add
+ */
+export function generateDataRequirement(retrieve: DataTypeQuery): R4.IDataRequirement {
+  if (retrieve.valueSet) {
+    return {
+      type: retrieve.dataType,
+      codeFilter: [
+        {
+          path: retrieve.path,
+          valueSet: retrieve.valueSet
+        }
+      ]
+    };
+  } else if (retrieve.code) {
+    return {
+      type: retrieve.dataType,
+      codeFilter: [
+        {
+          path: retrieve.path,
+          code: [retrieve.code as R4.ICoding]
+        }
+      ]
+    };
+  } else {
+    return {
+      type: retrieve.dataType
+    };
+  }
 }

--- a/src/helpers/MeasureHelpers.ts
+++ b/src/helpers/MeasureHelpers.ts
@@ -1,7 +1,7 @@
-import { ELM, ELMStatement } from './types/ELMTypes';
+import { ELM, ELMIdentifier, ELMStatement } from '../types/ELMTypes';
 import { R4 } from '@ahryman40k/ts-fhir-types';
-import { PopulationType } from './types/Enums';
-import { CalculationOptions } from './types/Calculator';
+import { PopulationType } from '../types/Enums';
+import { CalculationOptions } from '../types/Calculator';
 
 /**
  * Finds all localIds in a statement by it's library and statement name.
@@ -13,7 +13,7 @@ import { CalculationOptions } from './types/Calculator';
 export function findAllLocalIdsInStatementByName(libraryElm: ELM, statementName: string): any {
   // create place for aliases and their usages to be placed to be filled in later. Aliases and their usages (aka scope)
   // and returns do not have localIds in the elm but do in elm_annotations at a consistent calculable offset.
-  // BE WEARY of this calaculable offset.
+  // BE WARY of this calaculable offset.
   const emptyResultClauses: any[] = [];
   const statement = libraryElm.library.statements.def.find(stat => stat.name === statementName);
   const libraryName = libraryElm.library.identifier.id;
@@ -400,6 +400,70 @@ export function extractMeasurementPeriod(measureBundle: R4.IBundle): Calculation
   };
 }
 
+export function extractLibrariesFromBundle(measureBundle: R4.IBundle): {
+  cqls: { name: string; cql: string }[],
+  rootLibIdentifier: ELMIdentifier,
+  elmJSONs: ELM[]
+} {
+  const measure = extractMeasureFromBundle(measureBundle);
+  const rootLibRef = measure.library[0];
+  let rootLibId: string;
+  if (isValidLibraryURL(rootLibRef)) rootLibId = rootLibRef;
+  else rootLibId = rootLibRef.substring(rootLibRef.indexOf('/') + 1);
+
+  const libraries: R4.ILibrary[] = [];
+  const elmJSONs: ELM[] = [];
+  const cqls: { name: string; cql: string }[] = [];
+  let rootLibIdentifier: ELMIdentifier = {
+    id: '',
+    version: ''
+  };
+  measureBundle.entry?.forEach(e => {
+    if (e.resource?.resourceType == 'Library') {
+      const library = e.resource as R4.ILibrary;
+      libraries.push(library);
+      const elmsEncoded = library.content?.filter(a => a.contentType === 'application/elm+json');
+      elmsEncoded?.forEach(elmEncoded => {
+        if (elmEncoded.data) {
+          const decoded = Buffer.from(elmEncoded.data, 'base64').toString('binary');
+          const elm = JSON.parse(decoded) as ELM;
+          if (library.url == rootLibId) {
+            rootLibIdentifier = elm.library.identifier;
+          } else if (library.id === rootLibId) {
+            rootLibIdentifier = elm.library.identifier;
+          }
+          if (elm.library?.includes?.def) {
+            elm.library.includes.def = elm.library.includes.def.map(def => {
+              def.path = def.path.substring(def.path.lastIndexOf('/') + 1);
+
+              return def;
+            });
+          }
+          elmJSONs.push(elm);
+        }
+      });
+
+      const cqlsEncoded = library.content?.filter(a => a.contentType === 'text/cql');
+      cqlsEncoded?.forEach(elmEncoded => {
+        if (elmEncoded.data) {
+          const decoded = Buffer.from(elmEncoded.data, 'base64').toString('binary');
+          const cql = {
+            name: library.name || library.id || 'unknown library',
+            cql: decoded
+          };
+          cqls.push(cql);
+        }
+      });
+    }
+  });
+
+  if (rootLibIdentifier.id === '') {
+    throw new Error('No Root Library could be identified in provided measure bundle');
+  }
+
+  return { cqls, rootLibIdentifier, elmJSONs };
+}
+
 function __guard__(value: any, transform: any) {
   return typeof value !== 'undefined' && value !== null ? transform(value) : undefined;
 }
@@ -413,4 +477,22 @@ export function isValidLibraryURL(libraryName: string) {
   const urlFormat = /(ftp|http|https):\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-\/]))?/;
   const r = new RegExp(urlFormat);
   return r.test(libraryName);
+}
+
+export type MeasureWithLibrary = R4.IMeasure & { library: string[]}
+
+export function extractMeasureFromBundle(measureBundle: R4.IBundle): MeasureWithLibrary {
+  const measureEntry = measureBundle.entry?.find(e => e.resource?.resourceType === 'Measure');
+  
+  if (!measureEntry) {
+    throw new Error('Measure resource does not exist in provided measure bundle');
+  }
+
+  const measure = measureEntry.resource as MeasureWithLibrary;
+  
+  if (!measure.library) {
+    throw new Error('Measure resource must specify a "library"');
+  }
+
+  return measure;
 }

--- a/src/helpers/MeasureHelpers.ts
+++ b/src/helpers/MeasureHelpers.ts
@@ -400,10 +400,12 @@ export function extractMeasurementPeriod(measureBundle: R4.IBundle): Calculation
   };
 }
 
-export function extractLibrariesFromBundle(measureBundle: R4.IBundle): {
-  cqls: { name: string; cql: string }[],
-  rootLibIdentifier: ELMIdentifier,
-  elmJSONs: ELM[]
+export function extractLibrariesFromBundle(
+  measureBundle: R4.IBundle
+): {
+  cqls: { name: string; cql: string }[];
+  rootLibIdentifier: ELMIdentifier;
+  elmJSONs: ELM[];
 } {
   const measure = extractMeasureFromBundle(measureBundle);
   const rootLibRef = measure.library[0];
@@ -479,17 +481,17 @@ export function isValidLibraryURL(libraryName: string) {
   return r.test(libraryName);
 }
 
-export type MeasureWithLibrary = R4.IMeasure & { library: string[]}
+export type MeasureWithLibrary = R4.IMeasure & { library: string[] };
 
 export function extractMeasureFromBundle(measureBundle: R4.IBundle): MeasureWithLibrary {
   const measureEntry = measureBundle.entry?.find(e => e.resource?.resourceType === 'Measure');
-  
+
   if (!measureEntry) {
     throw new Error('Measure resource does not exist in provided measure bundle');
   }
 
   const measure = measureEntry.resource as MeasureWithLibrary;
-  
+
   if (!measure.library) {
     throw new Error('Measure resource must specify a "library"');
   }

--- a/src/helpers/RetrievesHelper.ts
+++ b/src/helpers/RetrievesHelper.ts
@@ -53,7 +53,8 @@ export function findRetrieves(
           queryLocalId,
           retrieveLocalId: exprRet.localId,
           libraryName: elm.library.identifier.id,
-          expressionStack: [...expressionStack]
+          expressionStack: [...expressionStack],
+          path: exprRet.codeProperty
         });
       }
     } else if (
@@ -76,7 +77,8 @@ export function findRetrieves(
           queryLocalId,
           retrieveLocalId: exprRet.localId,
           libraryName: elm.library.identifier.id,
-          expressionStack: [...expressionStack]
+          expressionStack: [...expressionStack],
+          path: exprRet.codeProperty
         });
       }
     }

--- a/src/helpers/RetrievesHelper.ts
+++ b/src/helpers/RetrievesHelper.ts
@@ -68,10 +68,13 @@ export function findRetrieves(
           : ((exprRet.codes as ELMToList).operand as ELMCodeRef).name;
       const code = elm.library.codes?.def.find(c => c.name === codeName);
       if (code) {
+        const cs = elm.library.codeSystems?.def.find(cs => cs.name == code.codeSystem.name);
         results.push({
           dataType,
           code: {
-            system: code.codeSystem.name,
+            system: cs?.id || code.codeSystem.name,
+            version: cs?.version,
+            display: code.display,
             code: code.id
           },
           queryLocalId,

--- a/src/helpers/RetrievesHelper.ts
+++ b/src/helpers/RetrievesHelper.ts
@@ -1,4 +1,14 @@
-import { ELM, ELMStatement } from '../types/ELMTypes';
+import {
+  AnyELMExpression,
+  ELM,
+  ELMCodeRef,
+  ELMExpressionRef,
+  ELMQuery,
+  ELMRetrieve,
+  ELMStatement,
+  ELMToList,
+  ELMValueSetRef
+} from '../types/ELMTypes';
 import { DataTypeQuery, ExpressionStackEntry } from '../types/Calculator';
 
 /**
@@ -13,7 +23,7 @@ import { DataTypeQuery, ExpressionStackEntry } from '../types/Calculator';
 export function findRetrieves(
   elm: ELM,
   deps: ELM[],
-  expr: ELMStatement,
+  expr: ELMStatement | AnyELMExpression,
   queryLocalId?: string,
   expressionStack: ExpressionStackEntry[] = []
 ) {
@@ -29,28 +39,32 @@ export function findRetrieves(
   }
 
   // Base case, get data type and code/valueset off the expression
-  if (expr.type === 'Retrieve' && expr.dataType) {
+  if (expr.type === 'Retrieve' && (expr as ELMRetrieve).dataType) {
+    const exprRet = expr as ELMRetrieve;
     // If present, strip off HL7 prefix to data type
-    const dataType = expr.dataType.replace(/^(\{http:\/\/hl7.org\/fhir\})?/, '');
+    const dataType = exprRet.dataType.replace(/^(\{http:\/\/hl7.org\/fhir\})?/, '');
 
-    if (expr.codes?.type === 'ValueSetRef') {
-      const valueSet = elm.library.valueSets?.def.find(v => v.name === expr.codes.name);
+    if (exprRet.codes?.type === 'ValueSetRef') {
+      const valueSet = elm.library.valueSets?.def.find(v => v.name === (exprRet.codes as ELMValueSetRef).name);
       if (valueSet) {
         results.push({
           dataType,
           valueSet: valueSet.id,
           queryLocalId,
-          retrieveLocalId: expr.localId,
+          retrieveLocalId: exprRet.localId,
           libraryName: elm.library.identifier.id,
           expressionStack: [...expressionStack]
         });
       }
     } else if (
-      expr.codes.type === 'CodeRef' ||
-      (expr.codes.type === 'ToList' && expr.codes.operand?.type === 'CodeRef')
+      exprRet.codes?.type === 'CodeRef' ||
+      (exprRet.codes?.type === 'ToList' && (exprRet.codes as ELMToList).operand?.type === 'CodeRef')
     ) {
       // ToList promotions have the CodeRef on the operand
-      const codeName = expr.codes.type === 'CodeRef' ? expr.codes.name : expr.codes.operand.name;
+      const codeName =
+        exprRet.codes.type === 'CodeRef'
+          ? (exprRet.codes as ELMCodeRef).name
+          : ((exprRet.codes as ELMToList).operand as ELMCodeRef).name;
       const code = elm.library.codes?.def.find(c => c.name === codeName);
       if (code) {
         results.push({
@@ -60,7 +74,7 @@ export function findRetrieves(
             code: code.id
           },
           queryLocalId,
-          retrieveLocalId: expr.localId,
+          retrieveLocalId: exprRet.localId,
           libraryName: elm.library.identifier.id,
           expressionStack: [...expressionStack]
         });
@@ -68,32 +82,33 @@ export function findRetrieves(
     }
   } else if (expr.type === 'Query') {
     // Queries have the source array containing the expressions
-    expr.source?.forEach(s => {
-      results.push(...findRetrieves(elm, deps, s.expression, expr.localId, [...expressionStack]));
+    (expr as ELMQuery).source?.forEach(s => {
+      results.push(...findRetrieves(elm, deps, s.expression, (expr as ELMQuery).localId, [...expressionStack]));
     });
   } else if (expr.type === 'ExpressionRef') {
     // Find expression in dependent library
-    if (expr.libraryName) {
-      const matchingLib = deps.find(d => d.library.identifier.id === expr.libraryName);
-      const exprRef = matchingLib?.library.statements.def.find(e => e.name === expr.name);
+    if ((expr as ELMExpressionRef).libraryName) {
+      const matchingLib = deps.find(d => d.library.identifier.id === (expr as ELMExpressionRef).libraryName);
+      const exprRef = matchingLib?.library.statements.def.find(e => e.name === (expr as ELMExpressionRef).name);
       if (matchingLib && exprRef) {
         results.push(...findRetrieves(matchingLib, deps, exprRef.expression, queryLocalId, [...expressionStack]));
       }
     } else {
       // Find expression in current library
-      const exprRef = elm.library.statements.def.find(d => d.name === expr.name);
+      const exprRef = elm.library.statements.def.find(d => d.name === (expr as ELMExpressionRef).name);
       if (exprRef) {
         results.push(...findRetrieves(elm, deps, exprRef.expression, queryLocalId, [...expressionStack]));
       }
     }
-  } else if (expr.operand) {
+  } else if ((expr as any).operand) {
     // Operand can be array or object. Recurse on either
-    if (Array.isArray(expr.operand)) {
-      expr.operand.forEach(e => {
+    const anyExpr = expr as any;
+    if (Array.isArray(anyExpr.operand)) {
+      anyExpr.operand.forEach((e: any) => {
         results.push(...findRetrieves(elm, deps, e, queryLocalId, [...expressionStack]));
       });
     } else {
-      results.push(...findRetrieves(elm, deps, expr.operand, queryLocalId, [...expressionStack]));
+      results.push(...findRetrieves(elm, deps, anyExpr.operand, queryLocalId, [...expressionStack]));
     }
   }
   return results;

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -200,6 +200,8 @@ export interface DataTypeQuery {
   code?: {
     system: string;
     code: string;
+    version?: string;
+    display?: string;
   };
   /** localId in ELM for the retrieve statement */
   retrieveLocalId?: string;

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -209,6 +209,8 @@ export interface DataTypeQuery {
   libraryName?: string;
   /** stack of expressions traversed during calculation */
   expressionStack?: ExpressionStackEntry[];
+  /** path that the code or valueset object refers to */
+  path?: string;
 }
 
 export interface GapsDataTypeQuery extends DataTypeQuery {

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -256,7 +256,7 @@ export interface DebugOutput {
   detailedResults?: ExecutionResult[];
   measureReports?: R4.IMeasureReport[];
   gaps?: {
-    retrieves: DataTypeQuery[];
-    bundle: R4.IBundle;
+    retrieves?: DataTypeQuery[];
+    bundle?: R4.IBundle;
   };
 }

--- a/src/types/ELMTypes.ts
+++ b/src/types/ELMTypes.ts
@@ -24,7 +24,9 @@ export interface ELMLibrary {
   /** Parameters for this ELM Library. ex. Measurement Period */
   parameters?: any;
   /** Code Systems defined for local use. */
-  codeSystems?: any;
+  codeSystems?: {
+    def: ELMCodeSystem[];
+  };
   /** ValueSet definitions in the ELM Library. */
   valueSets?: {
     /** List of valueset statement definitions. */
@@ -128,9 +130,21 @@ export interface ELMCode {
   id: string;
   name: string;
   accessLevel: string;
+  display?: string;
   codeSystem: {
     name: string;
   };
+}
+
+export interface ELMCodeSystem {
+  /** CodeSystem id */
+  id: string;
+  /** The name of the codesystem taht is used to locally reference this codesystem */
+  name: string;
+  /** versioned name of the codesystem */
+  version?: string;
+  /** The access level of this valueset. Usually 'Public'. */
+  accessLevel?: string;
 }
 
 export interface ELMConcept {

--- a/src/types/ELMTypes.ts
+++ b/src/types/ELMTypes.ts
@@ -88,7 +88,7 @@ export interface ELMStatement {
    */
   annotation?: Annotation[];
   /** The executable expression for this statement. */
-  expression?: any;
+  expression: AnyELMExpression;
   /** Type of this statement. Will be 'FunctionDef' if it is a function. */
   type?: string;
   /** Definition function parameters if this is a function. */
@@ -158,6 +158,7 @@ export type AnyELMExpression =
   | ELMExpression
   | ELMRetrieve
   | ELMValueSetRef
+  | ELMCodeRef
   | ELMQuery
   | ELMAs
   | ELMEqual
@@ -165,6 +166,7 @@ export type AnyELMExpression =
   | ELMAnd
   | ELMOr
   | ELMIsNull
+  | ELMToList
   | ELMIncludedIn
   | ELMIn
   | ELMEnd
@@ -177,7 +179,8 @@ export type AnyELMExpression =
   | ELMConceptRef
   | ELMLiteral
   | ELMInterval
-  | ELMList;
+  | ELMList
+  | ELMTuple;
 
 export interface ELMRetrieve extends ELMExpression {
   type: 'Retrieve';
@@ -191,14 +194,19 @@ export interface ELMValueSetRef extends ELMExpression {
   type: 'ValueSetRef';
   name: string;
   libraryName?: string;
-  locator?: string;
+}
+
+export interface ELMCodeRef extends ELMExpression {
+  type: 'CodeRef';
+  name: string;
+  libraryName?: string;
 }
 
 export interface ELMQuery extends ELMExpression {
   type: 'Query';
-  source: [ELMAliasedQuerySource];
-  let: [ELMLetClause];
-  relationship: [ELMRelationshipClause];
+  source: ELMAliasedQuerySource[];
+  let: ELMLetClause[];
+  relationship: ELMRelationshipClause[];
   where?: AnyELMExpression;
   return?: ELMReturnClause;
   sort?: any;
@@ -232,7 +240,7 @@ export interface ELMLetClause {
 
 export interface ELMReturnClause {
   expression: AnyELMExpression;
-  distinct?: string;
+  distinct?: boolean;
 }
 
 export interface ELMAs extends ELMExpression {
@@ -273,6 +281,9 @@ export interface ELMIsNull extends ELMUnaryExpression {
   type: 'IsNull';
 }
 
+export interface ELMToList extends ELMUnaryExpression {
+  type: 'ToList';
+}
 export interface ELMIncludedIn extends ELMBinaryExpression {
   type: 'IncludedIn';
 }
@@ -294,7 +305,7 @@ interface ELMIExpressionRef extends ELMExpression {
   libraryName?: string;
 }
 
-export interface ELMExpressionRef extends ELMExpression {
+export interface ELMExpressionRef extends ELMIExpressionRef {
   type: 'ExpressionRef';
 }
 
@@ -344,6 +355,15 @@ export interface ELMList extends ELMExpression {
   element: ELMLiteral[];
 }
 
+export interface ELMTuple extends ELMExpression {
+  type: 'Tuple';
+  element: ELMTupleElement[];
+}
+
+export interface ELMTupleElement {
+  name: string;
+  value: AnyELMExpression;
+}
 export interface LibraryDependencyInfo {
   /** The library id */
   libraryId: string;

--- a/test/CalculatorHelpers.test.ts
+++ b/test/CalculatorHelpers.test.ts
@@ -4,6 +4,7 @@ import { getJSONFixture } from './helpers/testHelpers';
 import { PopulationType } from '../src/types/Enums';
 import { StatementResults } from '../src/types/CQLTypes';
 import { PopulationResult } from '../src/types/Calculator';
+import { ELMExpressionRef, ELMQuery, ELMTuple } from '../src/types/ELMTypes';
 
 type MeasureWithGroup = R4.IMeasure & {
   group: R4.IMeasure_Group[];
@@ -188,10 +189,10 @@ describe('CalculatorHelpers', () => {
       const fn = CalculatorHelpers.generateELMJSONFunction(exampleFunctionName, exampleParameterName);
 
       expect(fn.name).toEqual(`obs_func_${exampleFunctionName}_${exampleParameterName}`);
-      expect(fn.expression.source[0].expression.name).toEqual(exampleParameterName);
-      expect(fn.expression.return).toBeDefined();
-      expect(fn.expression.return.expression.type).toEqual('Tuple');
-      expect(fn.expression.return.expression.element).toEqual(
+      expect(((fn.expression as ELMQuery).source[0].expression as ELMExpressionRef).name).toEqual(exampleParameterName);
+      expect((fn.expression as ELMQuery).return).toBeDefined();
+      expect((fn.expression as ELMQuery).return?.expression?.type).toEqual('Tuple');
+      expect(((fn.expression as ELMQuery).return?.expression as ELMTuple).element).toEqual(
         expect.arrayContaining([
           {
             name: 'observation',

--- a/test/DataRequirementHelpers.test.ts
+++ b/test/DataRequirementHelpers.test.ts
@@ -232,5 +232,18 @@ describe('DataRequirementHelpers', () => {
 
       expect(DataRequirementHelpers.generateDataRequirement(dtq)).toEqual(expectedDataReq);
     });
+
+    test('can create DataRequirement with out vs or code filters', () => {
+      const dtq: DataTypeQuery = {
+        dataType: 'fhir_type',
+        path: 'a.path',
+      };
+
+      const expectedDataReq: R4.IDataRequirement = {
+        type: dtq.dataType,
+      };
+
+      expect(DataRequirementHelpers.generateDataRequirement(dtq)).toEqual(expectedDataReq);
+    });
   });
 });

--- a/test/DataRequirementHelpers.test.ts
+++ b/test/DataRequirementHelpers.test.ts
@@ -1,6 +1,7 @@
-import * as DataRequirementHelpers from '../src/DataRequirementHelpers';
+import * as DataRequirementHelpers from '../src/helpers/DataRequirementHelpers';
 import { AndFilter, EqualsFilter, DuringFilter, InFilter } from '../src/types/QueryFilterTypes';
 import { R4 } from '@ahryman40k/ts-fhir-types';
+import { DataTypeQuery } from '../src/types/Calculator';
 
 describe('DataRequirementHelpers', () => {
   describe('Flatten Filters', () => {
@@ -188,6 +189,48 @@ describe('DataRequirementHelpers', () => {
       };
 
       expect(DataRequirementHelpers.generateDetailedDateFilter(df)).toEqual(expectedDateFilter);
+    });
+  });
+
+  describe('generateDataRequirement', () => {
+    test('can create DataRequirement with valueSet filter', () => {
+      const dtq: DataTypeQuery = {
+        dataType: 'fhir_type',
+        path: 'a.path',
+        valueSet: 'http://example.com/valueset'
+      };
+
+      const expectedDataReq: R4.IDataRequirement = {
+        type: dtq.dataType,
+        codeFilter: [
+          {
+            path: dtq.path,
+            valueSet: dtq.valueSet
+          }
+        ]
+      };
+
+      expect(DataRequirementHelpers.generateDataRequirement(dtq)).toEqual(expectedDataReq);
+    });
+
+    test('can create DataRequirement with code filter', () => {
+      const dtq: DataTypeQuery = {
+        dataType: 'fhir_type',
+        path: 'a.path',
+        code: { code: 'a_code', system: 'http://example.com/system' }
+      };
+
+      const expectedDataReq: R4.IDataRequirement = {
+        type: dtq.dataType,
+        codeFilter: [
+          {
+            path: dtq.path,
+            code: [dtq.code as R4.ICoding]
+          }
+        ]
+      };
+
+      expect(DataRequirementHelpers.generateDataRequirement(dtq)).toEqual(expectedDataReq);
     });
   });
 });

--- a/test/DataRequirementHelpers.test.ts
+++ b/test/DataRequirementHelpers.test.ts
@@ -236,11 +236,11 @@ describe('DataRequirementHelpers', () => {
     test('can create DataRequirement with out vs or code filters', () => {
       const dtq: DataTypeQuery = {
         dataType: 'fhir_type',
-        path: 'a.path',
+        path: 'a.path'
       };
 
       const expectedDataReq: R4.IDataRequirement = {
-        type: dtq.dataType,
+        type: dtq.dataType
       };
 
       expect(DataRequirementHelpers.generateDataRequirement(dtq)).toEqual(expectedDataReq);

--- a/test/MeasureHelpers.test.ts
+++ b/test/MeasureHelpers.test.ts
@@ -311,7 +311,9 @@ describe('MeasureHelpers', () => {
           {
             resource: {
               resourceType: 'Library',
-              type: { coding: [{ code: 'logic-library', system: 'http://terminology.hl7.org/CodeSystem/library-type' }] },
+              type: {
+                coding: [{ code: 'logic-library', system: 'http://terminology.hl7.org/CodeSystem/library-type' }]
+              }
             }
           }
         ]
@@ -357,7 +359,11 @@ describe('MeasureHelpers', () => {
       const measureBundle = getJSONFixture('EXM130-7.3.000-bundle-nocodes.json') as R4.IBundle;
       const { cqls, rootLibIdentifier, elmJSONs } = MeasureHelpers.extractLibrariesFromBundle(measureBundle);
 
-      expect(rootLibIdentifier).toStrictEqual({ id: 'EXM130', system: 'http://fhir.org/guides/dbcg/connectathon', version: '7.3.000'});
+      expect(rootLibIdentifier).toStrictEqual({
+        id: 'EXM130',
+        system: 'http://fhir.org/guides/dbcg/connectathon',
+        version: '7.3.000'
+      });
       // The EXM130 test bundle has 7 libraries, including the root one
       // BUT one of them is the FHIR model info file, which we ignore
       expect(cqls).toHaveLength(6);
@@ -371,7 +377,9 @@ describe('MeasureHelpers', () => {
           {
             resource: {
               resourceType: 'Library',
-              type: { coding: [{ code: 'logic-library', system: 'http://terminology.hl7.org/CodeSystem/library-type' }] },
+              type: {
+                coding: [{ code: 'logic-library', system: 'http://terminology.hl7.org/CodeSystem/library-type' }]
+              },
               url: 'http://example.com/root-library'
             }
           },
@@ -387,7 +395,9 @@ describe('MeasureHelpers', () => {
         ]
       };
 
-      expect(() => MeasureHelpers.extractLibrariesFromBundle(measureBundle)).toThrow('No Root Library could be identified in provided measure bundle');
+      expect(() => MeasureHelpers.extractLibrariesFromBundle(measureBundle)).toThrow(
+        'No Root Library could be identified in provided measure bundle'
+      );
     });
   });
 });

--- a/test/MeasureHelpers.test.ts
+++ b/test/MeasureHelpers.test.ts
@@ -385,7 +385,7 @@ describe('MeasureHelpers', () => {
             }
           }
         ]
-      }
+      };
 
       expect(() => MeasureHelpers.extractLibrariesFromBundle(measureBundle)).toThrow('No Root Library could be identified in provided measure bundle');
     });

--- a/test/MeasureHelpers.test.ts
+++ b/test/MeasureHelpers.test.ts
@@ -378,7 +378,7 @@ describe('MeasureHelpers', () => {
             resource: {
               resourceType: 'Library',
               type: {
-                coding: [{ code: 'logic-library', system: 'http://terminology.hl7.org/CodeSystem/library-type' }]
+                coding: [{ code: 'module-definition', system: 'http://terminology.hl7.org/CodeSystem/library-type' }]
               },
               url: 'http://example.com/root-library'
             }

--- a/test/RetrievesHelper.test.ts
+++ b/test/RetrievesHelper.test.ts
@@ -18,7 +18,8 @@ const EXPECTED_VS_RETRIEVE_RESULTS: DataTypeQuery[] = [
         libraryName: 'SimpleQueries',
         type: 'Retrieve'
       }
-    ]
+    ],
+    path: 'code'
   }
 ];
 
@@ -40,7 +41,8 @@ const EXPECTED_VS_QUERY_RESULTS: DataTypeQuery[] = [
         libraryName: 'SimpleQueries',
         type: 'Retrieve'
       }
-    ]
+    ],
+    path: 'code'
   }
 ];
 
@@ -60,7 +62,8 @@ const EXPECTED_CODE_RESULTS: DataTypeQuery[] = [
         libraryName: 'SimpleQueries',
         type: 'Retrieve'
       }
-    ]
+    ],
+    path: 'code'
   }
 ];
 
@@ -82,7 +85,8 @@ const EXPECTED_EXPRESSIONREF_RESULTS: DataTypeQuery[] = [
         libraryName: 'SimpleQueries',
         type: 'Retrieve'
       }
-    ]
+    ],
+    path: 'code'
   }
 ];
 
@@ -104,7 +108,8 @@ const EXPECTED_DEPENDENCY_RESULTS: DataTypeQuery[] = [
         libraryName: 'SimpleDep',
         type: 'Retrieve'
       }
-    ]
+    ],
+    path: 'code'
   }
 ];
 

--- a/test/RetrievesHelper.test.ts
+++ b/test/RetrievesHelper.test.ts
@@ -50,7 +50,7 @@ const EXPECTED_CODE_RESULTS: DataTypeQuery[] = [
   {
     dataType: 'Procedure',
     code: {
-      system: 'EXAMPLE',
+      system: 'http://example.com',
       code: 'test'
     },
     retrieveLocalId: '16',


### PR DESCRIPTION
# Summary
This PR implements a basic `calculateDataRequirements` function in fqm-execution. It only requires a measure `Bundle` object with a `Measure` object, and the required `Library` objects, included.

The `calculateDataRequirements` function returns a `Library` object, to conform to the [Measure/$data-requirements](https://www.hl7.org/fhir/measure-operation-data-requirements.html) operation. 

Currently, we only support providing `resourceType` and `valueSet` filter options for `DataRequirement` objects.

## New behavior
* Added a `calculateDataRequirements` function to `src/Calculator.ts`
* Added a `dataRequirements` output type to `src/cli`

## Code changes
* Moved `MeasureHelpers.ts` to `src/helpers`
* Moved `Library` extraction method out of `calculateGapsInCare` method and into `MeasureHelpers`, for re-use in Data Requirements code
* Created an `extractMeasureFromBundle` function, which returns the `Measure` object from a Measure `Bundle`, with a guaranteed library

# Testing guidance
* Run the tests
* Pick a measure bundle from `connectathon`, and run it using the CLI. Compare the list of `dataRequirements` in the exported `Library` to the one in the `Measure` object, and make sure they're somewhat similar

