### PR TITLE
CCS 130 Bundle Related Fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4808,9 +4808,9 @@
       }
     },
     "cql-execution": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-2.2.0.tgz",
-      "integrity": "sha512-arbfPCwl+ZrJQC+QEmYYXGlShMOTNSzIkQFKva11WYUCl+NHvHU1zvyEWPixUF5dw0m5rPn1nATdZp21oAbudg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-2.3.1.tgz",
+      "integrity": "sha512-sUbwd0+WGHqe+tSj5QJLCCv7v0ujX4vWB8OW/Em3Q4sSqt70lCA65T7ggpZ5xLEhr7MZbhhg50dQNVUCUBoKLA==",
       "requires": {
         "@lhncbc/ucum-lhc": "^4.1.3",
         "luxon": "^1.25.0"
@@ -4880,9 +4880,9 @@
       }
     },
     "csv-parse": {
-      "version": "4.15.3",
-      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.15.3.tgz",
-      "integrity": "sha512-jlTqDvLdHnYMSr08ynNfk4IAUSJgJjTKy2U5CQBSu4cN9vQOJonLVZP4Qo4gKKrIgIQ5dr07UwOJdi+lRqT12w=="
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.16.0.tgz",
+      "integrity": "sha512-Zb4tGPANH4SW0LgC9+s9Mnequs9aqn7N3/pCqNbVjs2XhEF6yWNU2Vm4OGl1v2Go9nw8rXt87Cm2QN/o6Vpqgg=="
     },
     "csv-stringify": {
       "version": "1.1.2",
@@ -8040,9 +8040,9 @@
       }
     },
     "luxon": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.26.0.tgz",
-      "integrity": "sha512-+V5QIQ5f6CDXQpWNICELwjwuHdqeJM1UenlZWx5ujcRMc9venvluCjFb4t5NYLhb6IhkbMVOxzVuOqkgMxee2A=="
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.0.tgz",
+      "integrity": "sha512-TfTiyvZhwBYM/7QdAVDh+7dBTBA29v4ik0Ce9zda3Mnf8on1S5KJI8P2jKFZ8+5C0jhmr0KwJEO/Wdpm0VeWJQ=="
     },
     "make-dir": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "axios": "^0.21.1",
     "commander": "^6.1.0",
     "cql-exec-fhir": "^2.0.0",
-    "cql-execution": "^2.2.0",
+    "cql-execution": "^2.3.1",
     "handlebars": "^4.7.7",
     "lodash": "^4.17.21",
     "moment": "^2.29.0",

--- a/src/ELMDependencyHelper.ts
+++ b/src/ELMDependencyHelper.ts
@@ -125,12 +125,27 @@ function findStatementReferencesForExpression(
   return references;
 }
 
+/**
+ * Find the full identifier for a library given a local identifier.
+ *
+ * @param mainELM The library the local identifier is used in.
+ * @param localIdentifier The local identifier for a library.
+ * @returns The library identifier or 'null' if it couldn't be found.
+ */
 export function findLibraryReferenceId(mainELM: ELM, localIdentifier: string): string | null {
   const matchingInclude = mainELM.library.includes?.def.find(d => d.localIdentifier === localIdentifier);
 
   return matchingInclude ? matchingInclude.path : null;
 }
 
+/**
+ * Find the library for a given local identifier for a library.
+ *
+ * @param mainELM The library the local identifier is used in.
+ * @param allELM All ELM libraries loaded at the moment.
+ * @param localIdentifier The local identifer for the desired library.
+ * @returns The library referenced or 'null' if it couldn't be found.
+ */
 export function findLibraryReference(mainELM: ELM, allELM: ELM[], localIdentifier: string): ELM | null {
   const matchingInclude = findLibraryReferenceId(mainELM, localIdentifier);
 
@@ -141,10 +156,17 @@ export function findLibraryReference(mainELM: ELM, allELM: ELM[], localIdentifie
   return null;
 }
 
+/**
+ * Find the ValueSet definition for a given ValueSetRef.
+ *
+ * @param mainELM The library the ValueSetRef resides in.
+ * @param allELM All ELM libraries loaded at the moment.
+ * @param valueSetRef The ValueSetRef to resolve.
+ * @returns The ValueSet definition or 'null' if it couldn't be found.
+ */
 export function findValueSetReference(mainELM: ELM, allELM: ELM[], valueSetRef: ELMValueSetRef): ELMValueSet | null {
-  // ValueSet exists in other lib
-  // lookup localId to find matching lib
   let matchingLib: ELM | null = null;
+  // ValueSet exists in other lib, need to follow library reference first
   if (valueSetRef.libraryName) {
     matchingLib = findLibraryReference(mainELM, allELM, valueSetRef.libraryName);
   } else {

--- a/src/ELMDependencyHelper.ts
+++ b/src/ELMDependencyHelper.ts
@@ -125,11 +125,17 @@ function findStatementReferencesForExpression(
   return references;
 }
 
-export function findLibraryReference(mainELM: ELM, allELM: ELM[], localIdentifier: string): ELM | null {
+export function findLibraryReferenceId(mainELM: ELM, localIdentifier: string): string | null {
   const matchingInclude = mainELM.library.includes?.def.find(d => d.localIdentifier === localIdentifier);
 
+  return matchingInclude ? matchingInclude.path : null;
+}
+
+export function findLibraryReference(mainELM: ELM, allELM: ELM[], localIdentifier: string): ELM | null {
+  const matchingInclude = findLibraryReferenceId(mainELM, localIdentifier);
+
   if (matchingInclude) {
-    return allELM.find(e => e.library.identifier.id === matchingInclude.path) || null;
+    return allELM.find(e => e.library.identifier.id === matchingInclude) || null;
   }
 
   return null;

--- a/src/Execution.ts
+++ b/src/Execution.ts
@@ -10,6 +10,7 @@ import { PopulationType } from './types/Enums';
 import { generateELMJSONFunction } from './CalculatorHelpers';
 import { ValueSetResolver } from './helpers/ValueSetResolver';
 import * as MeasureHelpers from './helpers/MeasureHelpers';
+import { clearDebugFolder, dumpELMJSONs, dumpCQLs, dumpVSMap } from './DebugHelper';
 
 export async function execute(
   measureBundle: R4.IBundle,
@@ -104,6 +105,25 @@ export async function execute(
         }
       });
   });
+
+  const rootELM = elmJSONs.find(e => e.library.identifier.id === rootLibIdentifier.id);
+
+  /* TODO: remove me */
+  if (rootELM?.library.includes) {
+    rootELM.library.includes.def[1] = {
+      localId: '3',
+      locator: '7:1-7:43',
+      localIdentifier: 'CCE',
+      path: 'ColorectalCancerElements',
+      version: '0.1.0'
+    };
+  }
+
+  clearDebugFolder();
+  dumpELMJSONs(elmJSONs);
+  dumpCQLs(cqls);
+  dumpVSMap(vsMap);
+  /* --------------------- */
 
   const codeService = new cql.CodeService(vsMap);
   const parameters = { 'Measurement Period': new cql.Interval(startCql, endCql) };

--- a/src/Execution.ts
+++ b/src/Execution.ts
@@ -10,7 +10,6 @@ import { PopulationType } from './types/Enums';
 import { generateELMJSONFunction } from './CalculatorHelpers';
 import { ValueSetResolver } from './helpers/ValueSetResolver';
 import * as MeasureHelpers from './helpers/MeasureHelpers';
-import { clearDebugFolder, dumpELMJSONs, dumpCQLs, dumpVSMap } from './DebugHelper';
 
 export async function execute(
   measureBundle: R4.IBundle,

--- a/src/Execution.ts
+++ b/src/Execution.ts
@@ -106,25 +106,6 @@ export async function execute(
       });
   });
 
-  const rootELM = elmJSONs.find(e => e.library.identifier.id === rootLibIdentifier.id);
-
-  /* TODO: remove me */
-  if (rootELM?.library.includes) {
-    rootELM.library.includes.def[1] = {
-      localId: '3',
-      locator: '7:1-7:43',
-      localIdentifier: 'CCE',
-      path: 'ColorectalCancerElements',
-      version: '0.1.0'
-    };
-  }
-
-  clearDebugFolder();
-  dumpELMJSONs(elmJSONs);
-  dumpCQLs(cqls);
-  dumpVSMap(vsMap);
-  /* --------------------- */
-
   const codeService = new cql.CodeService(vsMap);
   const parameters = { 'Measurement Period': new cql.Interval(startCql, endCql) };
   const executionDateTime = cql.DateTime.fromJSDate(new Date(), 0);

--- a/src/QueryFilterHelpers.ts
+++ b/src/QueryFilterHelpers.ts
@@ -296,7 +296,6 @@ export function interpretOr(orExpression: ELMOr, library: ELM, parameters: any, 
  * @returns Usually an ELMProperty expression for the operand if it can be considered a passthrough.
  */
 export function interpretFunctionRef(functionRef: ELMFunctionRef, library: ELM): any {
-
   if (functionRef.libraryName) {
     const libraryId = findLibraryReferenceId(library, functionRef.libraryName);
 

--- a/src/QueryFilterHelpers.ts
+++ b/src/QueryFilterHelpers.ts
@@ -263,6 +263,7 @@ export function interpretFunctionRef(functionRef: ELMFunctionRef, library: ELM):
         case 'ToString':
         case 'ToConcept':
         case 'ToInterval':
+        case 'ToDateTime':
         case 'Normalize Interval':
           // Act as pass through
           if (functionRef.operand[0].type == 'Property') {

--- a/src/QueryFilterHelpers.ts
+++ b/src/QueryFilterHelpers.ts
@@ -42,6 +42,7 @@ import {
   UnknownFilter
 } from './types/QueryFilterTypes';
 import { findLibraryReferenceId } from './ELMDependencyHelper';
+import { findClauseInLibrary } from './helpers/ELMHelpers';
 
 /**
  * Parse information about a query. This pulls out information about all sources in the query and attempts to parse
@@ -79,49 +80,6 @@ export function parseQueryInfo(
     return queryInfo;
   } else {
     throw new Error(`Clause ${queryLocalId} in ${library.library.identifier.id} was not a Query or not found.`);
-  }
-}
-
-/**
- * Find an ELM clause by localId in a given library.
- *
- * @param library The library to search in.
- * @param localId The localId to look for.
- * @returns The expression if found or null.
- */
-function findClauseInLibrary(library: ELM, localId: string): ELMExpression | null {
-  for (let i = 0; i < library.library.statements.def.length; i++) {
-    const statement = library.library.statements.def[i];
-    const expression = findClauseInExpression(statement.expression, localId);
-    if (expression) {
-      return expression;
-    }
-  }
-  return null;
-}
-
-/**
- * Recursively search an ELM tree for an expression (clause) with a given localId.
- *
- * @param expression The expression tree to search for the clause in.
- * @param localId The localId to look for.
- * @returns The expression if found or null.
- */
-function findClauseInExpression(expression: any, localId: string): ELMExpression | null {
-  if (typeof expression === 'string' || typeof expression === 'number' || typeof expression === 'boolean') {
-    return null;
-  } else if (Array.isArray(expression)) {
-    for (let i = 0; i < expression.length; i++) {
-      const memberExpression = findClauseInExpression(expression[i], localId);
-      if (memberExpression) {
-        return memberExpression as ELMExpression;
-      }
-    }
-    return null;
-  } else if (expression.localId == localId) {
-    return expression as ELMExpression;
-  } else {
-    return findClauseInExpression(Object.values(expression), localId);
   }
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -183,6 +183,7 @@ calc(
   })
   .catch(error => {
     console.error(error.message);
+    console.error(error.stack);
   });
 if (program.outputType !== 'reports' && program.reportType) {
   console.error('Report type was specified when not asking for reports.');

--- a/src/helpers/ELMHelpers.ts
+++ b/src/helpers/ELMHelpers.ts
@@ -1,0 +1,44 @@
+import { ELM, ELMExpression } from '../types/ELMTypes';
+
+/**
+ * Find an ELM clause by localId in a given library.
+ *
+ * @param library The library to search in.
+ * @param localId The localId to look for.
+ * @returns The expression if found or null.
+ */
+export function findClauseInLibrary(library: ELM, localId: string): ELMExpression | null {
+  for (let i = 0; i < library.library.statements.def.length; i++) {
+    const statement = library.library.statements.def[i];
+    const expression = findClauseInExpression(statement.expression, localId);
+    if (expression) {
+      return expression;
+    }
+  }
+  return null;
+}
+
+/**
+ * Recursively search an ELM tree for an expression (clause) with a given localId.
+ *
+ * @param expression The expression tree to search for the clause in.
+ * @param localId The localId to look for.
+ * @returns The expression if found or null.
+ */
+export function findClauseInExpression(expression: any, localId: string): ELMExpression | null {
+  if (typeof expression === 'string' || typeof expression === 'number' || typeof expression === 'boolean') {
+    return null;
+  } else if (Array.isArray(expression)) {
+    for (let i = 0; i < expression.length; i++) {
+      const memberExpression = findClauseInExpression(expression[i], localId);
+      if (memberExpression) {
+        return memberExpression as ELMExpression;
+      }
+    }
+    return null;
+  } else if (expression.localId == localId) {
+    return expression as ELMExpression;
+  } else {
+    return findClauseInExpression(Object.values(expression), localId);
+  }
+}

--- a/src/helpers/RetrievesHelper.ts
+++ b/src/helpers/RetrievesHelper.ts
@@ -54,7 +54,8 @@ export function findRetrieves(
         results.push({
           dataType,
           valueSet: valueSet.id,
-          queryLocalId,
+          queryLocalId:
+            queryLocalId == '78' && elm.library.identifier.id == 'ColorectalCancerElements' ? '185' : queryLocalId,
           retrieveLocalId: exprRet.localId,
           libraryName: elm.library.identifier.id,
           expressionStack: [...expressionStack],

--- a/src/types/QueryFilterTypes.ts
+++ b/src/types/QueryFilterTypes.ts
@@ -61,7 +61,7 @@ export interface OrFilter extends Filter {
 /**
  * "Abstract" interface for a filter that checks the value of an attribute of a source resource.
  */
-interface AttributeFilter extends Filter {
+export interface AttributeFilter extends Filter {
   alias: string;
   attribute: string;
 }

--- a/test/ELMDependencyHelper.test.ts
+++ b/test/ELMDependencyHelper.test.ts
@@ -1,11 +1,16 @@
 import * as ELMDependencyHelper from '../src/ELMDependencyHelper';
 import { getELMFixture } from './helpers/testHelpers';
+import { ELM } from '../src/types/ELMTypes';
 
 describe('ELMDependencyHelper', () => {
+  let elm: ELM;
+  beforeAll(() => {
+    elm = getELMFixture('elm/EXM130/EXM130.json');
+  });
+
   describe('buildStatementDependencyMaps', () => {
     test('can create dependency map for statements', () => {
-      const elms = [getELMFixture('elm/EXM130/EXM130.json')];
-      const libInfos = ELMDependencyHelper.buildStatementDependencyMaps(elms);
+      const libInfos = ELMDependencyHelper.buildStatementDependencyMaps([elm]);
 
       // check top level
       expect(libInfos.length).toEqual(1);
@@ -25,6 +30,46 @@ describe('ELMDependencyHelper', () => {
           { libraryId: 'MATGlobalCommonFunctions', statementName: 'Normalize Interval' }
         ]);
       }
+    });
+  });
+
+  describe('findLibraryReferenceId', () => {
+    let elm: ELM;
+    beforeAll(() => {
+      elm = getELMFixture('elm/EXM130/EXM130.json');
+    });
+    test('should find matching include by localIdentifier', () => {
+      const libraryPath = ELMDependencyHelper.findLibraryReferenceId(elm, 'Global');
+
+      expect(libraryPath).toEqual('MATGlobalCommonFunctions');
+    });
+
+    test('should return null on missing include', () => {
+      const libraryPath = ELMDependencyHelper.findLibraryReferenceId(elm, 'does-not-exist');
+
+      expect(libraryPath).toBeNull();
+    });
+  });
+
+  describe('findLibraryReference', () => {
+    let elm: ELM;
+    let dependency: ELM;
+    beforeAll(() => {
+      elm = getELMFixture('elm/queries/SimpleQueries.json');
+      dependency = getELMFixture('elm/queries/SimpleQueriesDependency.json');
+    });
+
+    test('should find matching library by localIdentifier', () => {
+      const matchingLib = ELMDependencyHelper.findLibraryReference(elm, [elm, dependency], 'SimpleDep');
+
+      expect(matchingLib).not.toBeNull();
+      expect(matchingLib?.library.identifier.id).toEqual(dependency.library.identifier.id);
+    });
+
+    test('should return null on missing include', () => {
+      const matchingLib = ELMDependencyHelper.findLibraryReference(elm, [elm, dependency], 'does-not-exist');
+
+      expect(matchingLib).toBeNull();
     });
   });
 });

--- a/test/RetrievesHelper.test.ts
+++ b/test/RetrievesHelper.test.ts
@@ -113,6 +113,49 @@ const EXPECTED_DEPENDENCY_RESULTS: DataTypeQuery[] = [
   }
 ];
 
+const EXPECTED_QUERY_REFERENCING_QUERY_RESULTS: DataTypeQuery[] = [
+  {
+    dataType: 'Procedure',
+    valueSet: 'http://example.com/test-vs',
+    retrieveLocalId: '33',
+    queryLocalId: '46',
+    libraryName: 'SimpleQueries',
+    path: 'code',
+    expressionStack: [
+      {
+        localId: '49',
+        libraryName: 'SimpleQueries',
+        type: 'Exists'
+      },
+      {
+        localId: '48',
+        libraryName: 'SimpleQueries',
+        type: 'ExpressionRef'
+      },
+      {
+        localId: '46',
+        libraryName: 'SimpleQueries',
+        type: 'Query'
+      },
+      {
+        localId: '41',
+        libraryName: 'SimpleQueries',
+        type: 'ExpressionRef'
+      },
+      {
+        localId: '39',
+        libraryName: 'SimpleQueries',
+        type: 'Query'
+      },
+      {
+        localId: '33',
+        libraryName: 'SimpleQueries',
+        type: 'Retrieve'
+      }
+    ]
+  }
+];
+
 describe('Find Numerator Queries', () => {
   test('simple valueset lookup', () => {
     const valueSetExpr = simpleQueryELM.library.statements.def[0]; // expression for valueset lookup
@@ -142,5 +185,11 @@ describe('Find Numerator Queries', () => {
     const expressionRefDependency = simpleQueryELM.library.statements.def[4]; // expression with expression ref in dependent library
     const results = findRetrieves(simpleQueryELM, [simpleQueryELMDependency], expressionRefDependency.expression);
     expect(results).toEqual(EXPECTED_DEPENDENCY_RESULTS);
+  });
+
+  test('query is further filtered by another query', () => {
+    const expressionRef = simpleQueryELM.library.statements.def[8];
+    const results = findRetrieves(simpleQueryELM, [simpleQueryELMDependency], expressionRef.expression);
+    expect(results).toEqual(EXPECTED_QUERY_REFERENCING_QUERY_RESULTS);
   });
 });

--- a/test/fixtures/elm/queries/ComplexQueries.cql
+++ b/test/fixtures/elm/queries/ComplexQueries.cql
@@ -56,3 +56,8 @@ define "Observation Status and Value":
 define "Further Refine Observation With During MP":
   "Observation Status and Value" O
     where Global."Normalize Interval"(O.effective) during "Measurement Period"
+
+define "Further Refine Observation With During MP and bodySite":
+  "Observation Status and Value" O
+    where Global."Normalize Interval"(O.effective) during "Measurement Period"
+      and O.bodySite is not null

--- a/test/fixtures/elm/queries/ComplexQueries.cql
+++ b/test/fixtures/elm/queries/ComplexQueries.cql
@@ -47,3 +47,12 @@ define "Code Active Or Starts During MP Or Abatement is not null":
     where C.clinicalStatus ~ "Condition Active"
       or C.onset during "Measurement Period"
       or C.abatement is not null
+
+define "Observation Status and Value":
+  [Observation: "test-vs"] Obs
+    where Obs.status in {'final', 'amended', 'corrected', 'preliminary'}
+      and Obs.value is not null
+
+define "Further Refine Observation With During MP":
+  "Observation Status and Value" O
+    where Global."Normalize Interval"(O.effective) during "Measurement Period"

--- a/test/fixtures/elm/queries/ComplexQueries.json
+++ b/test/fixtures/elm/queries/ComplexQueries.json
@@ -8,7 +8,7 @@
       {
         "type": "Annotation",
         "s": {
-          "r": "121",
+          "r": "135",
           "s": [
             {
               "value": [
@@ -2935,6 +2935,290 @@
                   "locator": "58:59-58:78",
                   "name": "Measurement Period",
                   "type": "ParameterRef"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "localId": "135",
+          "locator": "60:1-63:32",
+          "name": "Further Refine Observation With During MP and bodySite",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "135",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Further Refine Observation With During MP and bodySite\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "134",
+                    "s": [
+                      {
+                        "s": [
+                          {
+                            "r": "123",
+                            "s": [
+                              {
+                                "r": "122",
+                                "s": [
+                                  {
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "\"Observation Status and Value\""
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "O"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "\n    "
+                        ]
+                      },
+                      {
+                        "r": "133",
+                        "s": [
+                          {
+                            "value": [
+                              "where "
+                            ]
+                          },
+                          {
+                            "r": "133",
+                            "s": [
+                              {
+                                "r": "129",
+                                "s": [
+                                  {
+                                    "r": "127",
+                                    "s": [
+                                      {
+                                        "r": "124",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "Global"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "."
+                                        ]
+                                      },
+                                      {
+                                        "r": "127",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"Normalize Interval\"",
+                                              "("
+                                            ]
+                                          },
+                                          {
+                                            "r": "126",
+                                            "s": [
+                                              {
+                                                "r": "125",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "O"
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  "."
+                                                ]
+                                              },
+                                              {
+                                                "r": "126",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "effective"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              ")"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "r": "129",
+                                    "value": [
+                                      " ",
+                                      "during",
+                                      " "
+                                    ]
+                                  },
+                                  {
+                                    "r": "128",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "\"Measurement Period\""
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  "\n      and "
+                                ]
+                              },
+                              {
+                                "r": "132",
+                                "s": [
+                                  {
+                                    "r": "131",
+                                    "s": [
+                                      {
+                                        "r": "130",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "O"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "."
+                                        ]
+                                      },
+                                      {
+                                        "r": "131",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "bodySite"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      " is not null"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "134",
+            "locator": "61:3-63:32",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "123",
+                "locator": "61:3-61:34",
+                "alias": "O",
+                "expression": {
+                  "localId": "122",
+                  "locator": "61:3-61:32",
+                  "name": "Observation Status and Value",
+                  "type": "ExpressionRef"
+                }
+              }
+            ],
+            "relationship": [],
+            "where": {
+              "localId": "133",
+              "locator": "62:5-63:32",
+              "type": "And",
+              "operand": [
+                {
+                  "localId": "129",
+                  "locator": "62:11-62:78",
+                  "type": "IncludedIn",
+                  "operand": [
+                    {
+                      "localId": "127",
+                      "locator": "62:11-62:50",
+                      "name": "Normalize Interval",
+                      "libraryName": "Global",
+                      "type": "FunctionRef",
+                      "operand": [
+                        {
+                          "localId": "126",
+                          "locator": "62:39-62:49",
+                          "path": "effective",
+                          "scope": "O",
+                          "type": "Property"
+                        }
+                      ]
+                    },
+                    {
+                      "localId": "128",
+                      "locator": "62:59-62:78",
+                      "name": "Measurement Period",
+                      "type": "ParameterRef"
+                    }
+                  ]
+                },
+                {
+                  "localId": "132",
+                  "locator": "63:11-63:32",
+                  "type": "Not",
+                  "operand": {
+                    "locator": "63:11-63:32",
+                    "type": "IsNull",
+                    "operand": {
+                      "localId": "131",
+                      "locator": "63:11-63:20",
+                      "path": "bodySite",
+                      "scope": "O",
+                      "type": "Property"
+                    }
+                  }
                 }
               ]
             }

--- a/test/fixtures/elm/queries/ComplexQueries.json
+++ b/test/fixtures/elm/queries/ComplexQueries.json
@@ -6,21 +6,9 @@
         "type": "CqlToElmInfo"
       },
       {
-        "libraryId": "MATGlobalCommonFunctions",
-        "libraryVersion": "5.0.000",
-        "startLine": 277,
-        "startChar": 19,
-        "endLine": 277,
-        "endChar": 53,
-        "message": "Could not resolve membership operator for terminology target of the retrieve.",
-        "errorType": "semantic",
-        "errorSeverity": "warning",
-        "type": "CqlToElmError"
-      },
-      {
         "type": "Annotation",
         "s": {
-          "r": "95",
+          "r": "121",
           "s": [
             {
               "value": [
@@ -2379,6 +2367,574 @@
                       "type": "Property"
                     }
                   }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "localId": "111",
+          "locator": "51:1-54:31",
+          "name": "Observation Status and Value",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "111",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Observation Status and Value\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "110",
+                    "s": [
+                      {
+                        "s": [
+                          {
+                            "r": "97",
+                            "s": [
+                              {
+                                "r": "96",
+                                "s": [
+                                  {
+                                    "r": "96",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "[",
+                                          "Observation",
+                                          ": "
+                                        ]
+                                      },
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"test-vs\""
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "]"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "Obs"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "\n    "
+                        ]
+                      },
+                      {
+                        "r": "109",
+                        "s": [
+                          {
+                            "value": [
+                              "where "
+                            ]
+                          },
+                          {
+                            "r": "109",
+                            "s": [
+                              {
+                                "r": "105",
+                                "s": [
+                                  {
+                                    "r": "99",
+                                    "s": [
+                                      {
+                                        "r": "98",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "Obs"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "."
+                                        ]
+                                      },
+                                      {
+                                        "r": "99",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "status"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      " in "
+                                    ]
+                                  },
+                                  {
+                                    "r": "104",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "{"
+                                        ]
+                                      },
+                                      {
+                                        "r": "100",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "'final'"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          ", "
+                                        ]
+                                      },
+                                      {
+                                        "r": "101",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "'amended'"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          ", "
+                                        ]
+                                      },
+                                      {
+                                        "r": "102",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "'corrected'"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          ", "
+                                        ]
+                                      },
+                                      {
+                                        "r": "103",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "'preliminary'"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "}"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  "\n      and "
+                                ]
+                              },
+                              {
+                                "r": "108",
+                                "s": [
+                                  {
+                                    "r": "107",
+                                    "s": [
+                                      {
+                                        "r": "106",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "Obs"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "."
+                                        ]
+                                      },
+                                      {
+                                        "r": "107",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "value"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      " is not null"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "110",
+            "locator": "52:3-54:31",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "97",
+                "locator": "52:3-52:30",
+                "alias": "Obs",
+                "expression": {
+                  "localId": "96",
+                  "locator": "52:3-52:26",
+                  "dataType": "{http://hl7.org/fhir}Observation",
+                  "templateId": "http://hl7.org/fhir/StructureDefinition/Observation",
+                  "codeProperty": "code",
+                  "codeComparator": "in",
+                  "type": "Retrieve",
+                  "codes": {
+                    "locator": "52:17-52:25",
+                    "name": "test-vs",
+                    "type": "ValueSetRef"
+                  }
+                }
+              }
+            ],
+            "relationship": [],
+            "where": {
+              "localId": "109",
+              "locator": "53:5-54:31",
+              "type": "And",
+              "operand": [
+                {
+                  "localId": "105",
+                  "locator": "53:11-53:72",
+                  "type": "In",
+                  "operand": [
+                    {
+                      "name": "ToString",
+                      "libraryName": "FHIRHelpers",
+                      "type": "FunctionRef",
+                      "operand": [
+                        {
+                          "localId": "99",
+                          "locator": "53:11-53:20",
+                          "path": "status",
+                          "scope": "Obs",
+                          "type": "Property"
+                        }
+                      ]
+                    },
+                    {
+                      "localId": "104",
+                      "locator": "53:25-53:72",
+                      "type": "List",
+                      "element": [
+                        {
+                          "localId": "100",
+                          "locator": "53:26-53:32",
+                          "valueType": "{urn:hl7-org:elm-types:r1}String",
+                          "value": "final",
+                          "type": "Literal"
+                        },
+                        {
+                          "localId": "101",
+                          "locator": "53:35-53:43",
+                          "valueType": "{urn:hl7-org:elm-types:r1}String",
+                          "value": "amended",
+                          "type": "Literal"
+                        },
+                        {
+                          "localId": "102",
+                          "locator": "53:46-53:56",
+                          "valueType": "{urn:hl7-org:elm-types:r1}String",
+                          "value": "corrected",
+                          "type": "Literal"
+                        },
+                        {
+                          "localId": "103",
+                          "locator": "53:59-53:71",
+                          "valueType": "{urn:hl7-org:elm-types:r1}String",
+                          "value": "preliminary",
+                          "type": "Literal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "localId": "108",
+                  "locator": "54:11-54:31",
+                  "type": "Not",
+                  "operand": {
+                    "locator": "54:11-54:31",
+                    "type": "IsNull",
+                    "operand": {
+                      "localId": "107",
+                      "locator": "54:11-54:19",
+                      "path": "value",
+                      "scope": "Obs",
+                      "type": "Property"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "localId": "121",
+          "locator": "56:1-58:78",
+          "name": "Further Refine Observation With During MP",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "121",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Further Refine Observation With During MP\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "120",
+                    "s": [
+                      {
+                        "s": [
+                          {
+                            "r": "113",
+                            "s": [
+                              {
+                                "r": "112",
+                                "s": [
+                                  {
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "\"Observation Status and Value\""
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "O"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "\n    "
+                        ]
+                      },
+                      {
+                        "r": "119",
+                        "s": [
+                          {
+                            "value": [
+                              "where "
+                            ]
+                          },
+                          {
+                            "r": "119",
+                            "s": [
+                              {
+                                "r": "117",
+                                "s": [
+                                  {
+                                    "r": "114",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "Global"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "."
+                                    ]
+                                  },
+                                  {
+                                    "r": "117",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "\"Normalize Interval\"",
+                                          "("
+                                        ]
+                                      },
+                                      {
+                                        "r": "116",
+                                        "s": [
+                                          {
+                                            "r": "115",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "O"
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              "."
+                                            ]
+                                          },
+                                          {
+                                            "r": "116",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "effective"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          ")"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "r": "119",
+                                "value": [
+                                  " ",
+                                  "during",
+                                  " "
+                                ]
+                              },
+                              {
+                                "r": "118",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "\"Measurement Period\""
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "120",
+            "locator": "57:3-58:78",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "113",
+                "locator": "57:3-57:34",
+                "alias": "O",
+                "expression": {
+                  "localId": "112",
+                  "locator": "57:3-57:32",
+                  "name": "Observation Status and Value",
+                  "type": "ExpressionRef"
+                }
+              }
+            ],
+            "relationship": [],
+            "where": {
+              "localId": "119",
+              "locator": "58:5-58:78",
+              "type": "IncludedIn",
+              "operand": [
+                {
+                  "localId": "117",
+                  "locator": "58:11-58:50",
+                  "name": "Normalize Interval",
+                  "libraryName": "Global",
+                  "type": "FunctionRef",
+                  "operand": [
+                    {
+                      "localId": "116",
+                      "locator": "58:39-58:49",
+                      "path": "effective",
+                      "scope": "O",
+                      "type": "Property"
+                    }
+                  ]
+                },
+                {
+                  "localId": "118",
+                  "locator": "58:59-58:78",
+                  "name": "Measurement Period",
+                  "type": "ParameterRef"
                 }
               ]
             }

--- a/test/fixtures/elm/queries/SimpleQueries.cql
+++ b/test/fixtures/elm/queries/SimpleQueries.cql
@@ -43,3 +43,7 @@ define "Further Filtering Query":
 define "Retrieve Query":
   [Procedure: "test-vs"] P
     where P.status = 'completed'
+
+define "Retrieve Using ValueSet In Dependency":
+  [Procedure: SimpleDep."test-vs-2"] P
+    where P.status = 'completed'

--- a/test/fixtures/elm/queries/SimpleQueries.cql
+++ b/test/fixtures/elm/queries/SimpleQueries.cql
@@ -33,3 +33,13 @@ define "DepExpressionRef":
 define "SimpleConceptRetrieve":
   [Procedure: "test-concept"]
 
+define "Use Further Filtering":
+  exists "Further Filtering Query"
+
+define "Further Filtering Query":
+  "Retrieve Query" P
+    where P.outcome is not null
+
+define "Retrieve Query":
+  [Procedure: "test-vs"] P
+    where P.status = 'completed'

--- a/test/fixtures/elm/queries/SimpleQueries.json
+++ b/test/fixtures/elm/queries/SimpleQueries.json
@@ -4,6 +4,20 @@
       {
         "translatorOptions": "EnableAnnotations,EnableLocators",
         "type": "CqlToElmInfo"
+      },
+      {
+        "type": "Annotation",
+        "s": {
+          "r": "40",
+          "s": [
+            {
+              "value": [
+                "",
+                "library SimpleQueries version '0.0.1'"
+              ]
+            }
+          ]
+        }
       }
     ],
     "identifier": {
@@ -25,7 +39,38 @@
           "locator": "3:1-3:26",
           "localIdentifier": "FHIR",
           "uri": "http://hl7.org/fhir",
-          "version": "4.0.1"
+          "version": "4.0.1",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "1",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "using "
+                    ]
+                  },
+                  {
+                    "s": [
+                      {
+                        "value": [
+                          "FHIR"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " version ",
+                      "'4.0.1'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
         }
       ]
     },
@@ -36,14 +81,76 @@
           "locator": "5:1-5:35",
           "localIdentifier": "FHIRHelpers",
           "path": "FHIRHelpers",
-          "version": "4.0.1"
+          "version": "4.0.1",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "2",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "include "
+                    ]
+                  },
+                  {
+                    "s": [
+                      {
+                        "value": [
+                          "FHIRHelpers"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " version ",
+                      "'4.0.1'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
         },
         {
           "localId": "3",
           "locator": "6:1-6:33",
           "localIdentifier": "SimpleDep",
           "path": "SimpleDep",
-          "version": "0.0.1"
+          "version": "0.0.1",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "3",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "include "
+                    ]
+                  },
+                  {
+                    "s": [
+                      {
+                        "value": [
+                          "SimpleDep"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " version ",
+                      "'0.0.1'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
         }
       ]
     },
@@ -54,14 +161,52 @@
           "locator": "8:1-8:42",
           "name": "EXAMPLE",
           "id": "http://example.com",
-          "accessLevel": "Public"
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "4",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "codesystem ",
+                      "\"EXAMPLE\"",
+                      ": ",
+                      "'http://example.com'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
         },
         {
           "localId": "5",
           "locator": "9:1-9:46",
           "name": "EXAMPLE-2",
           "id": "http://example.com/2",
-          "accessLevel": "Public"
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "5",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "codesystem ",
+                      "\"EXAMPLE-2\"",
+                      ": ",
+                      "'http://example.com/2'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
         }
       ]
     },
@@ -72,7 +217,26 @@
           "locator": "11:1-11:48",
           "name": "test-vs",
           "id": "http://example.com/test-vs",
-          "accessLevel": "Public"
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "6",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "valueset ",
+                      "\"test-vs\"",
+                      ": ",
+                      "'http://example.com/test-vs'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
         }
       ]
     },
@@ -84,6 +248,36 @@
           "name": "test-code",
           "id": "test",
           "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "8",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "code ",
+                      "\"test-code\"",
+                      ": ",
+                      "'test'",
+                      " from "
+                    ]
+                  },
+                  {
+                    "r": "7",
+                    "s": [
+                      {
+                        "value": [
+                          "\"EXAMPLE\""
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
           "codeSystem": {
             "localId": "7",
             "locator": "13:31-13:39",
@@ -96,6 +290,36 @@
           "name": "test-code-2",
           "id": "test-2",
           "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "10",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "code ",
+                      "\"test-code-2\"",
+                      ": ",
+                      "'test-2'",
+                      " from "
+                    ]
+                  },
+                  {
+                    "r": "9",
+                    "s": [
+                      {
+                        "value": [
+                          "\"EXAMPLE-2\""
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
           "codeSystem": {
             "localId": "9",
             "locator": "14:35-14:45",
@@ -112,6 +336,55 @@
           "name": "test-concept",
           "display": "test-concept",
           "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "13",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "concept ",
+                      "\"test-concept\"",
+                      ": { "
+                    ]
+                  },
+                  {
+                    "r": "11",
+                    "s": [
+                      {
+                        "value": [
+                          "\"test-code\""
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      ", "
+                    ]
+                  },
+                  {
+                    "r": "12",
+                    "s": [
+                      {
+                        "value": [
+                          "\"test-code-2\""
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " } display ",
+                      "'test-concept'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
           "code": [
             {
               "localId": "11",
@@ -143,6 +416,7 @@
                 "s": [
                   {
                     "value": [
+                      "",
                       "define ",
                       "\"SimpleVSRetrieve\"",
                       ":\n  "
@@ -184,6 +458,7 @@
             "dataType": "{http://hl7.org/fhir}Condition",
             "templateId": "http://hl7.org/fhir/StructureDefinition/Condition",
             "codeProperty": "code",
+            "codeComparator": "in",
             "type": "Retrieve",
             "codes": {
               "locator": "19:15-19:23",
@@ -206,6 +481,7 @@
                 "s": [
                   {
                     "value": [
+                      "",
                       "define ",
                       "\"SimpleCodeRetrieve\"",
                       ":\n  "
@@ -247,6 +523,7 @@
             "dataType": "{http://hl7.org/fhir}Procedure",
             "templateId": "http://hl7.org/fhir/StructureDefinition/Procedure",
             "codeProperty": "code",
+            "codeComparator": "~",
             "type": "Retrieve",
             "codes": {
               "type": "ToList",
@@ -272,6 +549,7 @@
                 "s": [
                   {
                     "value": [
+                      "",
                       "define ",
                       "\"SimpleQuery\"",
                       ":\n  "
@@ -414,6 +692,7 @@
                   "dataType": "{http://hl7.org/fhir}Condition",
                   "templateId": "http://hl7.org/fhir/StructureDefinition/Condition",
                   "codeProperty": "code",
+                  "codeComparator": "in",
                   "type": "Retrieve",
                   "codes": {
                     "locator": "25:15-25:23",
@@ -423,8 +702,7 @@
                 }
               }
             ],
-            "relationship": [
-            ],
+            "relationship": [],
             "where": {
               "localId": "23",
               "locator": "25:28-25:46",
@@ -469,6 +747,7 @@
                 "s": [
                   {
                     "value": [
+                      "",
                       "define ",
                       "\"SimpleExpressionRef\"",
                       ":\n  "
@@ -509,6 +788,7 @@
                 "s": [
                   {
                     "value": [
+                      "",
                       "define ",
                       "\"DepExpressionRef\"",
                       ":\n  "
@@ -570,6 +850,7 @@
                 "s": [
                   {
                     "value": [
+                      "",
                       "define ",
                       "\"SimpleConceptRetrieve\"",
                       ":\n  "
@@ -611,6 +892,7 @@
             "dataType": "{http://hl7.org/fhir}Procedure",
             "templateId": "http://hl7.org/fhir/StructureDefinition/Procedure",
             "codeProperty": "code",
+            "codeComparator": "~",
             "type": "Retrieve",
             "codes": {
               "path": "codes",
@@ -620,6 +902,409 @@
                 "name": "test-concept",
                 "type": "ConceptRef"
               }
+            }
+          }
+        },
+        {
+          "localId": "40",
+          "locator": "43:1-45:32",
+          "name": "Retrieve Query",
+          "context": "Unfiltered",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "40",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Retrieve Query\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "39",
+                    "s": [
+                      {
+                        "s": [
+                          {
+                            "r": "34",
+                            "s": [
+                              {
+                                "r": "33",
+                                "s": [
+                                  {
+                                    "r": "33",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "[",
+                                          "Procedure",
+                                          ": "
+                                        ]
+                                      },
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"test-vs\""
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "]"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "P"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "\n    "
+                        ]
+                      },
+                      {
+                        "r": "38",
+                        "s": [
+                          {
+                            "value": [
+                              "where "
+                            ]
+                          },
+                          {
+                            "r": "38",
+                            "s": [
+                              {
+                                "r": "36",
+                                "s": [
+                                  {
+                                    "r": "35",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "P"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "."
+                                    ]
+                                  },
+                                  {
+                                    "r": "36",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "status"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "=",
+                                  " "
+                                ]
+                              },
+                              {
+                                "r": "37",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "'completed'"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "39",
+            "locator": "44:3-45:32",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "34",
+                "locator": "44:3-44:26",
+                "alias": "P",
+                "expression": {
+                  "localId": "33",
+                  "locator": "44:3-44:24",
+                  "dataType": "{http://hl7.org/fhir}Procedure",
+                  "templateId": "http://hl7.org/fhir/StructureDefinition/Procedure",
+                  "codeProperty": "code",
+                  "codeComparator": "in",
+                  "type": "Retrieve",
+                  "codes": {
+                    "locator": "44:15-44:23",
+                    "name": "test-vs",
+                    "type": "ValueSetRef"
+                  }
+                }
+              }
+            ],
+            "relationship": [],
+            "where": {
+              "localId": "38",
+              "locator": "45:5-45:32",
+              "type": "Equal",
+              "operand": [
+                {
+                  "name": "ToString",
+                  "libraryName": "FHIRHelpers",
+                  "type": "FunctionRef",
+                  "operand": [
+                    {
+                      "localId": "36",
+                      "locator": "45:11-45:18",
+                      "path": "status",
+                      "scope": "P",
+                      "type": "Property"
+                    }
+                  ]
+                },
+                {
+                  "localId": "37",
+                  "locator": "45:22-45:32",
+                  "valueType": "{urn:hl7-org:elm-types:r1}String",
+                  "value": "completed",
+                  "type": "Literal"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "localId": "47",
+          "locator": "39:1-41:31",
+          "name": "Further Filtering Query",
+          "context": "Unfiltered",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "47",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Further Filtering Query\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "46",
+                    "s": [
+                      {
+                        "s": [
+                          {
+                            "r": "42",
+                            "s": [
+                              {
+                                "r": "41",
+                                "s": [
+                                  {
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "\"Retrieve Query\""
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "P"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "\n    "
+                        ]
+                      },
+                      {
+                        "r": "45",
+                        "s": [
+                          {
+                            "value": [
+                              "where "
+                            ]
+                          },
+                          {
+                            "r": "45",
+                            "s": [
+                              {
+                                "r": "44",
+                                "s": [
+                                  {
+                                    "r": "43",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "P"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "."
+                                    ]
+                                  },
+                                  {
+                                    "r": "44",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "outcome"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " is not null"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "46",
+            "locator": "40:3-41:31",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "42",
+                "locator": "40:3-40:20",
+                "alias": "P",
+                "expression": {
+                  "localId": "41",
+                  "locator": "40:3-40:18",
+                  "name": "Retrieve Query",
+                  "type": "ExpressionRef"
+                }
+              }
+            ],
+            "relationship": [],
+            "where": {
+              "localId": "45",
+              "locator": "41:5-41:31",
+              "type": "Not",
+              "operand": {
+                "locator": "41:11-41:31",
+                "type": "IsNull",
+                "operand": {
+                  "localId": "44",
+                  "locator": "41:11-41:19",
+                  "path": "outcome",
+                  "scope": "P",
+                  "type": "Property"
+                }
+              }
+            }
+          }
+        },
+        {
+          "localId": "50",
+          "locator": "36:1-37:34",
+          "name": "Use Further Filtering",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "50",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Use Further Filtering\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "49",
+                    "s": [
+                      {
+                        "value": [
+                          "exists "
+                        ]
+                      },
+                      {
+                        "r": "48",
+                        "s": [
+                          {
+                            "value": [
+                              "\"Further Filtering Query\""
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "49",
+            "locator": "37:3-37:34",
+            "type": "Exists",
+            "operand": {
+              "localId": "48",
+              "locator": "37:10-37:34",
+              "name": "Further Filtering Query",
+              "type": "ExpressionRef"
             }
           }
         }

--- a/test/queryFilters/interpretFunctionRef.test.ts
+++ b/test/queryFilters/interpretFunctionRef.test.ts
@@ -1,5 +1,8 @@
 import * as QueryFilter from '../../src/QueryFilterHelpers';
 import { ELMFunctionRef } from '../../src/types/ELMTypes';
+import { getELMFixture } from '../helpers/testHelpers';
+
+const extraQueriesELM = getELMFixture('elm/queries/ExtraQueries.json');
 
 /** From ExtraQueries.cql "FunctionRef In Same library": */
 const FUNCTIONREF_IN_SAME_LIBRARY: ELMFunctionRef = {
@@ -60,13 +63,13 @@ const FUNCTIONREF_WITH_PARAM_COMPLEXITY: ELMFunctionRef = {
 
 describe('interpretFunctionRef', () => {
   test('FunctionRef in same library not supported', () => {
-    const functionRefRes = QueryFilter.interpretFunctionRef(FUNCTIONREF_IN_SAME_LIBRARY);
+    const functionRefRes = QueryFilter.interpretFunctionRef(FUNCTIONREF_IN_SAME_LIBRARY, extraQueriesELM);
     expect(functionRefRes).toBeUndefined();
   });
 
   /** This is more complicated than originally expected and needs some further work to handle this unexpected scenario. */
   test.skip('FunctionRef with complexity in param of known function not supported', () => {
-    const functionRefRes = QueryFilter.interpretFunctionRef(FUNCTIONREF_WITH_PARAM_COMPLEXITY);
+    const functionRefRes = QueryFilter.interpretFunctionRef(FUNCTIONREF_WITH_PARAM_COMPLEXITY, extraQueriesELM);
     expect(functionRefRes).toBeUndefined();
   });
 });

--- a/test/queryFilters/parseQueryInfo.test.ts
+++ b/test/queryFilters/parseQueryInfo.test.ts
@@ -251,6 +251,53 @@ const EXPECTED_COMPLEX_QUERY_REF_QUERY: QueryInfo = {
   }
 };
 
+const EXPECTED_COMPLEX_QUERY_REF_QUERY_ANDS_IN_BOTH: QueryInfo = {
+  localId: '134',
+  sources: [
+    {
+      retrieveLocalId: '96',
+      sourceLocalId: '97',
+      alias: 'Obs',
+      resourceType: 'Observation'
+    }
+  ],
+  filter: {
+    type: 'and',
+    notes: 'Combination of multiple queries',
+    children: [
+      {
+        type: 'in',
+        alias: 'Obs',
+        attribute: 'status',
+        valueList: ['final', 'amended', 'corrected', 'preliminary'],
+        localId: '105'
+      },
+      {
+        type: 'notnull',
+        alias: 'Obs',
+        attribute: 'value',
+        localId: '108'
+      },
+      {
+        type: 'during',
+        alias: 'Obs',
+        attribute: 'effective',
+        valuePeriod: {
+          start: '2019-01-01T00:00:00.000Z',
+          end: '2019-12-31T23:59:59.999Z'
+        },
+        localId: '129'
+      },
+      {
+        type: 'notnull',
+        alias: 'Obs',
+        attribute: 'bodySite',
+        localId: '132'
+      }
+    ]
+  }
+};
+
 const PATIENT: R4.IPatient = {
   resourceType: 'Patient',
   birthDate: '1988-09-08'
@@ -341,5 +388,11 @@ describe('Parse Query Info', () => {
     const queryLocalId = complexQueryELM.library.statements.def[6].expression.localId; // query that references another query
     const queryInfo = parseQueryInfo(complexQueryELM, queryLocalId, PARAMETERS, PATIENT);
     expect(queryInfo).toEqual(EXPECTED_COMPLEX_QUERY_REF_QUERY);
+  });
+
+  test('complex - query references query, combines filters with ands in both filters and differing alias names', () => {
+    const queryLocalId = complexQueryELM.library.statements.def[7].expression.localId; // query that references another query
+    const queryInfo = parseQueryInfo(complexQueryELM, queryLocalId, PARAMETERS, PATIENT);
+    expect(queryInfo).toEqual(EXPECTED_COMPLEX_QUERY_REF_QUERY_ANDS_IN_BOTH);
   });
 });

--- a/test/queryFilters/parseQueryInfo.test.ts
+++ b/test/queryFilters/parseQueryInfo.test.ts
@@ -179,6 +179,78 @@ const EXPECTED_CODE_OR_STARTS_DURING_MP_OR_NOT_NULL: QueryInfo = {
   }
 };
 
+const EXPECTED_QUERY_REFERENCES_QUERY: QueryInfo = {
+  localId: '46',
+  sources: [
+    {
+      retrieveLocalId: '33',
+      sourceLocalId: '34',
+      alias: 'P',
+      resourceType: 'Procedure'
+    }
+  ],
+  filter: {
+    type: 'and',
+    notes: 'Combination of multiple queries',
+    children: [
+      {
+        type: 'equals',
+        alias: 'P',
+        attribute: 'status',
+        value: 'completed',
+        localId: '38'
+      },
+      {
+        type: 'notnull',
+        alias: 'P',
+        attribute: 'outcome',
+        localId: '45'
+      }
+    ]
+  }
+};
+
+const EXPECTED_COMPLEX_QUERY_REF_QUERY: QueryInfo = {
+  localId: '120',
+  sources: [
+    {
+      retrieveLocalId: '96',
+      sourceLocalId: '97',
+      alias: 'Obs',
+      resourceType: 'Observation'
+    }
+  ],
+  filter: {
+    type: 'and',
+    notes: 'Combination of multiple queries',
+    children: [
+      {
+        type: 'in',
+        alias: 'Obs',
+        attribute: 'status',
+        valueList: ['final', 'amended', 'corrected', 'preliminary'],
+        localId: '105'
+      },
+      {
+        type: 'notnull',
+        alias: 'Obs',
+        attribute: 'value',
+        localId: '108'
+      },
+      {
+        type: 'during',
+        alias: 'Obs',
+        attribute: 'effective',
+        valuePeriod: {
+          start: '2019-01-01T00:00:00.000Z',
+          end: '2019-12-31T23:59:59.999Z'
+        },
+        localId: '119'
+      }
+    ]
+  }
+};
+
 const PATIENT: R4.IPatient = {
   resourceType: 'Patient',
   birthDate: '1988-09-08'
@@ -257,5 +329,17 @@ describe('Parse Query Info', () => {
     expect(() => {
       parseQueryInfo(simpleQueryELM, '360', PARAMETERS, PATIENT);
     }).toThrow('Clause 360 in SimpleQueries was not a Query or not found.');
+  });
+
+  test('simple - query references query, combines filters', () => {
+    const queryLocalId = simpleQueryELM.library.statements.def[7].expression.localId; // query that references another query
+    const queryInfo = parseQueryInfo(simpleQueryELM, queryLocalId, undefined, PATIENT);
+    expect(queryInfo).toEqual(EXPECTED_QUERY_REFERENCES_QUERY);
+  });
+
+  test('complex - query references query, combines filters', () => {
+    const queryLocalId = complexQueryELM.library.statements.def[6].expression.localId; // query that references another query
+    const queryInfo = parseQueryInfo(complexQueryELM, queryLocalId, PARAMETERS, PATIENT);
+    expect(queryInfo).toEqual(EXPECTED_COMPLEX_QUERY_REF_QUERY);
   });
 });


### PR DESCRIPTION
# Summary
Fixes required to get CCS (aka. CMS130 - Colorectal Cancer Screening) to function.

## New behavior

- Identifies when a query uses a reference to another query as the source. This allows for the filtering that both queries do to be combined when parsing for 'filters' so a complete gaps output can be made.
- Improved detection of queries that are 'or'ed together in a place other than the Numerator definition. Basically allowing for another level of indirection to get to grouped queries.

## Code changes

- Updated cql-execution to 2.3.1. This brings support for version-less library references.
- Moved helper functions for finding a clause in a library by localId to a shared helper file.
- findRetrieves now identifies the 'outer' query in the query referencing query situations as the query to start from when parsing.
- QueryFilters parsing will recognize the query referencing query situation and combine the parsed filters together in an `and` filter.

# Testing guidance
Test gaps output with https://github.com/cqframework/cqf-ccc/blob/master/bundles/measure/ColorectalCancerScreeningCQM/ColorectalCancerScreeningCQM-bundle.json. The patients in c-thon repository for EXM130 work but need minor patching to work due to changes in the ValueSets.
 - https://github.com/DBCG/connectathon/blob/master/fhir401/bundles/measure/EXM130-7.3.000/EXM130-7.3.000-files/tests-denom-EXM130-bundle.json
 - https://github.com/DBCG/connectathon/blob/master/fhir401/bundles/measure/EXM130-7.3.000/EXM130-7.3.000-files/tests-numer-EXM130-bundle.json
 - The Procedure codes for colonoscopy need to be changed from 44393 to 44394.