### PR TITLE
Additional MAT export support

### DIFF
--- a/src/Calculator.ts
+++ b/src/Calculator.ts
@@ -312,8 +312,11 @@ export async function calculateGapsInCare(
       const measureResource = MeasureHelpers.extractMeasureFromBundle(measureBundle);
 
       // Gaps only supported for proportion/ratio measures
-      const scoringCode = measureResource.scoring?.coding?.find(c => c.system === 'http://hl7.org/fhir/measure-scoring')
-        ?.code;
+      const scoringCode = measureResource.scoring?.coding?.find(
+        c =>
+          c.system === 'http://hl7.org/fhir/measure-scoring' ||
+          c.system === 'http://terminology.hl7.org/CodeSystem/measure-scoring'
+      )?.code;
 
       if (scoringCode !== MeasureScoreType.PROP) {
         throw new Error(`Gaps in care not supported for measure scoring type ${scoringCode}`);

--- a/src/Calculator.ts
+++ b/src/Calculator.ts
@@ -308,7 +308,7 @@ export async function calculateGapsInCare(
       throw new Error(`No MeasureReport generated during gaps in care for ${res.patientId}`);
     }
 
-    res.detailedResults?.forEach(dr => {
+    res.detailedResults?.forEach((dr, i) => {
       const measureResource = MeasureHelpers.extractMeasureFromBundle(measureBundle);
 
       // Gaps only supported for proportion/ratio measures
@@ -344,7 +344,7 @@ export async function calculateGapsInCare(
         (improvementNotation === ImprovementNotation.POSITIVE ? denomResult && !numerResult : numerResult);
 
       if (populationCriteria) {
-        const matchingGroup = measureResource.group?.find(g => g.id === dr.groupId);
+        const matchingGroup = measureResource.group?.find(g => g.id === dr.groupId) || measureResource.group?.[i];
 
         if (!matchingGroup) {
           throw new Error(`Could not find group with id ${dr.groupId} in measure resource`);

--- a/src/MeasureReportBuilder.ts
+++ b/src/MeasureReportBuilder.ts
@@ -27,7 +27,11 @@ export default class MeasureReportBuilder {
     this.measureBundle = measureBundle;
     this.measure = MeasureHelpers.extractMeasureFromBundle(measureBundle);
     this.scoringCode =
-      this.measure.scoring?.coding?.find(c => c.system === 'http://hl7.org/fhir/measure-scoring')?.code || '';
+      this.measure.scoring?.coding?.find(
+        c =>
+          c.system === 'http://hl7.org/fhir/measure-scoring' ||
+          c.system === 'http://terminology.hl7.org/CodeSystem/measure-scoring'
+      )?.code || '';
     this.options = options;
     // if report type is specified use it, otherwise default to individual report.
     if (this.options.reportType) {

--- a/src/MeasureReportBuilder.ts
+++ b/src/MeasureReportBuilder.ts
@@ -344,7 +344,7 @@ export default class MeasureReportBuilder {
   }
 
   private median(observations: number[]) {
-    const sorted = observations.sort(function(a, b) {
+    const sorted = observations.sort((a, b) => {
       return a - b;
     });
     const centerIndex = Math.floor(sorted.length / 2);

--- a/src/MeasureReportBuilder.ts
+++ b/src/MeasureReportBuilder.ts
@@ -78,7 +78,10 @@ export default class MeasureReportBuilder {
     // build population groups from measure resource
     this.measure.group?.forEach(measureGroup => {
       const group = <R4.IMeasureReport_Group>{};
-      group.id = measureGroup.id;
+      if (measureGroup.id) {
+        group.id = measureGroup.id;
+      }
+
       group.population = [];
 
       // build each population group with 0 for initial value
@@ -143,7 +146,7 @@ export default class MeasureReportBuilder {
       this.report.subject = subjectReference;
     }
 
-    results.detailedResults.forEach(groupResults => {
+    results.detailedResults.forEach((groupResults, i) => {
       if (this.isIndividual) {
         // add narrative for relevant clauses
         if (this.report.text && groupResults.html) {
@@ -152,7 +155,8 @@ export default class MeasureReportBuilder {
       }
 
       // find corresponding group in report
-      const group = this.report.group?.find(g => g.id == groupResults.groupId);
+      // default to index if group is missing an ID
+      const group = this.report.group?.find(g => g.id == groupResults.groupId) || this.report.group?.[i];
       if (!group) {
         throw new Error(`Group ${groupResults.groupId} not found in measure report`);
       }
@@ -340,7 +344,7 @@ export default class MeasureReportBuilder {
   }
 
   private median(observations: number[]) {
-    const sorted = observations.sort(function (a, b) {
+    const sorted = observations.sort(function(a, b) {
       return a - b;
     });
     const centerIndex = Math.floor(sorted.length / 2);


### PR DESCRIPTION
# Summary

This PR does 2 main things in order to further support MAT bundles:

1. Allow an alternate code system for searching for the measure scoring code (both `http://hl7.org/fhir/measure-scoring` and 
`http://terminology.hl7.org/CodeSystem/measure-scoring` are now supported)
2. Add a fallback in the `MeasureReportBuilder` where a groupId not being present on the report falls back to accessing the groups by index. Some of the MAT Measures don't include groupIds, so it's impossible to persist those over to the MeasureReport. This was causing the builder to break for MAT bundle. It doesn't now :) 

## New behavior

Main behavior change is measure report output for MAT bundles no longer erroring

## Code changes

* Add additional code system to measure scoring lookup (thanks @hossenlopp)
* Add logic for falling back to measure report indexed group when groupId doesn't exist.

# Testing guidance

I recommend testing this with a MAT bundle that has valuesets jammed into it just to isolate the changed behavior rather than rely on VSAC, esp because that behavior may change with caching. Let me know and I can provide such a bundle for testing.

Test all output types for the bundle and ensure that they all calculate without errors.
