### PR TITLE
Codesystem lookup

### DIFF
--- a/src/Calculator.ts
+++ b/src/Calculator.ts
@@ -307,8 +307,9 @@ export async function calculateGapsInCare(
     if (!matchingMeasureReport) {
       throw new Error(`No MeasureReport generated during gaps in care for ${res.patientId}`);
     }
-
+    
     res.detailedResults?.forEach((dr, i) => {
+
       const measureResource = MeasureHelpers.extractMeasureFromBundle(measureBundle);
 
       // Gaps only supported for proportion/ratio measures
@@ -339,10 +340,11 @@ export async function calculateGapsInCare(
       // If positive improvement measure, consider patients in denominator but not numerator for gaps
       // If negative improvement measure, consider patients in numerator for gaps
       // For either case, ignore patient if numerator isn't relevant
+
       const populationCriteria =
         numerRelevance &&
         (improvementNotation === ImprovementNotation.POSITIVE ? denomResult && !numerResult : numerResult);
-
+      
       if (populationCriteria) {
         const matchingGroup = measureResource.group?.find(g => g.id === dr.groupId) || measureResource.group?.[i];
 
@@ -411,7 +413,8 @@ export async function calculateGapsInCare(
         });
 
         detailedGapsRetrieves = GapsInCareHelpers.calculateReasonDetail(detailedGapsRetrieves, improvementNotation, dr);
-
+        
+        
         const detectedIssues = GapsInCareHelpers.generateDetectedIssueResources(
           detailedGapsRetrieves,
           matchingMeasureReport,

--- a/src/Calculator.ts
+++ b/src/Calculator.ts
@@ -307,9 +307,8 @@ export async function calculateGapsInCare(
     if (!matchingMeasureReport) {
       throw new Error(`No MeasureReport generated during gaps in care for ${res.patientId}`);
     }
-    
-    res.detailedResults?.forEach((dr, i) => {
 
+    res.detailedResults?.forEach((dr, i) => {
       const measureResource = MeasureHelpers.extractMeasureFromBundle(measureBundle);
 
       // Gaps only supported for proportion/ratio measures
@@ -344,7 +343,7 @@ export async function calculateGapsInCare(
       const populationCriteria =
         numerRelevance &&
         (improvementNotation === ImprovementNotation.POSITIVE ? denomResult && !numerResult : numerResult);
-      
+
       if (populationCriteria) {
         const matchingGroup = measureResource.group?.find(g => g.id === dr.groupId) || measureResource.group?.[i];
 
@@ -413,8 +412,7 @@ export async function calculateGapsInCare(
         });
 
         detailedGapsRetrieves = GapsInCareHelpers.calculateReasonDetail(detailedGapsRetrieves, improvementNotation, dr);
-        
-        
+
         const detectedIssues = GapsInCareHelpers.generateDetectedIssueResources(
           detailedGapsRetrieves,
           matchingMeasureReport,

--- a/src/GapsInCareHelpers.ts
+++ b/src/GapsInCareHelpers.ts
@@ -201,7 +201,8 @@ export function generateGuidanceResponses(
 
       detailedFilters.forEach(df => {
         if (df.type === 'equals' || df.type === 'in') {
-          const cf = generateDetailedCodeFilter(df as EqualsFilter | InFilter);
+
+          const cf = generateDetailedCodeFilter(df as EqualsFilter | InFilter, q.dataType);
 
           if (cf !== null) {
             dataRequirement.codeFilter?.push(cf);

--- a/src/GapsInCareHelpers.ts
+++ b/src/GapsInCareHelpers.ts
@@ -201,7 +201,6 @@ export function generateGuidanceResponses(
 
       detailedFilters.forEach(df => {
         if (df.type === 'equals' || df.type === 'in') {
-
           const cf = generateDetailedCodeFilter(df as EqualsFilter | InFilter, q.dataType);
 
           if (cf !== null) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -64,7 +64,6 @@ async function calc(
     result = await calculateMeasureReports(measureBundle, patientBundles, calcOptions);
   } else if (program.outputType === 'gaps') {
     result = await calculateGapsInCare(measureBundle, patientBundles, calcOptions);
-    
   } else if (program.outputType === 'dataRequirements') {
     // CalculateDataRequirements doesn't make use of the calcOptions object at this point
     result = calculateDataRequirements(measureBundle);
@@ -147,7 +146,6 @@ calc(measureBundle, patientBundles, calcOptions)
     }
 
     console.log(JSON.stringify(result?.results, null, 2));
-
   })
   .catch(error => {
     console.error(error.message);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -64,6 +64,7 @@ async function calc(
     result = await calculateMeasureReports(measureBundle, patientBundles, calcOptions);
   } else if (program.outputType === 'gaps') {
     result = await calculateGapsInCare(measureBundle, patientBundles, calcOptions);
+    
   } else if (program.outputType === 'dataRequirements') {
     // CalculateDataRequirements doesn't make use of the calcOptions object at this point
     result = calculateDataRequirements(measureBundle);
@@ -146,6 +147,7 @@ calc(measureBundle, patientBundles, calcOptions)
     }
 
     console.log(JSON.stringify(result?.results, null, 2));
+
   })
   .catch(error => {
     console.error(error.message);

--- a/src/helpers/DataRequirementHelpers.ts
+++ b/src/helpers/DataRequirementHelpers.ts
@@ -10,8 +10,6 @@ import {
   NotNullFilter
 } from '../types/QueryFilterTypes';
 
-
-
 /**
  * Take any nesting of base filters and AND filters and flatten into one list
  *
@@ -37,52 +35,42 @@ export function flattenFilters(filter: AnyFilter): AnyFilter[] {
  * @param filter the filter to translate
  * @returns codeFilter to be put on the DataRequirement
  */
-export function generateDetailedCodeFilter(filter: EqualsFilter | InFilter, dataType: string): R4.IDataRequirement_CodeFilter | null {
+export function generateDetailedCodeFilter(
+  filter: EqualsFilter | InFilter,
+  dataType: string
+): R4.IDataRequirement_CodeFilter | null {
+  const codeLookup = (dataType: string, attribute: string): string | undefined => {
+    const validDataTypes: string[] = ['Observation', 'Procedure', 'Encounter', 'MedicationRequest'];
 
-
-  const codeLookup = (dataType: string, attribute: string): (string | undefined) => {
-
-    const validDataTypes : string[] = ["Observation", "Procedure", "Encounter", "MedicationRequest"];
-    
-    if (!(validDataTypes.includes(dataType))) {
+    if (!validDataTypes.includes(dataType)) {
       return undefined;
-    }
-
-    else if (dataType === "Observation" && attribute === "status") {
-      return "http://hl7.org/fhir/observation-status";
-    }
-    
-    else if (dataType === "Procedure" && attribute === "status") {
-      return "http://hl7.org/fhir/event-status";
-    }
-
-    else if (dataType === "Encounter" && attribute === "status") {
+    } else if (dataType === 'Observation' && attribute === 'status') {
+      return 'http://hl7.org/fhir/observation-status';
+    } else if (dataType === 'Procedure' && attribute === 'status') {
+      return 'http://hl7.org/fhir/event-status';
+    } else if (dataType === 'Encounter' && attribute === 'status') {
       return 'http://hl7.org/fhir/encounter-status';
-    }
-
-    else if (dataType === 'MedicationRequest'){
-      
-      switch(attribute){
+    } else if (dataType === 'MedicationRequest') {
+      switch (attribute) {
         case 'status':
-          return "http://hl7.org/fhir/CodeSystem/medicationrequest-status";
-          
+          return 'http://hl7.org/fhir/CodeSystem/medicationrequest-status';
+
         case 'intent':
-          return "http://hl7.org/fhir/CodeSystem/medicationrequest-intent";
-            
+          return 'http://hl7.org/fhir/CodeSystem/medicationrequest-intent';
+
         case 'priority':
-          return "http://hl7.org/fhir/request-priority";
-          
+          return 'http://hl7.org/fhir/request-priority';
+
         default:
           return undefined;
       }
     }
     return undefined;
-    
-  }
-  let system : string | undefined = codeLookup(dataType, filter.attribute);
+  };
+  const system: string | undefined = codeLookup(dataType, filter.attribute);
   if (filter.type === 'equals') {
     const equalsFilter = filter as EqualsFilter;
-    if (typeof equalsFilter.value === 'string'){
+    if (typeof equalsFilter.value === 'string') {
       // console.log(`dataType: ${dataType}`);
       // console.log(`attribute: ${equalsFilter.attribute}`);
       // console.log(`code lookup: ${codeLookup(dataType, equalsFilter.attribute)}`);
@@ -98,10 +86,12 @@ export function generateDetailedCodeFilter(filter: EqualsFilter | InFilter, data
 
       return {
         path: equalsFilter.attribute,
-        code: [{ 
-          code: equalsFilter.value,
-          system: system
-         }]
+        code: [
+          {
+            code: equalsFilter.value,
+            system: system
+          }
+        ]
       };
     }
   } else if (filter.type === 'in') {

--- a/src/helpers/DataRequirementHelpers.ts
+++ b/src/helpers/DataRequirementHelpers.ts
@@ -9,9 +9,7 @@ import {
   Filter,
   NotNullFilter
 } from '../types/QueryFilterTypes';
-import { GapsDataTypeQuery } from '../types/Calculator';
-import { ICoding } from '@ahryman40k/ts-fhir-types/lib/R4';
-import { equal } from 'assert';
+
 
 
 /**

--- a/test/DataRequirementHelpers.test.ts
+++ b/test/DataRequirementHelpers.test.ts
@@ -9,7 +9,6 @@ import {
 } from '../src/types/QueryFilterTypes';
 import { R4 } from '@ahryman40k/ts-fhir-types';
 import { DataTypeQuery } from '../src/types/Calculator';
-import exp from 'constants';
 
 describe('DataRequirementHelpers', () => {
   describe('Flatten Filters', () => {

--- a/test/GapsInCareHelpers.test.ts
+++ b/test/GapsInCareHelpers.test.ts
@@ -716,7 +716,8 @@ describe('Guidance Response', () => {
             path: 'status',
             code: [
               {
-                code: 'completed'
+                code: 'completed',
+                system: 'http://hl7.org/fhir/event-status'
               }
             ]
           }
@@ -764,10 +765,12 @@ describe('Guidance Response', () => {
             path: 'status',
             code: [
               {
-                code: 'completed'
+                code: 'completed',
+                system: 'http://hl7.org/fhir/event-status'
               },
               {
-                code: 'amended'
+                code: 'amended',
+                system: 'http://hl7.org/fhir/event-status'
               }
             ]
           }
@@ -986,7 +989,8 @@ describe('Guidance Response', () => {
             path: 'status',
             code: [
               {
-                code: 'completed'
+                code: 'completed',
+                system: 'http://hl7.org/fhir/event-status'
               }
             ]
           }


### PR DESCRIPTION
# Summary
Added a codeLookup function inside the GenerateDetailedCodeFilters function which takes as arguments a string representing a FHIR dataType and an attribute of that dataType and returns the url of the codesystem that outlines the valid settings of said attribute when appropriate (returns undefined otherwise). Updated GenerateDetailedCodeFilters to call codeLookup when passed an appropriate dataType, attribute pair and add the codesystem url to the output code object.

## New behavior
adds the url of the codesystem to appropriate code objects in JSON output

## Code changes
GenerateDetailedCodeFilters now takes as input and additional string representing a FHIR dataType 

# Testing guidance
Tests will need to be updated to verify the new functionality is working properly and old tests will need to be altered to call the updated GenerateDetailedCodeFilters function which now takes an additional dataType: string as the second argument.
