### PR TITLE
Value filter for not null check

### DIFF
--- a/src/GapsInCareHelpers.ts
+++ b/src/GapsInCareHelpers.ts
@@ -357,12 +357,12 @@ export function calculateReasonDetail(
             const resources = detailedResult.clauseResults?.find(
               cr => cr.libraryName === r.libraryName && cr.localId === r.retrieveLocalId
             );
-            const attr_path = notNullFilter.attribute.split('.');
+            const attrPath = notNullFilter.attribute.split('.');
             if (resources) {
               // Access desired property of FHIRObject
               resources.raw.forEach((r: any) => {
                 let desiredAttr = r;
-                attr_path.forEach(key => {
+                attrPath.forEach(key => {
                   desiredAttr = desiredAttr[key];
                 });
 

--- a/src/GapsInCareHelpers.ts
+++ b/src/GapsInCareHelpers.ts
@@ -213,12 +213,14 @@ export function generateGuidanceResponses(
           } else {
             dataRequirement.dateFilter = [dateFilter];
           }
-        } else if (df.type === 'notnull') {
+        } else {
           const valueFilter = generateDetailedValueFilter(df);
-          if (dataRequirement.extension) {
-            dataRequirement.extension.push(valueFilter);
-          } else {
-            dataRequirement.extension = [valueFilter];
+          if (valueFilter) {
+            if (dataRequirement.extension) {
+              dataRequirement.extension.push(valueFilter);
+            } else {
+              dataRequirement.extension = [valueFilter];
+            }
           }
         }
       });

--- a/src/GapsInCareHelpers.ts
+++ b/src/GapsInCareHelpers.ts
@@ -14,7 +14,7 @@ import {
   generateDetailedDateFilter,
   generateDetailedValueFilter
 } from './helpers/DataRequirementHelpers';
-import { EqualsFilter, InFilter, DuringFilter, AnyFilter, NotNullFilter } from './types/QueryFilterTypes';
+import { EqualsFilter, InFilter, DuringFilter, AnyFilter } from './types/QueryFilterTypes';
 
 /**
  * Iterate through base queries and add clause results for parent query and retrieve

--- a/src/GapsInCareHelpers.ts
+++ b/src/GapsInCareHelpers.ts
@@ -11,9 +11,10 @@ import { FinalResult, ImprovementNotation, CareGapReasonCode, CareGapReasonCodeD
 import {
   flattenFilters,
   generateDetailedCodeFilter,
-  generateDetailedDateFilter
+  generateDetailedDateFilter,
+  generateDetailedValueFilter
 } from './helpers/DataRequirementHelpers';
-import { EqualsFilter, InFilter, DuringFilter, AnyFilter } from './types/QueryFilterTypes';
+import { EqualsFilter, InFilter, DuringFilter, AnyFilter, NotNullFilter } from './types/QueryFilterTypes';
 
 /**
  * Iterate through base queries and add clause results for parent query and retrieve
@@ -212,6 +213,13 @@ export function generateGuidanceResponses(
           } else {
             dataRequirement.dateFilter = [dateFilter];
           }
+        } else if (df.type === 'notnull') {
+          const valueFilter = generateDetailedValueFilter(df);
+          if (dataRequirement.extension) {
+            dataRequirement.extension.push(valueFilter);
+          } else {
+            dataRequirement.extension = [valueFilter];
+          }
         }
       });
     }
@@ -344,6 +352,8 @@ export function calculateReasonDetail(
                 }
               });
             }
+          } else if (f.type === 'notnull') {
+            reasonDetail.reasonCodes.push(CareGapReasonCode.VALUEMISSING);
           } else {
             // TODO: This logic is not perfect, and can be corrupted by multiple resources spanning truthy values for all filters
             // For non-during filters, look up clause result by localId

--- a/src/helpers/DataRequirementHelpers.ts
+++ b/src/helpers/DataRequirementHelpers.ts
@@ -83,7 +83,7 @@ export function generateDetailedDateFilter(filter: DuringFilter): R4.IDataRequir
  * @param filter the filter to map
  * @returns extension for the valueFilter list of dataRequirement
  */
-export function generateDetailedValueFilter(filter: Filter): R4.IExtension {
+export function generateDetailedValueFilter(filter: Filter): R4.IExtension | null {
   if (filter.type === 'notnull') {
     const notnullFilter = filter as NotNullFilter;
     return {
@@ -94,8 +94,8 @@ export function generateDetailedValueFilter(filter: Filter): R4.IExtension {
       ]
     };
   } else {
-    console.warn(`Detailed value filter is not yet supported for filter type ${filter.type}`);
-    return {};
+    console.error(`Detailed value filter is not yet supported for filter type ${filter.type}`);
+    return null;
   }
 }
 

--- a/src/helpers/DataRequirementHelpers.ts
+++ b/src/helpers/DataRequirementHelpers.ts
@@ -1,6 +1,14 @@
 import { R4 } from '@ahryman40k/ts-fhir-types';
 import { DataTypeQuery } from '../types/Calculator';
-import { EqualsFilter, InFilter, DuringFilter, AndFilter, AnyFilter } from '../types/QueryFilterTypes';
+import {
+  EqualsFilter,
+  InFilter,
+  DuringFilter,
+  AndFilter,
+  AnyFilter,
+  Filter,
+  NotNullFilter
+} from '../types/QueryFilterTypes';
 
 /**
  * Take any nesting of base filters and AND filters and flatten into one list
@@ -67,6 +75,28 @@ export function generateDetailedDateFilter(filter: DuringFilter): R4.IDataRequir
     path: filter.attribute,
     valuePeriod: { start: filter.valuePeriod.start, end: filter.valuePeriod.end }
   };
+}
+
+/**
+ * Map a filter into a FHIR DataRequirement valueFilter extension
+ *
+ * @param filter the filter to map
+ * @returns extension for the valueFilter list of dataRequirement
+ */
+export function generateDetailedValueFilter(filter: Filter): R4.IExtension {
+  if (filter.type === 'notnull') {
+    const notnullFilter = filter as NotNullFilter;
+    return {
+      url: 'http://example.com/dr-value',
+      extension: [
+        { url: 'dr-value-attribute', valueString: notnullFilter.attribute },
+        { url: 'dr-value-filter', valueString: 'not null' }
+      ]
+    };
+  } else {
+    console.warn(`Detailed value filter is not yet supported for filter type ${filter.type}`);
+    return {};
+  }
 }
 
 /**

--- a/src/types/Enums.ts
+++ b/src/types/Enums.ts
@@ -99,6 +99,7 @@ export enum CareGapReasonCode {
   INVALIDATTRIBUTE = 'InvalidAttribute',
   DATEOUTOFRANGE = 'DateOutOfRange',
   VALUEOUTOFRANGE = 'ValueOutOfRange',
+  VALUEMISSING = 'ValueMissing',
   COUNTOUTOFRANGE = 'CountOutOfRange'
 }
 
@@ -108,8 +109,9 @@ export enum CareGapReasonCode {
 export const CareGapReasonCodeDisplay = {
   [CareGapReasonCode.MISSING]: 'No Data Element found from Value Set',
   [CareGapReasonCode.PRESENT]: 'Data element was found',
+  [CareGapReasonCode.INVALIDATTRIBUTE]: 'Attribute on the data element did not equal desired value',
   [CareGapReasonCode.DATEOUTOFRANGE]: 'Key date was not in the expected range',
   [CareGapReasonCode.VALUEOUTOFRANGE]: 'Value was not in the expected range',
-  [CareGapReasonCode.COUNTOUTOFRANGE]: 'Count of data elements was not in the expected range',
-  [CareGapReasonCode.INVALIDATTRIBUTE]: 'Attribute on the data element did not equal desired value'
+  [CareGapReasonCode.VALUEMISSING]: 'Value was missing or null',
+  [CareGapReasonCode.COUNTOUTOFRANGE]: 'Count of data elements was not in the expected range'
 };

--- a/test/DataRequirementHelpers.test.ts
+++ b/test/DataRequirementHelpers.test.ts
@@ -1,5 +1,5 @@
 import * as DataRequirementHelpers from '../src/helpers/DataRequirementHelpers';
-import { AndFilter, EqualsFilter, DuringFilter, InFilter } from '../src/types/QueryFilterTypes';
+import { AndFilter, EqualsFilter, DuringFilter, InFilter, NotNullFilter } from '../src/types/QueryFilterTypes';
 import { R4 } from '@ahryman40k/ts-fhir-types';
 import { DataTypeQuery } from '../src/types/Calculator';
 
@@ -189,6 +189,26 @@ describe('DataRequirementHelpers', () => {
       };
 
       expect(DataRequirementHelpers.generateDetailedDateFilter(df)).toEqual(expectedDateFilter);
+    });
+  });
+
+  describe('Value Filters', () => {
+    test('not null filter should create value filter', () => {
+      const nnf: NotNullFilter = {
+        type: 'notnull',
+        alias: 'R',
+        attribute: 'attr-1'
+      };
+
+      const expectedDetailFilter: R4.IExtension = {
+        url: 'http://example.com/dr-value',
+        extension: [
+          { url: 'dr-value-attribute', valueString: 'attr-1' },
+          { url: 'dr-value-filter', valueString: 'not null' }
+        ]
+      };
+
+      expect(DataRequirementHelpers.generateDetailedValueFilter(nnf)).toEqual(expectedDetailFilter);
     });
   });
 

--- a/test/DataRequirementHelpers.test.ts
+++ b/test/DataRequirementHelpers.test.ts
@@ -1,5 +1,12 @@
 import * as DataRequirementHelpers from '../src/helpers/DataRequirementHelpers';
-import { AndFilter, EqualsFilter, DuringFilter, InFilter, NotNullFilter } from '../src/types/QueryFilterTypes';
+import {
+  AndFilter,
+  EqualsFilter,
+  DuringFilter,
+  InFilter,
+  NotNullFilter,
+  UnknownFilter
+} from '../src/types/QueryFilterTypes';
 import { R4 } from '@ahryman40k/ts-fhir-types';
 import { DataTypeQuery } from '../src/types/Calculator';
 
@@ -209,6 +216,16 @@ describe('DataRequirementHelpers', () => {
       };
 
       expect(DataRequirementHelpers.generateDetailedValueFilter(nnf)).toEqual(expectedDetailFilter);
+    });
+
+    test('unknown filter should create a null for filter creation', () => {
+      const uf: UnknownFilter = {
+        type: 'unknown',
+        alias: 'R',
+        attribute: 'attr-1'
+      };
+
+      expect(DataRequirementHelpers.generateDetailedValueFilter(uf)).toBeNull();
     });
   });
 

--- a/test/GapsInCareHelpers.test.ts
+++ b/test/GapsInCareHelpers.test.ts
@@ -447,6 +447,17 @@ describe('Find Near Misses', () => {
               }
             }
           ]
+        },
+        {
+          localId: 'observation',
+          libraryName: 'example',
+          statementName: '',
+          final: FinalResult.TRUE,
+          raw: [
+            {
+              value: false
+            }
+          ]
         }
       ],
       statementResults: []
@@ -512,6 +523,63 @@ describe('Find Near Misses', () => {
       expect(r.reasonDetail).toBeDefined();
       expect(r.reasonDetail?.hasReasonDetail).toBe(true);
       expect(r.reasonDetail?.reasonCodes).toEqual([CareGapReasonCode.DATEOUTOFRANGE]);
+    });
+
+    test('retrieve with false not null filter should be code VALUEMISSING', () => {
+      const q: GapsDataTypeQuery = {
+        ...baseQuery,
+        queryInfo: {
+          sources: [
+            {
+              alias: 'P',
+              resourceType: 'Procedure',
+              retrieveLocalId: 'true-clause'
+            }
+          ],
+          filter: {
+            type: 'notnull',
+            alias: 'P',
+            attribute: 'result'
+          }
+        }
+      };
+
+      const [r] = calculateReasonDetail([q], ImprovementNotation.POSITIVE, dr);
+
+      expect(r.reasonDetail).toBeDefined();
+      expect(r.reasonDetail?.hasReasonDetail).toBe(true);
+      expect(r.reasonDetail?.reasonCodes).toEqual([CareGapReasonCode.VALUEMISSING]);
+    });
+
+    test('retrieve with true not null filter should have default reason detail', () => {
+      const q: GapsDataTypeQuery = {
+        dataType: 'Observation',
+        valueSet: 'http://example.com/test-vs',
+        retrieveHasResult: true,
+        parentQueryHasResult: false,
+        libraryName: 'example',
+        retrieveLocalId: 'observation',
+        queryInfo: {
+          sources: [
+            {
+              alias: 'O',
+              resourceType: 'Observation',
+              retrieveLocalId: 'true-clause'
+            }
+          ],
+          filter: {
+            type: 'notnull',
+            alias: 'O',
+            attribute: 'value'
+          }
+        }
+      };
+
+      const [r] = calculateReasonDetail([q], ImprovementNotation.POSITIVE, dr);
+
+      expect(r.reasonDetail).toBeDefined();
+      // If no specific reason details found, default is missing
+      expect(r.reasonDetail?.reasonCodes).toEqual([CareGapReasonCode.MISSING]);
     });
 
     test('retrieve with both false date and attribute filters should be code both INVALIDATTRIBUTE and DATEOUTOFRANGE', () => {

--- a/test/GapsInCareHelpers.test.ts
+++ b/test/GapsInCareHelpers.test.ts
@@ -916,6 +916,63 @@ describe('Guidance Response', () => {
     expect(gr.dataRequirement).toEqual(drWithDate);
   });
 
+  test('should generate data requirement with valueFilter for not-null filter', () => {
+    const drWithValue: R4.IDataRequirement[] = [
+      {
+        type: 'Observation',
+        codeFilter: [
+          {
+            path: 'code',
+            valueSet: 'http://example.com/test-vs'
+          }
+        ],
+        extension: [
+          {
+            url: 'http://example.com/dr-value',
+            extension: [
+              {
+                url: 'dr-value-attribute',
+                valueString: 'value'
+              },
+              {
+                url: 'dr-value-filter',
+                valueString: 'not null'
+              }
+            ]
+          }
+        ]
+      }
+    ];
+
+    const query: GapsDataTypeQuery = {
+      dataType: 'Observation',
+      valueSet: 'http://example.com/test-vs',
+      retrieveHasResult: true,
+      parentQueryHasResult: false,
+      queryInfo: {
+        sources: [
+          {
+            alias: 'O',
+            resourceType: 'Observation'
+          }
+        ],
+        filter: {
+          type: 'notnull',
+          alias: 'O',
+          attribute: 'value'
+        }
+      }
+    };
+
+    const grs = generateGuidanceResponses([query], '', ImprovementNotation.POSITIVE);
+
+    expect(grs).toHaveLength(1);
+
+    const [gr] = grs;
+
+    expect(gr.dataRequirement).toEqual(drWithValue);
+  });
+
   test('should generate combo data requirement with codeFilter and dateFilter', () => {
     const drWithDateAndCode: R4.IDataRequirement[] = [
       {


### PR DESCRIPTION
# Summary
Creates a value filter for Data requirements that are associated with a not null check in the cql.
## New behavior
The produced gaps report for a patient in the denominator (for a positive improvement measure) will include a value filter (extension) for any corresponding not null checks that are a part of the numerator cql. This data requirement will use the ValueMissing CareGapReasonCode (needs to be added to the gaps in care profile/IG that Sam has been working on).
## Code changes
- Small changes in the GapsInCareHelpers to handle the notnull filter case and use the ValueMissing code. 
- Change to add the ValueMissing code in Enums.
- `generateDetailedValueFilter` added to DataRequirementHelpers to generate the value filter extension. Future value filters can be added to this for other filter types, but for now, it just uses a console warn to warn the user if a different filter type gets there (shouldn't happen yet).
# Testing guidance
A test has been added which can be run with `npm test`. More generally, testing can be done with EXM124. Launch,json configuration would look something like this: 
`"args": ["-d","-o", "gaps","-m", "${workspaceFolder}/test/fixtures/EXM124-9.0.000-bundle.json", "-p", "${workspaceFolder}/test/fixtures/EXM124-9.0.000/tests-denom-EXM124-bundle.json"]`
