### PR TITLE
Nested query in library

### DIFF
--- a/src/Calculator.ts
+++ b/src/Calculator.ts
@@ -376,7 +376,6 @@ export async function calculateGapsInCare(
       // If positive improvement measure, consider patients in denominator but not numerator for gaps
       // If negative improvement measure, consider patients in numerator for gaps
       // For either case, ignore patient if numerator isn't relevant
-
       const populationCriteria =
         numerRelevance &&
         (improvementNotation === ImprovementNotation.POSITIVE ? denomResult && !numerResult : numerResult);
@@ -435,8 +434,8 @@ export async function calculateGapsInCare(
         detailedGapsRetrieves.forEach(retrieve => {
           // If the retrieves have a localId for the query and a known library name, we can get more info
           // on how the query filters the sources.
-          if (retrieve.queryLocalId && retrieve.libraryName) {
-            const library = elmLibraries.find(lib => lib.library.identifier.id === retrieve.libraryName);
+          if (retrieve.queryLocalId && retrieve.queryLibraryName) {
+            const library = elmLibraries.find(lib => lib.library.identifier.id === retrieve.queryLibraryName);
             if (library) {
               retrieve.queryInfo = parseQueryInfo(
                 library,

--- a/src/Calculator.ts
+++ b/src/Calculator.ts
@@ -439,6 +439,7 @@ export async function calculateGapsInCare(
             if (library) {
               retrieve.queryInfo = parseQueryInfo(
                 library,
+                elmLibraries,
                 retrieve.queryLocalId,
                 parameters,
                 patientEntry.resource as R4.IPatient

--- a/src/GapsInCareHelpers.ts
+++ b/src/GapsInCareHelpers.ts
@@ -30,7 +30,7 @@ export function processQueriesForGaps(
   return queries.map(q => {
     // Determine satisfaction of parent query and leaf node retrieve
     const parentQueryResult = detailedResult.clauseResults?.find(
-      cr => cr.libraryName === q.retrieveLibraryName && cr.localId === q.queryLocalId
+      cr => cr.libraryName === q.queryLibraryName && cr.localId === q.queryLocalId
     );
 
     const retrieveResult = detailedResult.clauseResults?.find(

--- a/src/GapsInCareHelpers.ts
+++ b/src/GapsInCareHelpers.ts
@@ -431,10 +431,8 @@ export function calculateReasonDetail(
                       path: duringFilter.attribute,
                       reference: `${resource._json.resourceType}/${resource.id.value}`
                     });
-
                   }
                 }
-
               } else if (f.type === 'notnull') {
                 const notNullFilter = f as NotNullFilter;
                 const attrPath = notNullFilter.attribute.split('.');
@@ -460,7 +458,7 @@ export function calculateReasonDetail(
                 // For non-during filters, look up clause result by localId
                 // Ideally we can look to modify cql-execution to help us with this flaw
                 const clauseResult = detailedResult.clauseResults?.find(
-                  cr => cr.libraryName === r.libraryName && cr.localId === f.localId
+                  cr => cr.libraryName === r.retrieveLibraryName && cr.localId === f.localId
                 );
 
                 // False clause means this specific filter was falsy

--- a/src/GapsInCareHelpers.ts
+++ b/src/GapsInCareHelpers.ts
@@ -30,11 +30,11 @@ export function processQueriesForGaps(
   return queries.map(q => {
     // Determine satisfaction of parent query and leaf node retrieve
     const parentQueryResult = detailedResult.clauseResults?.find(
-      cr => cr.libraryName === q.libraryName && cr.localId === q.queryLocalId
+      cr => cr.libraryName === q.retrieveLibraryName && cr.localId === q.queryLocalId
     );
 
     const retrieveResult = detailedResult.clauseResults?.find(
-      cr => cr.libraryName === q.libraryName && cr.localId === q.retrieveLocalId
+      cr => cr.libraryName === q.retrieveLibraryName && cr.localId === q.retrieveLocalId
     );
 
     const parentQueryHasResult = parentQueryResult?.final === FinalResult.TRUE;
@@ -348,7 +348,7 @@ export function calculateReasonDetail(
           if (f.type === 'during') {
             const duringFilter = f as DuringFilter;
             const resources = detailedResult.clauseResults?.find(
-              cr => cr.libraryName === r.libraryName && cr.localId === r.retrieveLocalId
+              cr => cr.libraryName === r.retrieveLibraryName && cr.localId === r.retrieveLocalId
             );
 
             if (duringFilter.valuePeriod.interval && resources) {
@@ -377,7 +377,7 @@ export function calculateReasonDetail(
           } else if (f.type === 'notnull') {
             const notNullFilter = f as NotNullFilter;
             const resources = detailedResult.clauseResults?.find(
-              cr => cr.libraryName === r.libraryName && cr.localId === r.retrieveLocalId
+              cr => cr.libraryName === r.retrieveLibraryName && cr.localId === r.retrieveLocalId
             );
             const attrPath = notNullFilter.attribute.split('.');
             if (resources) {
@@ -399,7 +399,7 @@ export function calculateReasonDetail(
             // For non-during filters, look up clause result by localId
             // Ideally we can look to modify cql-execution to help us with this flaw
             const clauseResult = detailedResult.clauseResults?.find(
-              cr => cr.libraryName === r.libraryName && cr.localId === f.localId
+              cr => cr.libraryName === r.retrieveLibraryName && cr.localId === f.localId
             );
 
             // False clause means this specific filter was falsy

--- a/src/QueryFilterHelpers.ts
+++ b/src/QueryFilterHelpers.ts
@@ -145,7 +145,6 @@ export function parseQueryInfo(
         );
       }
     }
-
     return queryInfo;
   } else {
     throw new Error(`Clause ${queryLocalId} in ${library.library.identifier.id} was not a Query or not found.`);
@@ -218,7 +217,8 @@ export function interpretExpression(
   patient: R4.IPatient
 ): AnyFilter {
   let returnFilter: AnyFilter = {
-    type: ''
+    type: 'unknown',
+    localId: expression.localId
   };
   switch (expression.type) {
     case 'Equal':
@@ -252,19 +252,14 @@ export function interpretExpression(
       const propUsage = findPropertyUsage(expression, expression.localId);
 
       if (propUsage) {
-        return propUsage;
+        returnFilter = propUsage;
       }
-      return {
-        type: 'unknown',
-        localId: expression.localId
-      };
   }
   // If we cannot make sense of this expression or find a parameter usage in it, then we should return
   // an UnknownFilter to denote something is done here that we could not interpret.
 
-  if (expression.type !== 'And' && expression.type !== 'Or') {
-    returnFilter.libraryName = library.library.identifier.id;
-  }
+  returnFilter.libraryName = library.library.identifier.id;
+
   return returnFilter;
 }
 

--- a/src/QueryFilterHelpers.ts
+++ b/src/QueryFilterHelpers.ts
@@ -45,13 +45,13 @@ import {
 } from './types/QueryFilterTypes';
 import { findLibraryReference, findLibraryReferenceId } from './ELMDependencyHelper';
 import { findClauseInLibrary } from './helpers/ELMHelpers';
-import exp from 'constants';
 
 /**
  * Parse information about a query. This pulls out information about all sources in the query and attempts to parse
  * how the query is filtered.
  *
  * @param library The library ELM the query resides in.
+ * @param allELM An array of all the ELM libraries accessible to fqm-execution (includes library from library param)
  * @param queryLocalId The localId for the query we want to get information on.
  * @param parameters The parameters used for calculation so they could be reused for re-calculating small bits for CQL.
  *                    "Measurement Period" is the only supported parameter at the moment as it is the only parameter

--- a/src/QueryFilterHelpers.ts
+++ b/src/QueryFilterHelpers.ts
@@ -220,7 +220,6 @@ export function interpretExpression(
   let returnFilter: AnyFilter = {
     type: ''
   };
-  let errorOcurred = false;
   switch (expression.type) {
     case 'Equal':
       returnFilter = interpretEqual(expression as ELMEqual, library);
@@ -255,16 +254,14 @@ export function interpretExpression(
       if (propUsage) {
         return propUsage;
       }
-      errorOcurred = true;
+      return {
+        type: 'unknown',
+        localId: expression.localId
+      };
   }
   // If we cannot make sense of this expression or find a parameter usage in it, then we should return
   // an UnknownFilter to denote something is done here that we could not interpret.
-  if (errorOcurred) {
-    return {
-      type: 'unknown',
-      localId: expression.localId
-    };
-  }
+
   if (expression.type !== 'And' && expression.type !== 'Or') {
     returnFilter.libraryName = library.library.identifier.id;
   }

--- a/src/QueryFilterHelpers.ts
+++ b/src/QueryFilterHelpers.ts
@@ -86,6 +86,14 @@ export function parseQueryInfo(
     if (query.source[0].expression.type === 'ExpressionRef') {
       const exprRef = query.source[0].expression as ELMExpressionRef;
       const statement = library.library.statements.def.find(s => s.name === exprRef.name);
+      /**
+       * Add support for library search in another library if necessary
+       * steps:
+       *  Determine if query.source[0] references a different library
+       *    is this possible or will we need to instead just search all accessible libraries for source??
+       *  Replace library.library with apropriate library
+       *  The rest of this function should be unchnaged??
+       */
       // if we find the statement and it is a query we can move forward.
       if (statement) {
         if (statement.expression.type === 'Query') {

--- a/src/QueryFilterHelpers.ts
+++ b/src/QueryFilterHelpers.ts
@@ -66,7 +66,6 @@ export function parseQueryInfo(
   parameters: { [key: string]: any } = {},
   patient: R4.IPatient
 ): QueryInfo {
-  console.log('reached');
   if (!queryLocalId) {
     throw new Error('QueryLocalId was not provided');
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -182,7 +182,7 @@ calc(
       });
     }
 
-    //console.log(JSON.stringify(result?.results, null, 2));
+    console.log(JSON.stringify(result?.results, null, 2));
   })
   .catch(error => {
     console.error(error.message);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -182,7 +182,7 @@ calc(
       });
     }
 
-    console.log(JSON.stringify(result?.results, null, 2));
+    //console.log(JSON.stringify(result?.results, null, 2));
   })
   .catch(error => {
     console.error(error.message);

--- a/src/helpers/RetrievesHelper.ts
+++ b/src/helpers/RetrievesHelper.ts
@@ -17,14 +17,14 @@ import { findClauseInLibrary } from './ELMHelpers';
  * Get all data types, and codes/valuesets used in Query ELM expressions
  *
  * @param elm main ELM library with expressions to traverse
- * @param deps list of any dependent ELM libraries included in the main ELM
+ * @param allELM list of any dependent ELM libraries included in the main ELM
  * @param expr expression to find queries under (usually numerator for gaps in care)
  * @param queryLocalId keeps track of latest id of query statements for lookup later
  * @returns query info for each ELM retrieve
  */
 export function findRetrieves(
   elm: ELM,
-  deps: ELM[],
+  allELM: ELM[],
   expr: ELMStatement | AnyELMExpression,
   queryLocalId?: string,
   expressionStack: ExpressionStackEntry[] = []
@@ -46,7 +46,7 @@ export function findRetrieves(
     // If present, strip off HL7 prefix to data type
     const dataType = exprRet.dataType.replace(/^(\{http:\/\/hl7.org\/fhir\})?/, '');
 
-    const queryLibraryName = elm.library.identifier.id;
+    let queryLibraryName = elm.library.identifier.id;
 
     // We need to detect if this query/retrieve is used as the source of another query directly. This is an indication
     // that the retrieve is filtered by two separate queries and we need to actually look at the 'outermost' query closest
@@ -66,13 +66,18 @@ export function findRetrieves(
          * seems like here we will need to replace elm with the ELM object of
          * the referenced library when necessary
          */
-        const outerQuery = findClauseInLibrary(elm, bottomExprs[0].localId) as ELMQuery;
+        const queryLib = allELM.find(lib => lib.library.identifier.id === bottomExprs[0].libraryName);
+        if (!queryLib) {
+          throw new Error('Referenced query library cannot be found.');
+        }
+        const outerQuery = findClauseInLibrary(queryLib, bottomExprs[0].localId) as ELMQuery;
         if (
           outerQuery.source[0].expression.localId === bottomExprs[1].localId &&
           outerQuery.source[0].expression.type === 'ExpressionRef'
         ) {
           // Change the queryLocalId to the outer query.
           queryLocalId = bottomExprs[0].localId;
+          queryLibraryName = bottomExprs[0].libraryName;
         } else {
           console.warn(
             'Query is referenced in another query but not as a single source. Gaps output may be incomplete.'
@@ -84,7 +89,7 @@ export function findRetrieves(
     if (exprRet.codes?.type === 'ValueSetRef') {
       const codes = exprRet.codes as ELMValueSetRef;
 
-      const valueSet = findValueSetReference(elm, deps, codes);
+      const valueSet = findValueSetReference(elm, allELM, codes);
 
       if (valueSet) {
         results.push({
@@ -130,21 +135,21 @@ export function findRetrieves(
   } else if (expr.type === 'Query') {
     // Queries have the source array containing the expressions
     (expr as ELMQuery).source?.forEach(s => {
-      results.push(...findRetrieves(elm, deps, s.expression, (expr as ELMQuery).localId, [...expressionStack]));
+      results.push(...findRetrieves(elm, allELM, s.expression, (expr as ELMQuery).localId, [...expressionStack]));
     });
   } else if (expr.type === 'ExpressionRef') {
     // Find expression in dependent library
     if ((expr as ELMExpressionRef).libraryName) {
-      const matchingLib = findLibraryReference(elm, deps, (expr as ELMExpressionRef).libraryName || '');
+      const matchingLib = findLibraryReference(elm, allELM, (expr as ELMExpressionRef).libraryName || '');
       const exprRef = matchingLib?.library.statements.def.find(e => e.name === (expr as ELMExpressionRef).name);
       if (matchingLib && exprRef) {
-        results.push(...findRetrieves(matchingLib, deps, exprRef.expression, queryLocalId, [...expressionStack]));
+        results.push(...findRetrieves(matchingLib, allELM, exprRef.expression, queryLocalId, [...expressionStack]));
       }
     } else {
       // Find expression in current library
       const exprRef = elm.library.statements.def.find(d => d.name === (expr as ELMExpressionRef).name);
       if (exprRef) {
-        results.push(...findRetrieves(elm, deps, exprRef.expression, queryLocalId, [...expressionStack]));
+        results.push(...findRetrieves(elm, allELM, exprRef.expression, queryLocalId, [...expressionStack]));
       }
     }
   } else if ((expr as any).operand) {
@@ -152,10 +157,10 @@ export function findRetrieves(
     const anyExpr = expr as any;
     if (Array.isArray(anyExpr.operand)) {
       anyExpr.operand.forEach((e: any) => {
-        results.push(...findRetrieves(elm, deps, e, queryLocalId, [...expressionStack]));
+        results.push(...findRetrieves(elm, allELM, e, queryLocalId, [...expressionStack]));
       });
     } else {
-      results.push(...findRetrieves(elm, deps, anyExpr.operand, queryLocalId, [...expressionStack]));
+      results.push(...findRetrieves(elm, allELM, anyExpr.operand, queryLocalId, [...expressionStack]));
     }
   }
   return results;

--- a/src/helpers/RetrievesHelper.ts
+++ b/src/helpers/RetrievesHelper.ts
@@ -46,6 +46,8 @@ export function findRetrieves(
     // If present, strip off HL7 prefix to data type
     const dataType = exprRet.dataType.replace(/^(\{http:\/\/hl7.org\/fhir\})?/, '');
 
+    const queryLibraryName = elm.library.identifier.id;
+
     // We need to detect if this query/retrieve is used as the source of another query directly. This is an indication
     // that the retrieve is filtered by two separate queries and we need to actually look at the 'outermost' query closest
     // to the numerator.
@@ -53,12 +55,17 @@ export function findRetrieves(
     if (expressionStack.length >= 4) {
       // Grab the last 4 in the stack and see if they match the case we are looking for
       const bottomExprs = expressionStack.slice(-4);
+
       if (
         bottomExprs[0].type === 'Query' &&
         bottomExprs[1].type === 'ExpressionRef' &&
         bottomExprs[2].type === 'Query'
       ) {
         // check if the outer query is indeed referencing the inner one in the source.
+        /**
+         * seems like here we will need to replace elm with the ELM object of
+         * the referenced library when necessary
+         */
         const outerQuery = findClauseInLibrary(elm, bottomExprs[0].localId) as ELMQuery;
         if (
           outerQuery.source[0].expression.localId === bottomExprs[1].localId &&
@@ -85,7 +92,8 @@ export function findRetrieves(
           valueSet: valueSet.id,
           queryLocalId,
           retrieveLocalId: exprRet.localId,
-          libraryName: elm.library.identifier.id,
+          retrieveLibraryName: elm.library.identifier.id,
+          queryLibraryName,
           expressionStack: [...expressionStack],
           path: exprRet.codeProperty
         });
@@ -112,7 +120,8 @@ export function findRetrieves(
           },
           queryLocalId,
           retrieveLocalId: exprRet.localId,
-          libraryName: elm.library.identifier.id,
+          retrieveLibraryName: elm.library.identifier.id,
+          queryLibraryName,
           expressionStack: [...expressionStack],
           path: exprRet.codeProperty
         });

--- a/src/helpers/RetrievesHelper.ts
+++ b/src/helpers/RetrievesHelper.ts
@@ -62,10 +62,6 @@ export function findRetrieves(
         bottomExprs[2].type === 'Query'
       ) {
         // check if the outer query is indeed referencing the inner one in the source.
-        /**
-         * seems like here we will need to replace elm with the ELM object of
-         * the referenced library when necessary
-         */
         const queryLib = allELM.find(lib => lib.library.identifier.id === bottomExprs[0].libraryName);
         if (!queryLib) {
           throw new Error('Referenced query library cannot be found.');

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -212,7 +212,9 @@ export interface DataTypeQuery {
   /** localId in ELM for the query statement */
   queryLocalId?: string;
   /** name of the library where the statment can be looked up */
-  libraryName?: string;
+  retrieveLibraryName?: string;
+  /** name of library where the outermost query is */
+  queryLibraryName?: string;
   /** stack of expressions traversed during calculation */
   expressionStack?: ExpressionStackEntry[];
   /** path that the code or valueset object refers to */

--- a/src/types/ELMTypes.ts
+++ b/src/types/ELMTypes.ts
@@ -121,6 +121,7 @@ export interface ELMValueSet {
   accessLevel?: string;
   /** Version of the valueset. Should not be used in eCQM land. */
   version?: string;
+  annotation?: Annotation[];
 }
 
 /**

--- a/src/types/QueryFilterTypes.ts
+++ b/src/types/QueryFilterTypes.ts
@@ -21,6 +21,7 @@ export interface QueryInfo {
   localId?: string;
   sources: SourceInfo[];
   filter: AnyFilter;
+  libraryName?: string;
 }
 
 /**
@@ -40,6 +41,7 @@ export interface Filter {
   type: string;
   localId?: string;
   notes?: string;
+  libraryName?: string;
 }
 
 /**

--- a/test/ELMDependencyHelper.test.ts
+++ b/test/ELMDependencyHelper.test.ts
@@ -130,6 +130,9 @@ describe('ELMDependencyHelper', () => {
         accessLevel: 'Public'
       };
       const vs = ELMDependencyHelper.findValueSetReference(elm, [elm, dependency], valueSetRef);
+      if (vs) {
+        vs.annotation = undefined;
+      }
       expect(vs).toEqual(expectedValueSet);
     });
 

--- a/test/ELMDependencyHelper.test.ts
+++ b/test/ELMDependencyHelper.test.ts
@@ -131,7 +131,7 @@ describe('ELMDependencyHelper', () => {
       };
       const vs = ELMDependencyHelper.findValueSetReference(elm, [elm, dependency], valueSetRef);
       if (vs) {
-        vs.annotation = undefined;
+        delete vs.annotation;
       }
       expect(vs).toEqual(expectedValueSet);
     });

--- a/test/GapsInCareHelpers.test.ts
+++ b/test/GapsInCareHelpers.test.ts
@@ -22,7 +22,7 @@ const BASE_VS_RETRIEVE_RESULTS: DataTypeQuery[] = [
     valueSet: 'http://example.com/test-vs',
     retrieveLocalId: '14',
     queryLocalId: undefined,
-    libraryName: 'SimpleQueries',
+    retrieveLibraryName: 'SimpleQueries',
     expressionStack: [
       {
         localId: '14',
@@ -39,7 +39,7 @@ const BASE_VS_QUERY_RESULT: DataTypeQuery[] = [
     valueSet: 'http://example.com/test-vs',
     retrieveLocalId: '18',
     queryLocalId: '24',
-    libraryName: 'SimpleQueries',
+    retrieveLibraryName: 'SimpleQueries',
     expressionStack: [
       {
         localId: '24',
@@ -64,7 +64,7 @@ const BASE_CODE_RESULTS: DataTypeQuery[] = [
     },
     retrieveLocalId: '16',
     queryLocalId: undefined,
-    libraryName: 'SimpleQueries',
+    retrieveLibraryName: 'SimpleQueries',
     expressionStack: [
       {
         localId: '16',
@@ -81,7 +81,7 @@ const BASE_EXPRESSIONREF_RESULTS: DataTypeQuery[] = [
     valueSet: 'http://example.com/test-vs',
     retrieveLocalId: '14',
     queryLocalId: undefined,
-    libraryName: 'SimpleQueries',
+    retrieveLibraryName: 'SimpleQueries',
     expressionStack: [
       {
         localId: '26',
@@ -103,7 +103,7 @@ const BASE_DEPENDENCY_RESULTS: DataTypeQuery[] = [
     valueSet: 'http://example.com/test-vs-2',
     retrieveLocalId: '4',
     queryLocalId: undefined,
-    libraryName: 'SimpleDep',
+    retrieveLibraryName: 'SimpleDep',
     expressionStack: [
       {
         localId: '29',
@@ -127,7 +127,7 @@ const OR_GROUP_QUERIES: GapsDataTypeQuery[] = [
     retrieveLocalId: '4',
     parentQueryHasResult: false,
     queryLocalId: undefined,
-    libraryName: 'SimpleDep',
+    retrieveLibraryName: 'SimpleDep',
     expressionStack: [
       {
         localId: '29',
@@ -148,7 +148,7 @@ const OR_GROUP_QUERIES: GapsDataTypeQuery[] = [
     retrieveLocalId: '5',
     parentQueryHasResult: false,
     queryLocalId: undefined,
-    libraryName: 'SimpleDep',
+    retrieveLibraryName: 'SimpleDep',
     expressionStack: [
       {
         localId: '29',
@@ -169,7 +169,7 @@ const OR_GROUP_QUERIES: GapsDataTypeQuery[] = [
     retrieveLocalId: '6',
     parentQueryHasResult: false,
     queryLocalId: undefined,
-    libraryName: 'SimpleDep',
+    retrieveLibraryName: 'SimpleDep',
     expressionStack: [
       {
         localId: '44',
@@ -345,7 +345,7 @@ describe('Generate DetectedIssue Resource', () => {
         valueSet: 'http://example.com/test-vs',
         retrieveHasResult: false,
         parentQueryHasResult: true,
-        libraryName: 'SimpleQueries'
+        retrieveLibraryName: 'SimpleQueries'
       }
     ];
 
@@ -362,7 +362,7 @@ describe('Generate DetectedIssue Resource', () => {
         valueSet: 'http://example.com/test-vs',
         retrieveHasResult: false,
         parentQueryHasResult: true,
-        libraryName: 'SimpleQueries'
+        retrieveLibraryName: 'SimpleQueries'
       }
     ];
 
@@ -413,7 +413,7 @@ describe('Find Near Misses', () => {
       valueSet: 'http://example.com/test-vs',
       retrieveHasResult: true,
       parentQueryHasResult: false,
-      libraryName: 'example',
+      retrieveLibraryName: 'example',
       retrieveLocalId: 'procedure'
     };
 
@@ -557,7 +557,7 @@ describe('Find Near Misses', () => {
         valueSet: 'http://example.com/test-vs',
         retrieveHasResult: true,
         parentQueryHasResult: false,
-        libraryName: 'example',
+        retrieveLibraryName: 'example',
         retrieveLocalId: 'observation',
         queryInfo: {
           sources: [

--- a/test/GapsInCareHelpers.test.ts
+++ b/test/GapsInCareHelpers.test.ts
@@ -562,7 +562,7 @@ describe('Find Reason Detail', () => {
         valueSet: 'http://example.com/test-vs',
         retrieveHasResult: true,
         parentQueryHasResult: false,
-        libraryName: 'example',
+        retrieveLibraryName: 'example',
         retrieveLocalId: 'procedure-no-performed',
         queryInfo: {
           sources: [

--- a/test/RetrievesHelper.test.ts
+++ b/test/RetrievesHelper.test.ts
@@ -5,6 +5,8 @@ import { DataTypeQuery } from '../src/types/Calculator';
 const simpleQueryELM = getELMFixture('elm/queries/SimpleQueries.json');
 const simpleQueryELMDependency = getELMFixture('elm/queries/SimpleQueriesDependency.json');
 
+const allELM = [simpleQueryELM, simpleQueryELMDependency];
+
 const EXPECTED_VS_RETRIEVE_RESULTS: DataTypeQuery[] = [
   {
     dataType: 'Condition',
@@ -168,8 +170,8 @@ const EXPECTED_QUERY_REFERENCING_QUERY_IN_ANOTHER_LIBRARY_RESULTS: DataTypeQuery
     valueSet: 'http://example.com/test-vs-2',
     retrieveLocalId: '6',
     queryLocalId: '65',
-    retrieveLibraryName: 'SimpleQueries',
-    queryLibraryName: 'SimpleDep',
+    retrieveLibraryName: 'SimpleDep',
+    queryLibraryName: 'SimpleQueries',
     path: 'code',
     expressionStack: [
       {
@@ -199,42 +201,43 @@ const EXPECTED_QUERY_REFERENCING_QUERY_IN_ANOTHER_LIBRARY_RESULTS: DataTypeQuery
 describe('Find Numerator Queries', () => {
   test('simple valueset lookup', () => {
     const valueSetExpr = simpleQueryELM.library.statements.def[0]; // expression for valueset lookup
-    const results = findRetrieves(simpleQueryELM, [simpleQueryELMDependency], valueSetExpr.expression);
+    const results = findRetrieves(simpleQueryELM, allELM, valueSetExpr.expression);
     expect(results).toEqual(EXPECTED_VS_RETRIEVE_RESULTS);
   });
 
   test('simple code lookup', () => {
     const codeExpr = simpleQueryELM.library.statements.def[1]; // expression for code lookup
-    const results = findRetrieves(simpleQueryELM, [simpleQueryELMDependency], codeExpr.expression);
+    const results = findRetrieves(simpleQueryELM, allELM, codeExpr.expression);
     expect(results).toEqual(EXPECTED_CODE_RESULTS);
   });
 
   test('simple aliased query', () => {
     const queryExpr = simpleQueryELM.library.statements.def[2]; // expression with aliased query
-    const results = findRetrieves(simpleQueryELM, [simpleQueryELMDependency], queryExpr.expression);
+    const results = findRetrieves(simpleQueryELM, allELM, queryExpr.expression);
     expect(results).toEqual(EXPECTED_VS_QUERY_RESULTS);
   });
 
   test('simple expression ref', () => {
     const expressionRef = simpleQueryELM.library.statements.def[3]; // expression with local expression ref
-    const results = findRetrieves(simpleQueryELM, [simpleQueryELMDependency], expressionRef.expression);
+    const results = findRetrieves(simpleQueryELM, allELM, expressionRef.expression);
     expect(results).toEqual(EXPECTED_EXPRESSIONREF_RESULTS);
   });
 
   test('dependent library expression ref', () => {
     const expressionRefDependency = simpleQueryELM.library.statements.def[4]; // expression with expression ref in dependent library
-    const results = findRetrieves(simpleQueryELM, [simpleQueryELMDependency], expressionRefDependency.expression);
+    const results = findRetrieves(simpleQueryELM, allELM, expressionRefDependency.expression);
     expect(results).toEqual(EXPECTED_DEPENDENCY_RESULTS);
   });
 
   test('query is further filtered by another query', () => {
     const expressionRef = simpleQueryELM.library.statements.def[8];
-    const results = findRetrieves(simpleQueryELM, [simpleQueryELMDependency], expressionRef.expression);
+    const results = findRetrieves(simpleQueryELM, allELM, expressionRef.expression);
     expect(results).toEqual(EXPECTED_QUERY_REFERENCING_QUERY_RESULTS);
   });
 
-  test.skip('query is further filtered by another query from another library', () => {
+  test('query is further filtered by another query from another library', () => {
     const expressionRef = simpleQueryELM.library.statements.def[10];
-    const results = findRetrieves(simpleQueryELM, [simpleQueryELMDependency], expressionRef.expression);
+    const results = findRetrieves(simpleQueryELM, allELM, expressionRef.expression);
+    expect(results).toEqual(EXPECTED_QUERY_REFERENCING_QUERY_IN_ANOTHER_LIBRARY_RESULTS);
   });
 });

--- a/test/RetrievesHelper.test.ts
+++ b/test/RetrievesHelper.test.ts
@@ -11,7 +11,8 @@ const EXPECTED_VS_RETRIEVE_RESULTS: DataTypeQuery[] = [
     valueSet: 'http://example.com/test-vs',
     retrieveLocalId: '14',
     queryLocalId: undefined,
-    libraryName: 'SimpleQueries',
+    retrieveLibraryName: 'SimpleQueries',
+    queryLibraryName: 'SimpleQueries',
     expressionStack: [
       {
         localId: '14',
@@ -29,7 +30,8 @@ const EXPECTED_VS_QUERY_RESULTS: DataTypeQuery[] = [
     valueSet: 'http://example.com/test-vs',
     retrieveLocalId: '18',
     queryLocalId: '24',
-    libraryName: 'SimpleQueries',
+    retrieveLibraryName: 'SimpleQueries',
+    queryLibraryName: 'SimpleQueries',
     expressionStack: [
       {
         localId: '24',
@@ -55,7 +57,8 @@ const EXPECTED_CODE_RESULTS: DataTypeQuery[] = [
     },
     retrieveLocalId: '16',
     queryLocalId: undefined,
-    libraryName: 'SimpleQueries',
+    retrieveLibraryName: 'SimpleQueries',
+    queryLibraryName: 'SimpleQueries',
     expressionStack: [
       {
         localId: '16',
@@ -73,7 +76,8 @@ const EXPECTED_EXPRESSIONREF_RESULTS: DataTypeQuery[] = [
     valueSet: 'http://example.com/test-vs',
     retrieveLocalId: '14',
     queryLocalId: undefined,
-    libraryName: 'SimpleQueries',
+    retrieveLibraryName: 'SimpleQueries',
+    queryLibraryName: 'SimpleQueries',
     expressionStack: [
       {
         localId: '26',
@@ -96,7 +100,8 @@ const EXPECTED_DEPENDENCY_RESULTS: DataTypeQuery[] = [
     valueSet: 'http://example.com/test-vs-2',
     retrieveLocalId: '4',
     queryLocalId: undefined,
-    libraryName: 'SimpleDep',
+    retrieveLibraryName: 'SimpleDep',
+    queryLibraryName: 'SimpleDep',
     expressionStack: [
       {
         localId: '29',
@@ -119,7 +124,8 @@ const EXPECTED_QUERY_REFERENCING_QUERY_RESULTS: DataTypeQuery[] = [
     valueSet: 'http://example.com/test-vs',
     retrieveLocalId: '33',
     queryLocalId: '46',
-    libraryName: 'SimpleQueries',
+    retrieveLibraryName: 'SimpleQueries',
+    queryLibraryName: 'SimpleQueries',
     path: 'code',
     expressionStack: [
       {
@@ -150,6 +156,40 @@ const EXPECTED_QUERY_REFERENCING_QUERY_RESULTS: DataTypeQuery[] = [
       {
         localId: '33',
         libraryName: 'SimpleQueries',
+        type: 'Retrieve'
+      }
+    ]
+  }
+];
+
+const EXPECTED_QUERY_REFERENCING_QUERY_IN_ANOTHER_LIBRARY_RESULTS: DataTypeQuery[] = [
+  {
+    dataType: 'Procedure',
+    valueSet: 'http://example.com/test-vs-2',
+    retrieveLocalId: '6',
+    queryLocalId: '65',
+    retrieveLibraryName: 'SimpleQueries',
+    queryLibraryName: 'SimpleDep',
+    path: 'code',
+    expressionStack: [
+      {
+        localId: '65',
+        libraryName: 'SimpleQueries',
+        type: 'Query'
+      },
+      {
+        localId: '59',
+        libraryName: 'SimpleQueries',
+        type: 'ExpressionRef'
+      },
+      {
+        localId: '12',
+        libraryName: 'SimpleDep',
+        type: 'Query'
+      },
+      {
+        localId: '6',
+        libraryName: 'SimpleDep',
         type: 'Retrieve'
       }
     ]
@@ -191,5 +231,10 @@ describe('Find Numerator Queries', () => {
     const expressionRef = simpleQueryELM.library.statements.def[8];
     const results = findRetrieves(simpleQueryELM, [simpleQueryELMDependency], expressionRef.expression);
     expect(results).toEqual(EXPECTED_QUERY_REFERENCING_QUERY_RESULTS);
+  });
+
+  test.skip('query is further filtered by another query from another library', () => {
+    const expressionRef = simpleQueryELM.library.statements.def[10];
+    const results = findRetrieves(simpleQueryELM, [simpleQueryELMDependency], expressionRef.expression);
   });
 });

--- a/test/fixtures/elm/queries/SimpleQueries.cql
+++ b/test/fixtures/elm/queries/SimpleQueries.cql
@@ -47,3 +47,7 @@ define "Retrieve Query":
 define "Retrieve Using ValueSet In Dependency":
   [Procedure: SimpleDep."test-vs-2"] P
     where P.status = 'completed'
+
+define "Nested Query From Another Library":
+  SimpleDep."SimpleQuery" S
+    where S.status = 'completed'

--- a/test/fixtures/elm/queries/SimpleQueries.json
+++ b/test/fixtures/elm/queries/SimpleQueries.json
@@ -8,7 +8,7 @@
       {
         "type": "Annotation",
         "s": {
-          "r": "40",
+          "r": "66",
           "s": [
             {
               "value": [
@@ -1305,6 +1305,383 @@
               "locator": "37:10-37:34",
               "name": "Further Filtering Query",
               "type": "ExpressionRef"
+            }
+          }
+        },
+        {
+          "localId": "58",
+          "locator": "47:1-49:32",
+          "name": "Retrieve Using ValueSet In Dependency",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "58",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Retrieve Using ValueSet In Dependency\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "57",
+                    "s": [
+                      {
+                        "s": [
+                          {
+                            "r": "52",
+                            "s": [
+                              {
+                                "r": "51",
+                                "s": [
+                                  {
+                                    "r": "51",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "[",
+                                          "Procedure",
+                                          ": "
+                                        ]
+                                      },
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "SimpleDep",
+                                              ".",
+                                              "\"test-vs-2\""
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "]"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "P"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "\n    "
+                        ]
+                      },
+                      {
+                        "r": "56",
+                        "s": [
+                          {
+                            "value": [
+                              "where "
+                            ]
+                          },
+                          {
+                            "r": "56",
+                            "s": [
+                              {
+                                "r": "54",
+                                "s": [
+                                  {
+                                    "r": "53",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "P"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "."
+                                    ]
+                                  },
+                                  {
+                                    "r": "54",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "status"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "=",
+                                  " "
+                                ]
+                              },
+                              {
+                                "r": "55",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "'completed'"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "57",
+            "locator": "48:3-49:32",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "52",
+                "locator": "48:3-48:38",
+                "alias": "P",
+                "expression": {
+                  "localId": "51",
+                  "locator": "48:3-48:36",
+                  "dataType": "{http://hl7.org/fhir}Procedure",
+                  "templateId": "http://hl7.org/fhir/StructureDefinition/Procedure",
+                  "codeProperty": "code",
+                  "codeComparator": "in",
+                  "type": "Retrieve",
+                  "codes": {
+                    "locator": "48:15-48:35",
+                    "name": "test-vs-2",
+                    "libraryName": "SimpleDep",
+                    "type": "ValueSetRef"
+                  }
+                }
+              }
+            ],
+            "relationship": [],
+            "where": {
+              "localId": "56",
+              "locator": "49:5-49:32",
+              "type": "Equal",
+              "operand": [
+                {
+                  "name": "ToString",
+                  "libraryName": "FHIRHelpers",
+                  "type": "FunctionRef",
+                  "operand": [
+                    {
+                      "localId": "54",
+                      "locator": "49:11-49:18",
+                      "path": "status",
+                      "scope": "P",
+                      "type": "Property"
+                    }
+                  ]
+                },
+                {
+                  "localId": "55",
+                  "locator": "49:22-49:32",
+                  "valueType": "{urn:hl7-org:elm-types:r1}String",
+                  "value": "completed",
+                  "type": "Literal"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "localId": "66",
+          "locator": "51:1-53:32",
+          "name": "Nested Query From Another Library",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "66",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Nested Query From Another Library\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "65",
+                    "s": [
+                      {
+                        "s": [
+                          {
+                            "r": "60",
+                            "s": [
+                              {
+                                "r": "59",
+                                "s": [
+                                  {
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "SimpleDep",
+                                          ".",
+                                          "\"SimpleQuery\""
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "S"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "\n    "
+                        ]
+                      },
+                      {
+                        "r": "64",
+                        "s": [
+                          {
+                            "value": [
+                              "where "
+                            ]
+                          },
+                          {
+                            "r": "64",
+                            "s": [
+                              {
+                                "r": "62",
+                                "s": [
+                                  {
+                                    "r": "61",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "S"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "."
+                                    ]
+                                  },
+                                  {
+                                    "r": "62",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "status"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "=",
+                                  " "
+                                ]
+                              },
+                              {
+                                "r": "63",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "'completed'"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "65",
+            "locator": "52:3-53:32",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "60",
+                "locator": "52:3-52:27",
+                "alias": "S",
+                "expression": {
+                  "localId": "59",
+                  "locator": "52:3-52:25",
+                  "name": "SimpleQuery",
+                  "libraryName": "SimpleDep",
+                  "type": "ExpressionRef"
+                }
+              }
+            ],
+            "relationship": [],
+            "where": {
+              "localId": "64",
+              "locator": "53:5-53:32",
+              "type": "Equal",
+              "operand": [
+                {
+                  "name": "ToString",
+                  "libraryName": "FHIRHelpers",
+                  "type": "FunctionRef",
+                  "operand": [
+                    {
+                      "localId": "62",
+                      "locator": "53:11-53:18",
+                      "path": "status",
+                      "scope": "S",
+                      "type": "Property"
+                    }
+                  ]
+                },
+                {
+                  "localId": "63",
+                  "locator": "53:22-53:32",
+                  "valueType": "{urn:hl7-org:elm-types:r1}String",
+                  "value": "completed",
+                  "type": "Literal"
+                }
+              ]
             }
           }
         }

--- a/test/fixtures/elm/queries/SimpleQueriesDependency.cql
+++ b/test/fixtures/elm/queries/SimpleQueriesDependency.cql
@@ -9,3 +9,8 @@ valueset "test-vs-2": 'http://example.com/test-vs-2'
 define "SimpleRetrieve":
   [Condition: "test-vs-2"]
 
+
+define "SimpleQuery":
+  [Procedure: "test-vs-2"] P
+    where P.id = 'test' 
+

--- a/test/fixtures/elm/queries/SimpleQueriesDependency.cql
+++ b/test/fixtures/elm/queries/SimpleQueriesDependency.cql
@@ -12,5 +12,5 @@ define "SimpleRetrieve":
 
 define "SimpleQuery":
   [Procedure: "test-vs-2"] P
-    where P.id = 'test' 
+    where P.id = 'test-2' 
 

--- a/test/fixtures/elm/queries/SimpleQueriesDependency.json
+++ b/test/fixtures/elm/queries/SimpleQueriesDependency.json
@@ -4,6 +4,20 @@
       {
         "translatorOptions": "EnableAnnotations,EnableLocators",
         "type": "CqlToElmInfo"
+      },
+      {
+        "type": "Annotation",
+        "s": {
+          "r": "13",
+          "s": [
+            {
+              "value": [
+                "",
+                "library SimpleDep version '0.0.1'"
+              ]
+            }
+          ]
+        }
       }
     ],
     "identifier": {
@@ -25,7 +39,38 @@
           "locator": "3:1-3:26",
           "localIdentifier": "FHIR",
           "uri": "http://hl7.org/fhir",
-          "version": "4.0.1"
+          "version": "4.0.1",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "1",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "using "
+                    ]
+                  },
+                  {
+                    "s": [
+                      {
+                        "value": [
+                          "FHIR"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " version ",
+                      "'4.0.1'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
         }
       ]
     },
@@ -36,7 +81,38 @@
           "locator": "5:1-5:35",
           "localIdentifier": "FHIRHelpers",
           "path": "FHIRHelpers",
-          "version": "4.0.1"
+          "version": "4.0.1",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "2",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "include "
+                    ]
+                  },
+                  {
+                    "s": [
+                      {
+                        "value": [
+                          "FHIRHelpers"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " version ",
+                      "'4.0.1'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
         }
       ]
     },
@@ -47,7 +123,26 @@
           "locator": "7:1-7:52",
           "name": "test-vs-2",
           "id": "http://example.com/test-vs-2",
-          "accessLevel": "Public"
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "3",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "valueset ",
+                      "\"test-vs-2\"",
+                      ": ",
+                      "'http://example.com/test-vs-2'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
         }
       ]
     },
@@ -67,6 +162,7 @@
                 "s": [
                   {
                     "value": [
+                      "",
                       "define ",
                       "\"SimpleRetrieve\"",
                       ":\n  "
@@ -108,11 +204,210 @@
             "dataType": "{http://hl7.org/fhir}Condition",
             "templateId": "http://hl7.org/fhir/StructureDefinition/Condition",
             "codeProperty": "code",
+            "codeComparator": "in",
             "type": "Retrieve",
             "codes": {
               "locator": "10:15-10:25",
               "name": "test-vs-2",
               "type": "ValueSetRef"
+            }
+          }
+        },
+        {
+          "localId": "13",
+          "locator": "13:1-15:23",
+          "name": "SimpleQuery",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "13",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"SimpleQuery\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "12",
+                    "s": [
+                      {
+                        "s": [
+                          {
+                            "r": "7",
+                            "s": [
+                              {
+                                "r": "6",
+                                "s": [
+                                  {
+                                    "r": "6",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "[",
+                                          "Procedure",
+                                          ": "
+                                        ]
+                                      },
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"test-vs-2\""
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "]"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "P"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "\n    "
+                        ]
+                      },
+                      {
+                        "r": "11",
+                        "s": [
+                          {
+                            "value": [
+                              "where "
+                            ]
+                          },
+                          {
+                            "r": "11",
+                            "s": [
+                              {
+                                "r": "9",
+                                "s": [
+                                  {
+                                    "r": "8",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "P"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "."
+                                    ]
+                                  },
+                                  {
+                                    "r": "9",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "id"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "=",
+                                  " "
+                                ]
+                              },
+                              {
+                                "r": "10",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "'test'"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "12",
+            "locator": "14:3-15:23",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "7",
+                "locator": "14:3-14:28",
+                "alias": "P",
+                "expression": {
+                  "localId": "6",
+                  "locator": "14:3-14:26",
+                  "dataType": "{http://hl7.org/fhir}Procedure",
+                  "templateId": "http://hl7.org/fhir/StructureDefinition/Procedure",
+                  "codeProperty": "code",
+                  "codeComparator": "in",
+                  "type": "Retrieve",
+                  "codes": {
+                    "locator": "14:15-14:25",
+                    "name": "test-vs-2",
+                    "type": "ValueSetRef"
+                  }
+                }
+              }
+            ],
+            "relationship": [],
+            "where": {
+              "localId": "11",
+              "locator": "15:5-15:23",
+              "type": "Equal",
+              "operand": [
+                {
+                  "name": "ToString",
+                  "libraryName": "FHIRHelpers",
+                  "type": "FunctionRef",
+                  "operand": [
+                    {
+                      "localId": "9",
+                      "locator": "15:11-15:14",
+                      "path": "id",
+                      "scope": "P",
+                      "type": "Property"
+                    }
+                  ]
+                },
+                {
+                  "localId": "10",
+                  "locator": "15:18-15:23",
+                  "valueType": "{urn:hl7-org:elm-types:r1}String",
+                  "value": "test",
+                  "type": "Literal"
+                }
+              ]
             }
           }
         }

--- a/test/fixtures/elm/queries/SimpleQueriesDependency.json
+++ b/test/fixtures/elm/queries/SimpleQueriesDependency.json
@@ -215,7 +215,7 @@
         },
         {
           "localId": "13",
-          "locator": "13:1-15:23",
+          "locator": "13:1-15:25",
           "name": "SimpleQuery",
           "context": "Patient",
           "accessLevel": "Public",
@@ -340,7 +340,7 @@
                                 "s": [
                                   {
                                     "value": [
-                                      "'test'"
+                                      "'test-2'"
                                     ]
                                   }
                                 ]
@@ -357,7 +357,7 @@
           ],
           "expression": {
             "localId": "12",
-            "locator": "14:3-15:23",
+            "locator": "14:3-15:25",
             "type": "Query",
             "source": [
               {
@@ -383,7 +383,7 @@
             "relationship": [],
             "where": {
               "localId": "11",
-              "locator": "15:5-15:23",
+              "locator": "15:5-15:25",
               "type": "Equal",
               "operand": [
                 {
@@ -402,9 +402,9 @@
                 },
                 {
                   "localId": "10",
-                  "locator": "15:18-15:23",
+                  "locator": "15:18-15:25",
                   "valueType": "{urn:hl7-org:elm-types:r1}String",
-                  "value": "test",
+                  "value": "test-2",
                   "type": "Literal"
                 }
               ]

--- a/test/queryFilters/interpretExpression.test.ts
+++ b/test/queryFilters/interpretExpression.test.ts
@@ -34,6 +34,8 @@ describe('interpretExpression', () => {
     };
 
     expect(QueryFilter.interpretExpression(functionRef, complexQueryELM, {}, PATIENT)).toEqual({
+      libraryName: 'ComplexQueries',
+      localId: undefined,
       type: 'unknown',
       attribute: 'onset',
       alias: 'C'
@@ -61,6 +63,8 @@ describe('interpretExpression', () => {
     };
 
     expect(QueryFilter.interpretExpression(functionRef, complexQueryELM, {}, PATIENT)).toEqual({
+      libraryName: 'ComplexQueries',
+      localId: undefined,
       type: 'unknown'
     });
   });

--- a/test/queryFilters/parseQueryInfo.test.ts
+++ b/test/queryFilters/parseQueryInfo.test.ts
@@ -49,6 +49,7 @@ const EXPECTED_CODE_AND_STARTS_DURING_MP: QueryInfo = {
   ],
   filter: {
     type: 'and',
+    libraryName: 'ComplexQueries',
     children: [
       {
         type: 'in',
@@ -90,6 +91,7 @@ const EXPECTED_STATUS_VALUE_EXISTS_DURING_MP: QueryInfo = {
   ],
   filter: {
     type: 'and',
+    libraryName: 'ComplexQueries',
     children: [
       {
         type: 'in',
@@ -134,6 +136,7 @@ const EXPECTED_ENC_TWO_YEAR_BEFORE_END_OF_MP: QueryInfo = {
   ],
   filter: {
     type: 'and',
+    libraryName: 'ComplexQueries',
     children: [
       {
         type: 'during',
@@ -162,6 +165,7 @@ const EXPECTED_CODE_OR_STARTS_DURING_MP_OR_NOT_NULL: QueryInfo = {
   ],
   filter: {
     type: 'or',
+    libraryName: 'ComplexQueries',
     children: [
       {
         type: 'in',

--- a/test/queryFilters/parseQueryInfo.test.ts
+++ b/test/queryFilters/parseQueryInfo.test.ts
@@ -17,6 +17,7 @@ const PARAMETERS = { 'Measurement Period': new cql.Interval(START_MP, END_MP, tr
 
 const EXPECTED_VS_WITH_ID_CHECK_QUERY: QueryInfo = {
   localId: '24',
+  libraryName: 'SimpleQueries',
   sources: [
     {
       retrieveLocalId: '18',
@@ -30,12 +31,14 @@ const EXPECTED_VS_WITH_ID_CHECK_QUERY: QueryInfo = {
     alias: 'C',
     attribute: 'id',
     value: 'test',
-    localId: '23'
+    localId: '23',
+    libraryName: 'SimpleQueries'
   }
 };
 
 const EXPECTED_CODE_AND_STARTS_DURING_MP: QueryInfo = {
   localId: '42',
+  libraryName: 'ComplexQueries',
   sources: [
     {
       retrieveLocalId: '31',
@@ -56,7 +59,8 @@ const EXPECTED_CODE_AND_STARTS_DURING_MP: QueryInfo = {
           { code: 'recurrence', system: 'http://terminology.hl7.org/CodeSystem/condition-clinical' },
           { code: 'relapse', system: 'http://terminology.hl7.org/CodeSystem/condition-clinical' }
         ],
-        localId: '36'
+        localId: '36',
+        libraryName: 'ComplexQueries'
       },
       {
         type: 'during',
@@ -66,7 +70,8 @@ const EXPECTED_CODE_AND_STARTS_DURING_MP: QueryInfo = {
           start: '2019-01-01T00:00:00.000Z',
           end: '2019-12-31T23:59:59.999Z'
         },
-        localId: '40'
+        localId: '40',
+        libraryName: 'ComplexQueries'
       }
     ]
   }
@@ -74,6 +79,7 @@ const EXPECTED_CODE_AND_STARTS_DURING_MP: QueryInfo = {
 
 const EXPECTED_STATUS_VALUE_EXISTS_DURING_MP: QueryInfo = {
   localId: '65',
+  libraryName: 'ComplexQueries',
   sources: [
     {
       retrieveLocalId: '44',
@@ -90,13 +96,15 @@ const EXPECTED_STATUS_VALUE_EXISTS_DURING_MP: QueryInfo = {
         alias: 'Obs',
         attribute: 'status',
         valueList: ['final', 'amended', 'corrected', 'preliminary'],
-        localId: '53'
+        localId: '53',
+        libraryName: 'ComplexQueries'
       },
       {
         type: 'notnull',
         alias: 'Obs',
         attribute: 'value',
-        localId: '56'
+        localId: '56',
+        libraryName: 'ComplexQueries'
       },
       {
         type: 'during',
@@ -106,7 +114,8 @@ const EXPECTED_STATUS_VALUE_EXISTS_DURING_MP: QueryInfo = {
           start: '2019-01-01T00:00:00.000Z',
           end: '2019-12-31T23:59:59.999Z'
         },
-        localId: '63'
+        localId: '63',
+        libraryName: 'ComplexQueries'
       }
     ]
   }
@@ -114,6 +123,7 @@ const EXPECTED_STATUS_VALUE_EXISTS_DURING_MP: QueryInfo = {
 
 const EXPECTED_ENC_TWO_YEAR_BEFORE_END_OF_MP: QueryInfo = {
   localId: '77',
+  libraryName: 'ComplexQueries',
   sources: [
     {
       retrieveLocalId: '67',
@@ -132,7 +142,8 @@ const EXPECTED_ENC_TWO_YEAR_BEFORE_END_OF_MP: QueryInfo = {
         valuePeriod: {
           start: '2017-12-31T23:59:59.999Z',
           end: '2019-12-31T23:59:59.998Z'
-        }
+        },
+        libraryName: 'ComplexQueries'
       }
     ]
   }
@@ -140,6 +151,7 @@ const EXPECTED_ENC_TWO_YEAR_BEFORE_END_OF_MP: QueryInfo = {
 
 const EXPECTED_CODE_OR_STARTS_DURING_MP_OR_NOT_NULL: QueryInfo = {
   localId: '94',
+  libraryName: 'ComplexQueries',
   sources: [
     {
       retrieveLocalId: '79',
@@ -160,7 +172,8 @@ const EXPECTED_CODE_OR_STARTS_DURING_MP_OR_NOT_NULL: QueryInfo = {
           { code: 'recurrence', system: 'http://terminology.hl7.org/CodeSystem/condition-clinical' },
           { code: 'relapse', system: 'http://terminology.hl7.org/CodeSystem/condition-clinical' }
         ],
-        localId: '84'
+        localId: '84',
+        libraryName: 'ComplexQueries'
       },
       {
         type: 'during',
@@ -170,13 +183,15 @@ const EXPECTED_CODE_OR_STARTS_DURING_MP_OR_NOT_NULL: QueryInfo = {
           start: '2019-01-01T00:00:00.000Z',
           end: '2019-12-31T23:59:59.999Z'
         },
-        localId: '88'
+        localId: '88',
+        libraryName: 'ComplexQueries'
       },
       {
         type: 'notnull',
         alias: 'C',
         attribute: 'abatement',
-        localId: '92'
+        localId: '92',
+        libraryName: 'ComplexQueries'
       }
     ]
   }
@@ -184,6 +199,7 @@ const EXPECTED_CODE_OR_STARTS_DURING_MP_OR_NOT_NULL: QueryInfo = {
 
 const EXPECTED_QUERY_REFERENCES_QUERY: QueryInfo = {
   localId: '46',
+  libraryName: 'SimpleQueries',
   sources: [
     {
       retrieveLocalId: '33',
@@ -201,13 +217,15 @@ const EXPECTED_QUERY_REFERENCES_QUERY: QueryInfo = {
         alias: 'P',
         attribute: 'status',
         value: 'completed',
-        localId: '38'
+        localId: '38',
+        libraryName: 'SimpleQueries'
       },
       {
         type: 'notnull',
         alias: 'P',
         attribute: 'outcome',
-        localId: '45'
+        localId: '45',
+        libraryName: 'SimpleQueries'
       }
     ]
   }
@@ -215,6 +233,7 @@ const EXPECTED_QUERY_REFERENCES_QUERY: QueryInfo = {
 
 const EXPECTED_COMPLEX_QUERY_REF_QUERY: QueryInfo = {
   localId: '120',
+  libraryName: 'ComplexQueries',
   sources: [
     {
       retrieveLocalId: '96',
@@ -232,13 +251,15 @@ const EXPECTED_COMPLEX_QUERY_REF_QUERY: QueryInfo = {
         alias: 'Obs',
         attribute: 'status',
         valueList: ['final', 'amended', 'corrected', 'preliminary'],
-        localId: '105'
+        localId: '105',
+        libraryName: 'ComplexQueries'
       },
       {
         type: 'notnull',
         alias: 'Obs',
         attribute: 'value',
-        localId: '108'
+        localId: '108',
+        libraryName: 'ComplexQueries'
       },
       {
         type: 'during',
@@ -248,7 +269,8 @@ const EXPECTED_COMPLEX_QUERY_REF_QUERY: QueryInfo = {
           start: '2019-01-01T00:00:00.000Z',
           end: '2019-12-31T23:59:59.999Z'
         },
-        localId: '119'
+        localId: '119',
+        libraryName: 'ComplexQueries'
       }
     ]
   }
@@ -256,6 +278,7 @@ const EXPECTED_COMPLEX_QUERY_REF_QUERY: QueryInfo = {
 
 const EXPECTED_COMPLEX_QUERY_REF_QUERY_ANDS_IN_BOTH: QueryInfo = {
   localId: '134',
+  libraryName: 'ComplexQueries',
   sources: [
     {
       retrieveLocalId: '96',
@@ -273,13 +296,15 @@ const EXPECTED_COMPLEX_QUERY_REF_QUERY_ANDS_IN_BOTH: QueryInfo = {
         alias: 'Obs',
         attribute: 'status',
         valueList: ['final', 'amended', 'corrected', 'preliminary'],
-        localId: '105'
+        localId: '105',
+        libraryName: 'ComplexQueries'
       },
       {
         type: 'notnull',
         alias: 'Obs',
         attribute: 'value',
-        localId: '108'
+        localId: '108',
+        libraryName: 'ComplexQueries'
       },
       {
         type: 'during',
@@ -289,13 +314,15 @@ const EXPECTED_COMPLEX_QUERY_REF_QUERY_ANDS_IN_BOTH: QueryInfo = {
           start: '2019-01-01T00:00:00.000Z',
           end: '2019-12-31T23:59:59.999Z'
         },
-        localId: '129'
+        localId: '129',
+        libraryName: 'ComplexQueries'
       },
       {
         type: 'notnull',
         alias: 'Obs',
         attribute: 'bodySite',
-        localId: '132'
+        localId: '132',
+        libraryName: 'ComplexQueries'
       }
     ]
   }
@@ -303,6 +330,7 @@ const EXPECTED_COMPLEX_QUERY_REF_QUERY_ANDS_IN_BOTH: QueryInfo = {
 
 const EXPECTED_QUERY_REFERENCES_QUERY_IN_ANOTHER_LIBRARY: QueryInfo = {
   localId: '65',
+  libraryName: 'SimpleQueries',
   sources: [
     {
       retrieveLocalId: '6',
@@ -320,14 +348,16 @@ const EXPECTED_QUERY_REFERENCES_QUERY_IN_ANOTHER_LIBRARY: QueryInfo = {
         alias: 'P',
         attribute: 'id',
         value: 'test-2',
-        localId: '11'
+        localId: '11',
+        libraryName: 'SimpleDep'
       },
       {
         type: 'equals',
         alias: 'P',
         attribute: 'status',
         value: 'completed',
-        localId: '64'
+        localId: '64',
+        libraryName: 'SimpleQueries'
       }
     ]
   }


### PR DESCRIPTION
# Summary
Added support for nested queries which reference a query in another library. Added libraryName attribute to QueryInfo type and filters.

## New behavior
Queries which reference another query in a different library can now be handled by fqm-execution. Previously, nested queries were only supported if defined in the same library. 

Objects in the retrieves output array should now have attributes retrieveLibraryName and queryLibraryName instead of attribute libraryName. 

QueryInfo and Filter objects which have a localId attribute should now all have a libraryName attribute to accompany it.

## Code changes
parseQueryInfo and findRetrieves now take an additional param allElm: ELM[]
Main changes can be found in QueryFilterHelpers.ts and RetrievesHelpers.ts

# Testing guidance
Added and edited tests to ensure support for nested query referencing another query which can be run using npm run test
Run EXM-130 or any other Measure + Patient bundle combo which is appropriate for gaps in care testing and ensure that the output is unchanged. As of right now there is not a Measure bundle which causes fqm-execution to handle a nested query in another library, so the best method is to ensure all other functionality remains unchanged and that the added unit tests are correct and passing. New tests are in RetrievesHelper.test.ts ('query is further filtered by another query from another library') and parseQueryInfo.test.ts ('simple - query references query in another library, combines filters'). Also ensure that all output of parseQueryInfo is unchanged besides adding correct libraryNames where localIds are found. I accomplished this with some console.logs to print the output of parseQueryInfo while running EXM130 bundles for gaps in care report. There may also be a way to do this with the -d flag. 
