### PR TITLE
Created interfaces for Calculator function return types

### DIFF
--- a/src/Calculator.ts
+++ b/src/Calculator.ts
@@ -37,9 +37,9 @@ import { generateDataRequirement } from './helpers/DataRequirementHelpers';
 export async function calculate(
   measureBundle: R4.IBundle,
   patientBundles: R4.IBundle[],
-  options: CalculationOptions
+  options: CalculationOptions,
+  valueSetCache: R4.IValueSet[] = []
 ): Promise<CalculationOutput> {
-
   const debugObject: DebugOutput | undefined = options.enableDebugOutput ? <DebugOutput>{} : undefined;
 
   // Ensure the CalculationOptions have sane defaults, only if they're not set
@@ -196,9 +196,9 @@ export async function calculate(
 export async function calculateMeasureReports(
   measureBundle: R4.IBundle,
   patientBundles: R4.IBundle[],
-  options: CalculationOptions
+  options: CalculationOptions,
+  valueSetCache: R4.IValueSet[] = []
 ): Promise<MRCalculationOutput> {
-
   return options.reportType === 'summary'
     ? calculateAggregateMeasureReport(measureBundle, patientBundles, options, valueSetCache)
     : calculateIndividualMeasureReports(measureBundle, patientBundles, options, valueSetCache);
@@ -216,9 +216,9 @@ export async function calculateMeasureReports(
 export async function calculateIndividualMeasureReports(
   measureBundle: R4.IBundle,
   patientBundles: R4.IBundle[],
-  options: CalculationOptions
+  options: CalculationOptions,
+  valueSetCache: R4.IValueSet[] = []
 ): Promise<IMRCalculationOutput> {
-
   if (options.reportType && options.reportType !== 'individual') {
     throw new Error('calculateMeasureReports only supports reportType "individual".');
   }
@@ -247,9 +247,9 @@ export async function calculateIndividualMeasureReports(
 export async function calculateAggregateMeasureReport(
   measureBundle: R4.IBundle,
   patientBundles: R4.IBundle[],
-  options: CalculationOptions
+  options: CalculationOptions,
+  valueSetCache: R4.IValueSet[] = []
 ): Promise<AMRCalculationOutput> {
-
   if (options.reportType && options.reportType === 'individual') {
     throw new Error('calculateAggregateMeasureReports only supports reportType "summary".');
   }
@@ -301,7 +301,8 @@ export async function calculateAggregateMeasureReport(
 export async function calculateRaw(
   measureBundle: R4.IBundle,
   patientBundles: R4.IBundle[],
-  options: CalculationOptions
+  options: CalculationOptions,
+  valueSetCache: R4.IValueSet[] = []
 ): Promise<RCalculationOutput> {
   const debugObject: DebugOutput | undefined = options.enableDebugOutput ? <DebugOutput>{} : undefined;
   const results = await Execution.execute(measureBundle, patientBundles, options, valueSetCache, debugObject);
@@ -324,9 +325,9 @@ export async function calculateRaw(
 export async function calculateGapsInCare(
   measureBundle: R4.IBundle,
   patientBundles: R4.IBundle[],
-  options: CalculationOptions
+  options: CalculationOptions,
+  valueSetCache: R4.IValueSet[] = []
 ): Promise<GICCalculationOutput> {
-
   // Detailed results for populations get ELM content back
   options.returnELM = true;
 
@@ -482,7 +483,6 @@ export async function calculateGapsInCare(
  */
 
 export function calculateDataRequirements(measureBundle: R4.IBundle): DRCalculationOutput {
-
   // Extract the library ELM, and the id of the root library, from the measure bundle
   const { cqls, rootLibIdentifier, elmJSONs } = MeasureHelpers.extractLibrariesFromBundle(measureBundle);
   const rootLib = elmJSONs.find(ej => ej.library.identifier == rootLibIdentifier);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,7 +12,7 @@ import {
   calculateDataRequirements
 } from './Calculator';
 import { clearDebugFolder, dumpCQLs, dumpELMJSONs, dumpHTMLs, dumpObject, dumpVSMap } from './DebugHelper';
-import { CalculationOptions } from './types/Calculator';
+import { CalculationOptions, CalculatorFunctionOutput } from './types/Calculator';
 
 program
   .option('-d, --debug', 'enable debug output', false)
@@ -53,7 +53,7 @@ async function calc(
   measureBundle: R4.IBundle,
   patientBundles: R4.IBundle[],
   calcOptions: CalculationOptions
-): Promise<any> {
+): Promise<CalculatorFunctionOutput | undefined> {
   let result;
   if (program.outputType === 'raw') {
     result = await calculateRaw(measureBundle, patientBundles, calcOptions);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -79,7 +79,7 @@ async function calc(
     result = calculateDataRequirements(measureBundle);
   }
   if (!result) {
-    throw new Error('Result is not defined');
+    throw new Error(`Could not obtain result based on outputType ${program.outputType}`);
   }
   return result;
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -61,9 +61,9 @@ function getCachedValueSets(cacheDir: string): R4.IValueSet[] {
 async function calc(
   measureBundle: R4.IBundle,
   patientBundles: R4.IBundle[],
-  calcOptions: CalculationOptions
-): Promise<CalculatorFunctionOutput | undefined> {
-
+  calcOptions: CalculationOptions,
+  valueSetCache: R4.IValueSet[] = []
+): Promise<CalculatorFunctionOutput> {
   let result;
   if (program.outputType === 'raw') {
     result = await calculateRaw(measureBundle, patientBundles, calcOptions, valueSetCache);
@@ -77,6 +77,9 @@ async function calc(
   } else if (program.outputType === 'dataRequirements') {
     // CalculateDataRequirements doesn't make use of the calcOptions object at this point
     result = calculateDataRequirements(measureBundle);
+  }
+  if (!result) {
+    throw new Error('Result is not defined');
   }
   return result;
 }

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -264,3 +264,70 @@ export interface DebugOutput {
     bundle?: R4.IBundle;
   };
 }
+
+/*
+ * Parent dataType for output of calculate functions
+ */
+export interface CalculatorFunctionOutput {
+  results:
+    | ExecutionResult[]
+    | R4.IMeasureReport
+    | R4.IMeasureReport[]
+    | cql.Results
+    | string
+    | R4.IBundle
+    | R4.ILibrary;
+  debugOutput?: DebugOutput;
+}
+
+/**
+ * dataType for calculate() function
+ */
+export interface CalculationOutput extends CalculatorFunctionOutput {
+  results: ExecutionResult[];
+  elmLibraries?: ELM[];
+  mainLibraryName?: string;
+  parameters?: { [key: string]: any };
+}
+
+/**
+ * dataType for calculateMeasureReports() function
+ */
+export interface MRCalculationOutput extends CalculatorFunctionOutput {
+  results: R4.IMeasureReport | R4.IMeasureReport[];
+}
+
+/**
+ * dataType for calculateAggregateMeasureReports() function
+ */
+export interface AMRCalculationOutput extends MRCalculationOutput {
+  results: R4.IMeasureReport;
+}
+
+/**
+ * dataType for calculateIndividualMeasureReports() function
+ */
+export interface IMRCalculationOutput extends MRCalculationOutput {
+  results: R4.IMeasureReport[];
+}
+
+/**
+ * dataType for calculateRaw() function
+ */
+export interface RCalculationOutput extends CalculatorFunctionOutput {
+  results: cql.Results | string;
+}
+
+/**
+ * dataType for calculateGapsInCare() function
+ */
+export interface GICCalculationOutput extends CalculatorFunctionOutput {
+  results: R4.IBundle;
+}
+
+/**
+ * dataType for calculateDataRequirements() function
+ */
+export interface DRCalculationOutput extends CalculatorFunctionOutput {
+  results: R4.ILibrary;
+}

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -278,6 +278,7 @@ export interface CalculatorFunctionOutput {
     | R4.IBundle
     | R4.ILibrary;
   debugOutput?: DebugOutput;
+  valueSetCache?: R4.IValueSet[];
 }
 
 /**
@@ -328,6 +329,6 @@ export interface GICCalculationOutput extends CalculatorFunctionOutput {
 /**
  * dataType for calculateDataRequirements() function
  */
-export interface DRCalculationOutput extends CalculatorFunctionOutput {
+export interface DRCalculationOutput extends Omit<CalculatorFunctionOutput, 'valueSetCache'> {
   results: R4.ILibrary;
 }


### PR DESCRIPTION
# Summary
Add interfaces to the Calculator function return types so that we have stricter typing across the entire application.
 
## New behavior
Behavior should remain unchanged, but the application will have stricter typing due to these changes for the Calculator functions.

## Code changes
- New interfaces added to `src/types/Calculator.ts`, including a parent interface `CalculatorFunctionOutput` for the 'results' and 'debugOutput`. 
- The interfaces `MRCalculationOutput`, `RCalculationOutput`, `GICCalculationOutput`, and `DRCalculationOutput` extend from the parent interface.
- The interfaces `AMRCalculationOutput` and `IMRCalculationOutput` extend from `MRCalculationOutput`, as they pertain to measure reports.
- Function outputs were adjusted in `src/cli.ts` from `any` type to stricter typing.

# Testing guidance
Functionality should be unchanged. Run standard tests and look over for typescript errors. Review that the interface names make sense (are they too long? confusing? not allowed to have acronyms?)
