### PR TITLE
ValueSet Caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ test/fixtures/elm/queries/.start-translator
 connectathon/
 fhir-patient-generator/
 coverage
+cache

--- a/README.md
+++ b/README.md
@@ -2,36 +2,34 @@
 
 Library for executing FHIR-based Electronic Clinical Quality Measures (eCQMs) written in Clinical Quality Language (CQL)
 
-- [Installation](#installation)
+*   [Installation](#installation)
 
-- [Usage](#usage)
+*   [Usage](#usage)
+    *   [Module](#module)
+    *   [Calculation Options](#calculation-options)
+    *   [CLI](#cli)
+    *   [TypeScript](#typescript)
 
-  - [Module](#module)
-  - [Calculation Options](#calculation-options)
-  - [CLI](#cli)
-  - [TypeScript](#typescript)
+*   [Local Development](#local-development)
+    *   [Prerequisites](#prerequisites)
+    *   [Local Installation/Usage](#local-installation%2Fusage)
+    *   [Debugging in VS Code](#debugging-in-vs-code)
+    *   [Testing](#testing)
+    *   [Checks](#checks)
 
-- [Local Development](#local-development)
-
-  - [Prerequisites](#prerequisites)
-  - [Local Installation/Usage](#local-installation%2Fusage)
-  - [Debugging in VS Code](#debugging-in-vs-code)
-  - [Testing](#testing)
-  - [Checks](#checks)
-
-- [License](#license)
+*   [License](#license)
 
 ## Installation
 
 `fqm-execution` can be installed into your project with npm:
 
-```bash
+``` bash
 npm install --save https://github.com/projecttacoma/fqm-execution.git
 ```
 
 To install the global command line interface (CLI), use npm global installation:
 
-```bash
+``` bash
 npm install -g https://github.com/projecttacoma/fqm-execution.git
 ```
 
@@ -65,10 +63,10 @@ const dataRequirements = Calculator.calculateDataRequirements(measureBundle); //
 
 #### Arguments
 
-- `measureBundle`: Bundle containing a FHIR Measure and its dependendent Libraries. FHIR ValueSets may be included as well
-- `patientBundles`: Array of FHIR Bundles containing patient data
-- `options` (optional): Object of calculation options (see below)
-- `valueSetCache` (optional): Array of FHIR ValueSet resources to use for calculation
+*   `measureBundle`: Bundle containing a FHIR Measure and its dependendent Libraries. FHIR ValueSets may be included as well
+*   `patientBundles`: Array of FHIR Bundles containing patient data
+*   `options` (optional): Object of calculation options (see below)
+*   `valueSetCache` (optional): Array of FHIR ValueSet resources to use for calculation
 
 #### Calculation Options
 
@@ -110,7 +108,7 @@ Options:
 
 E.g.
 
-```bash
+``` bash
 fqm-execution -o reports -m /path/to/measure/bundle.json -p /path/to/patient1/bundle.json > reports.json
 ```
 
@@ -128,38 +126,38 @@ To find your VSAC API key, sign into [the UTS homepage](https://uts.nlm.nih.gov/
 
 ### Prerequisites
 
-- [Node.js >=10.15.1](https://nodejs.org/en/)
-- [Git](https://git-scm.com/)
+*   [Node.js >=10.15.1](https://nodejs.org/en/)
+*   [Git](https://git-scm.com/)
 
 ### Local Installation/Usage
 
 Clone the source code:
 
-```bash
+``` bash
 git clone https://github.com/projecttacoma/fqm-execution.git
 ```
 
 Install dependencies:
 
-```bash
+``` bash
 npm install
 ```
 
 Optionally, you can install the `ts-node` utility globally to execute the TypeScript files directly instead of running the build script:
 
-```bash
+``` bash
 npm install -g ts-node
 ```
 
 Run the CLI with ts-node:
 
-```bash
+``` bash
 ts-node --files src/cli.ts [options]
 ```
 
 Or using the built JavaScript:
 
-```bash
+``` bash
 npm run build
 node build/cli.js [options]
 ```
@@ -174,7 +172,7 @@ To attach a debugger to the TypeScript files for deeper inspection of the tool's
 
 Add the following contents to `.vscode/launch.json` in the root of the project directory:
 
-```JavaScript
+``` JavaScript
 {
     // Use IntelliSense to learn about possible attributes.
     // Hover to view descriptions of existing attributes.
@@ -207,7 +205,7 @@ This will allow you to run the CLI from the `Run` tab in VS Code, and will halt 
 
 We use [Jest](https://jestjs.io/en/) for unit-testing `fqm-execution`. Tests can be running using the `test` script in package.json:
 
-```bash
+``` bash
 npm test
 ```
 
@@ -215,17 +213,16 @@ npm test
 
 When contributing new code, ensure that all tests, lint, and prettier checks pass with the following command:
 
-```bash
+``` bash
 npm run check
 ```
-
 ### Architecture Overview
-
 ![Overview](doc/FQM.png)
 
-A visual representation of the calculate sequence of the application can be seen below:
+A visual representation of the  calculate sequence of the application can be seen below:
 
 ![Calculate](doc/calculate_Sequence.png)
+
 
 ## License
 
@@ -233,7 +230,7 @@ Copyright 2020 The MITRE Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 
-```bash
+``` bash
 http://www.apache.org/licenses/LICENSE-2.0
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,34 +2,36 @@
 
 Library for executing FHIR-based Electronic Clinical Quality Measures (eCQMs) written in Clinical Quality Language (CQL)
 
-*   [Installation](#installation)
+- [Installation](#installation)
 
-*   [Usage](#usage)
-    *   [Module](#module)
-    *   [Calculation Options](#calculation-options)
-    *   [CLI](#cli)
-    *   [TypeScript](#typescript)
+- [Usage](#usage)
 
-*   [Local Development](#local-development)
-    *   [Prerequisites](#prerequisites)
-    *   [Local Installation/Usage](#local-installation%2Fusage)
-    *   [Debugging in VS Code](#debugging-in-vs-code)
-    *   [Testing](#testing)
-    *   [Checks](#checks)
+  - [Module](#module)
+  - [Calculation Options](#calculation-options)
+  - [CLI](#cli)
+  - [TypeScript](#typescript)
 
-*   [License](#license)
+- [Local Development](#local-development)
+
+  - [Prerequisites](#prerequisites)
+  - [Local Installation/Usage](#local-installation%2Fusage)
+  - [Debugging in VS Code](#debugging-in-vs-code)
+  - [Testing](#testing)
+  - [Checks](#checks)
+
+- [License](#license)
 
 ## Installation
 
 `fqm-execution` can be installed into your project with npm:
 
-``` bash
+```bash
 npm install --save https://github.com/projecttacoma/fqm-execution.git
 ```
 
 To install the global command line interface (CLI), use npm global installation:
 
-``` bash
+```bash
 npm install -g https://github.com/projecttacoma/fqm-execution.git
 ```
 
@@ -38,49 +40,59 @@ npm install -g https://github.com/projecttacoma/fqm-execution.git
 ### Module
 
 #### ES6
-``` JavaScript
+
+```JavaScript
 import { Calculator } from 'fqm-execution';
 
-const rawResults = await Calculator.calculateRaw(measureBundle, patientBundles, options); // Get raw results from CQL engine for each patient
-const detailedResults = await Calculator.calculate(measureBundle, patientBundles, options); // Get detailed population results for each patient
-const measureReports = await Calculator.calculateMeasureReports(measureBundle, patientBundles, options); // Get individual FHIR MeasureReports for each patient
-const gapsInCare = await Calculator.calculateGapsInCare(measureBundle, patientBundles, options); // Get gaps in care for each patient, if present
+const rawResults = await Calculator.calculateRaw(measureBundle, patientBundles, options, valueSetCache); // Get raw results from CQL engine for each patient
+const detailedResults = await Calculator.calculate(measureBundle, patientBundles, options, valueSetCache); // Get detailed population results for each patient
+const measureReports = await Calculator.calculateMeasureReports(measureBundle, patientBundles, options, valueSetCache); // Get individual FHIR MeasureReports for each patient
+const gapsInCare = await Calculator.calculateGapsInCare(measureBundle, patientBundles, options, valueSetCache); // Get gaps in care for each patient, if present
 const dataRequirements = Calculator.calculateDataRequirements(measureBundle); // Get data requirements for a given measure (in a bundle)
 ```
 
 #### Require
-``` JavaScript
+
+```JavaScript
 const { Calculator } = require('fqm-execution');
 
-const rawResults = await Calculator.calculateRaw(measureBundle, patientBundles, options); // Get raw results from CQL engine for each patient
-const detailedResults = await Calculator.calculate(measureBundle, patientBundles, options); // Get detailed population results for each patient
-const measureReports = await Calculator.calculateMeasureReports(measureBundle, patientBundles, options); // Get individual FHIR MeasureReports for each patient
-const gapsInCare = await Calculator.calculateGapsInCare(measureBundle, patientBundles, options); // Get gaps in care for each patient, if present
+const rawResults = await Calculator.calculateRaw(measureBundle, patientBundles, options, valueSetCache); // Get raw results from CQL engine for each patient
+const detailedResults = await Calculator.calculate(measureBundle, patientBundles, options, valueSetCache); // Get detailed population results for each patient
+const measureReports = await Calculator.calculateMeasureReports(measureBundle, patientBundles, options, valueSetCache); // Get individual FHIR MeasureReports for each patient
+const gapsInCare = await Calculator.calculateGapsInCare(measureBundle, patientBundles, options, valueSetCache); // Get gaps in care for each patient, if present
 const dataRequirements = Calculator.calculateDataRequirements(measureBundle); // Get data requirements for a given measure (in a bundle)
 ```
+
+#### Arguments
+
+- `measureBundle`: Bundle containing a FHIR Measure and its dependendent Libraries. FHIR ValueSets may be included as well
+- `patientBundles`: Array of FHIR Bundles containing patient data
+- `options` (optional): Object of calculation options (see below)
+- `valueSetCache` (optional): Array of FHIR ValueSet resources to use for calculation
 
 #### Calculation Options
 
 The options that we support for calculation are as follows:
-| option                 |  type   | optional? | description                                                                        |
+| option | type | optional? | description |
 | :--------------------- | :-----: | :-------: | :--------------------------------------------------------------------------------- |
-| enableDebugOutput      | boolean |    yes    |                        Enable debug output from function calls. Defaults to false. |
-| includeClauseResults   | boolean |    yes    |                               Option to include clause results. Defaults to false. |
-| includePrettyResults   | boolean |    yes    |          Option to include pretty results on statement results. Defaults to false. |
-| includeHighlighting    | boolean |    yes    |                Include highlighting in MeasureReport narrative. Defaults to false. |
-| measurementPeriodStart | string  |    yes    |                                                       Start of measurement period. |
-| measurementPeriodEnd   | string  |    yes    |                                                         End of measurement period. |
-| patientSource          |   any   |    yes    |        PatientSource to use. If provided, the patientBundles will not be required. |
-| reportType             | string  |    yes    |                      Type of MeasureReport to generate: "summary" or "individual". |
-| calculateSDEs          | boolean |    yes    |              Include Supplemental Data Elements in calculation. Defaults to false. |
-| calculateHTML          | boolean |    yes    |                        Include HTML structure for highlighting. Defaults to false. |
-| vsAPIKey               | string  |    yes    | API key, to be used to access a valueset API for downloading any missing valuesets |
+| enableDebugOutput | boolean | yes | Enable debug output from function calls. Defaults to false. |
+| includeClauseResults | boolean | yes | Option to include clause results. Defaults to false. |
+| includePrettyResults | boolean | yes | Option to include pretty results on statement results. Defaults to false. |
+| includeHighlighting | boolean | yes | Include highlighting in MeasureReport narrative. Defaults to false. |
+| measurementPeriodStart | string | yes | Start of measurement period. |
+| measurementPeriodEnd | string | yes | End of measurement period. |
+| patientSource | any | yes | PatientSource to use. If provided, the patientBundles will not be required. |
+| reportType | string | yes | Type of MeasureReport to generate: "summary" or "individual". |
+| calculateSDEs | boolean | yes | Include Supplemental Data Elements in calculation. Defaults to false. |
+| calculateHTML | boolean | yes | Include HTML structure for highlighting. Defaults to false. |
+| vsAPIKey | string | yes | API key, to be used to access a valueset API for downloading any missing valuesets |
+| useValueSetCaching | boolean | yes | Whether to cache valuesets obtained by an API on the filesystem |
 
 ### CLI
 
 To run the globally installed CLI (see above), use the global `fqm-execution command`
 
-``` bash
+```bash
 Usage: fqm-execution [options]
 
 Options:
@@ -91,13 +103,14 @@ Options:
   -p, --patient-bundles <patient-bundles...>  paths to patient bundle
   -s, --measurement-period-start <date>       start date for the measurement period, in YYYY-MM-DD format (defaults to the start date defined in the Measure, or 2019-01-01 if not set there)
   -e, --measurement-period-end <date>         end date for the measurement period, in YYYY-MM-DD format (defaults to the end date defined in the Measure, or 2019-12-31 if not set there)
-  -h, --help                                  display help for command
   -a, --vs-api-key <key>                      API key, to authenticate against the valueset service to be used for resolving missing valuesets
+  -c, --cache-valuesets                       Whether or not to cache ValueSets retrieved from the ValueSet service (default: false)
+  -h, --help                                  display help for command
 ```
 
 E.g.
 
-``` bash
+```bash
 fqm-execution -o reports -m /path/to/measure/bundle.json -p /path/to/patient1/bundle.json > reports.json
 ```
 
@@ -115,38 +128,38 @@ To find your VSAC API key, sign into [the UTS homepage](https://uts.nlm.nih.gov/
 
 ### Prerequisites
 
-*   [Node.js >=10.15.1](https://nodejs.org/en/)
-*   [Git](https://git-scm.com/)
+- [Node.js >=10.15.1](https://nodejs.org/en/)
+- [Git](https://git-scm.com/)
 
 ### Local Installation/Usage
 
 Clone the source code:
 
-``` bash
+```bash
 git clone https://github.com/projecttacoma/fqm-execution.git
 ```
 
 Install dependencies:
 
-``` bash
+```bash
 npm install
 ```
 
 Optionally, you can install the `ts-node` utility globally to execute the TypeScript files directly instead of running the build script:
 
-``` bash
+```bash
 npm install -g ts-node
 ```
 
 Run the CLI with ts-node:
 
-``` bash
+```bash
 ts-node --files src/cli.ts [options]
 ```
 
 Or using the built JavaScript:
 
-``` bash
+```bash
 npm run build
 node build/cli.js [options]
 ```
@@ -161,7 +174,7 @@ To attach a debugger to the TypeScript files for deeper inspection of the tool's
 
 Add the following contents to `.vscode/launch.json` in the root of the project directory:
 
-``` JavaScript
+```JavaScript
 {
     // Use IntelliSense to learn about possible attributes.
     // Hover to view descriptions of existing attributes.
@@ -194,7 +207,7 @@ This will allow you to run the CLI from the `Run` tab in VS Code, and will halt 
 
 We use [Jest](https://jestjs.io/en/) for unit-testing `fqm-execution`. Tests can be running using the `test` script in package.json:
 
-``` bash
+```bash
 npm test
 ```
 
@@ -202,16 +215,17 @@ npm test
 
 When contributing new code, ensure that all tests, lint, and prettier checks pass with the following command:
 
-``` bash
+```bash
 npm run check
 ```
+
 ### Architecture Overview
+
 ![Overview](doc/FQM.png)
 
-A visual representation of the  calculate sequence of the application can be seen below:
+A visual representation of the calculate sequence of the application can be seen below:
 
 ![Calculate](doc/calculate_Sequence.png)
-
 
 ## License
 
@@ -219,7 +233,7 @@ Copyright 2020 The MITRE Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 
-``` bash
+```bash
 http://www.apache.org/licenses/LICENSE-2.0
 ```
 

--- a/src/helpers/VSACHelper.ts
+++ b/src/helpers/VSACHelper.ts
@@ -1,10 +1,10 @@
-const VSAC_REXEG = /http:\/\/cts\.nlm\.nih\.gov.*ValueSet/;
+const VSAC_REGEX = /http:\/\/cts\.nlm\.nih\.gov.*ValueSet/;
 const OID_REGEX = /([0-9]+\.)+[0-9]+/;
 
 export const VSAC_BASE = 'http://cts.nlm.nih.gov/fhir/r4/ValueSet';
 
 export function isVSACUrl(url: string): boolean {
-  return VSAC_REXEG.test(url);
+  return VSAC_REGEX.test(url);
 }
 
 export function getOIDFromValueSet(url: string): string | null {

--- a/src/helpers/VSACHelper.ts
+++ b/src/helpers/VSACHelper.ts
@@ -1,0 +1,28 @@
+const VSAC_REXEG = /http:\/\/cts\.nlm\.nih\.gov.*ValueSet/;
+const OID_REGEX = /([0-9]+\.)+[0-9]+/;
+
+export const VSAC_BASE = 'http://cts.nlm.nih.gov/fhir/r4/ValueSet';
+
+export function isVSACUrl(url: string): boolean {
+  return VSAC_REXEG.test(url);
+}
+
+export function getOIDFromValueSet(url: string): string | null {
+  const match = url.match(OID_REGEX);
+
+  if (match !== null) {
+    return match[0];
+  }
+
+  return null;
+}
+
+export function normalizeCanonical(url: string): string | null {
+  const oid = getOIDFromValueSet(url);
+
+  if (oid !== null) {
+    return `${VSAC_BASE}/${oid}`;
+  }
+
+  return null;
+}

--- a/src/helpers/ValueSetResolver.ts
+++ b/src/helpers/ValueSetResolver.ts
@@ -1,5 +1,6 @@
 import { R4 } from '@ahryman40k/ts-fhir-types';
 import axios, { AxiosInstance } from 'axios';
+import { isVSACUrl, normalizeCanonical } from './VSACHelper';
 
 export class ValueSetResolver {
   protected apiKey: string;
@@ -31,11 +32,17 @@ export class ValueSetResolver {
     for (const url of urls) {
       // Go through the results and find any that failed.
       // If there are failures, build an error string
+      let normalizedUrl = url;
       try {
-        const res = await this.instance.get<R4.IValueSet>(`${url}/$expand`);
+        // Use known good base for VSAC urls
+        if (isVSACUrl(url)) {
+          normalizedUrl = normalizeCanonical(url) || url;
+        }
+
+        const res = await this.instance.get<R4.IValueSet>(`${normalizedUrl}/$expand`);
         valuesets.push(res.data);
       } catch (e) {
-        errors.push(`Valueset with URL ${url} could not be retrieved. Reason: ${e.message}`);
+        errors.push(`Valueset with URL ${normalizedUrl} could not be retrieved. Reason: ${e.message}`);
       }
     }
 

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -32,6 +32,8 @@ export interface CalculationOptions {
   vsAPIKey?: string;
   /** The type of report to return, will default to individual. */
   reportType?: 'individual' | 'subject-list' | 'summary';
+  /** If true, ValueSets retrieved from VSAC will be cached and used in subsequent runs where this is also true */
+  useValueSetCaching?: boolean;
 }
 
 /**
@@ -50,6 +52,8 @@ export interface RawExecutionData {
   parameters?: {
     [key: string]: any;
   };
+  /** Cache of VSAC ValueSets */
+  valueSetCache?: R4.IValueSet[];
 }
 
 /**

--- a/test/VSACHelper.test.ts
+++ b/test/VSACHelper.test.ts
@@ -1,0 +1,41 @@
+import { isVSACUrl, getOIDFromValueSet, normalizeCanonical, VSAC_BASE } from '../src/helpers/VSACHelper';
+
+describe('VSACHelper', () => {
+  describe('isVSACUrl', () => {
+    test('vsac url should return true', () => {
+      expect(isVSACUrl('http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1')).toBe(true);
+    });
+
+    test('non vsac url should return false', () => {
+      expect(isVSACUrl('http://example.com/ValueSet/1.1.1.1.1')).toBe(false);
+    });
+
+    test('vsac url with no ValueSet path should return false', () => {
+      expect(isVSACUrl('http://cts.nlm.nih.gov/fhir')).toBe(false);
+    });
+  });
+
+  describe('getOIDFromValueSet', () => {
+    test('vsac url with oid should return the oid', () => {
+      expect(getOIDFromValueSet('http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1')).toEqual(
+        '2.16.840.1.113762.1.4.1'
+      );
+    });
+
+    test('url with no oid should return null', () => {
+      expect(getOIDFromValueSet('http://cts.nlm.nih.gov/fhir')).toBeNull();
+    });
+  });
+
+  describe('normalizeCanonical', () => {
+    test('url should map to defined base', () => {
+      expect(normalizeCanonical('http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1')).toEqual(
+        `${VSAC_BASE}/2.16.840.1.113762.1.4.1`
+      );
+    });
+
+    test('url with no OID should return null', () => {
+      expect(normalizeCanonical('http://cts.nlm.nih.gov/fhir/ValueSet/')).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
# Summary

Add ability to cache ValueSets obtained via API calls. When the option is enabled, the CLI will write ValueSets to a gitignored directory after calculation succeeds.

## New behavior

* If the calculation engine encounters a scenario where valuesets are passed in to the calculation functions, it will include those valuesets in the code service used for cql execution
* If `useValueSetCaching` is specified as a calculation option, any new ValueSets retrieved from an API will be cached in memory until the results are returned to the CLI, where it will write them to disk in a `cache/terminology` directory (I went with a subdirectory in case we ever want to store something other than ValueSets in a cache

## Code changes

* New CLI option `-c/--cache-valuesets` which, if enabled, will update a gitignored directory `cache/terminology` on the users' machine with any valuesets retrieved via API requests (valuesets present in the provided measure bundle are not cached)
* All Calculator functions now have a new argument `valueSetCache` which can either be directly provided if calling the functions (e.g. in a service or other application), or in this case, is auto-generated by reading the contents of `cache/terminology`. This also makes the task to include an optional valueSet argument in calculate functions OBE
* ValueSet resolver code
  * Normalize all VSAC URLs to use the r4 base (we were getting back some stu3 valuesets somehow)
  * Include the provided valueset cache to check for missing valuesets before querying the API
* Add helper for VSAC specific resolutions and unit tests
* My editor formatted the README using prettier so instead of undoing that I just committed it idk

# Testing guidance

Testing might be annoying, but I'd recommend the following steps:

1. Run the CLI with a measure bundle where a valueset is missing (e.g. `test/fixtures/EXM130-7.3.000-bundle-nocodes-missingVS.json`), and make sure you provide an api key and use caching (`-a` and `-c` respectively)
2. The code will notice that there is a valueset missing, and will ping VSAC for it
3. After the results are output, there should be a new directory on your machine `cache/terminology` that contains that missing valueset
4. Run the CLI again with the exact same inputs, and it should be a little faster this time (that is because it is using the cached valueset rather than reaching out to VSAC). If you don't believe me, add a console log before GET requests are sent to VSAC to ensure that they aren't happening in this case

I recommend repeating this behavior for all output types except data requirements just to ensure that the argument passing is correct