### PR TITLE
Reason Detail Extension with Resource References

### DIFF
--- a/src/GapsInCareHelpers.ts
+++ b/src/GapsInCareHelpers.ts
@@ -182,11 +182,11 @@ export function generateGuidanceResponses(
     let gapCoding: R4.ICoding[];
 
     // TODO: update system to be full URL once defined
-    if (q.reasonDetail?.hasReasonDetail && q.reasonDetail.reasonCodes) {
-      gapCoding = q.reasonDetail.reasonCodes.map(c => ({
+    if (q.reasonDetail?.hasReasonDetail && q.reasonDetail.reasons.length > 0) {
+      gapCoding = q.reasonDetail.reasons.map(r => ({
         system: 'CareGapReasonCodeSystem',
-        code: c,
-        display: CareGapReasonCodeDisplay[c]
+        code: r.code,
+        display: CareGapReasonCodeDisplay[r.code]
       }));
     } else {
       gapCoding =
@@ -337,7 +337,7 @@ export function calculateReasonDetail(
     if (improvementNotation === ImprovementNotation.POSITIVE) {
       reasonDetail = {
         hasReasonDetail: r.retrieveHasResult === true && r.parentQueryHasResult === false,
-        reasonCodes: []
+        reasons: []
       };
 
       if (reasonDetail.hasReasonDetail && r.queryInfo && detailedResult?.clauseResults) {
@@ -370,7 +370,7 @@ export function calculateReasonDetail(
                 const isAttrContainedInInterval = interval.contains(desiredAttr.value);
 
                 if (isAttrContainedInInterval === false) {
-                  reasonDetail.reasonCodes.push(CareGapReasonCode.DATEOUTOFRANGE);
+                  reasonDetail.reasons.push({ code: CareGapReasonCode.DATEOUTOFRANGE });
                 }
               });
             }
@@ -390,7 +390,7 @@ export function calculateReasonDetail(
 
                 // Use VALUEMISSING code if data is null
                 if (desiredAttr === null || desiredAttr === undefined) {
-                  reasonDetail.reasonCodes.push(CareGapReasonCode.VALUEMISSING);
+                  reasonDetail.reasons.push({ code: CareGapReasonCode.VALUEMISSING });
                 }
               });
             }
@@ -406,7 +406,7 @@ export function calculateReasonDetail(
             if (clauseResult && clauseResult.final === FinalResult.FALSE) {
               const code = getGapReasonCode(f);
               if (code !== null) {
-                reasonDetail.reasonCodes.push(code);
+                reasonDetail.reasons.push({ code });
               }
             }
           }
@@ -414,14 +414,14 @@ export function calculateReasonDetail(
       }
 
       // If no specific reason details found, default is missing
-      if (reasonDetail.hasReasonDetail && reasonDetail.reasonCodes.length === 0) {
-        reasonDetail.reasonCodes = [CareGapReasonCode.MISSING];
+      if (reasonDetail.hasReasonDetail && reasonDetail.reasons.length === 0) {
+        reasonDetail.reasons = [{ code: CareGapReasonCode.MISSING }];
       }
     } else {
       // TODO: this can probably be expanded to address negative improvement cases, but it will be a bit more complicated
       reasonDetail = {
         hasReasonDetail: false,
-        reasonCodes: []
+        reasons: []
       };
     }
     return { ...r, reasonDetail };

--- a/src/GapsInCareHelpers.ts
+++ b/src/GapsInCareHelpers.ts
@@ -190,11 +190,36 @@ export function generateGuidanceResponses(
 
     // TODO: update system to be full URL once defined
     if (q.reasonDetail?.hasReasonDetail && q.reasonDetail.reasons.length > 0) {
-      gapCoding = q.reasonDetail.reasons.map(r => ({
-        system: 'CareGapReasonCodeSystem',
-        code: r.code,
-        display: CareGapReasonCodeDisplay[r.code]
-      }));
+      gapCoding = q.reasonDetail.reasons.map(r => {
+        const reasonCoding: R4.ICoding = {
+          system: 'CareGapReasonCodeSystem',
+          code: r.code,
+          display: CareGapReasonCodeDisplay[r.code]
+        };
+
+        // If there is a referenced resource create and add the extension
+        if (r.reference) {
+          const detailExt: R4.IExtension = {
+            url: 'ReasonDetail',
+            extension: [
+              {
+                url: 'reference',
+                valueReference: {
+                  reference: r.reference
+                }
+              }
+            ]
+          };
+          if (r.path) {
+            detailExt.extension?.push({
+              url: 'path',
+              valueString: r.path
+            });
+          }
+          reasonCoding.extension = [detailExt];
+        }
+        return reasonCoding;
+      });
     } else {
       gapCoding =
         improvementNotation === ImprovementNotation.POSITIVE

--- a/src/GapsInCareHelpers.ts
+++ b/src/GapsInCareHelpers.ts
@@ -375,16 +375,17 @@ export function calculateReasonDetail(
 ): GapsDataTypeQuery[] {
   return retrieves.map(r => {
     let reasonDetail: ReasonDetail;
-    // If this is a positive improvement notation then results
+    // If this is a positive improvement notation measure then we can look for reasons why the query wasn't satisfied
     if (improvementNotation === ImprovementNotation.POSITIVE) {
       // Create the initial reasonDetail information. There will be detail if the retrieve has a result but the query
-      // that filters on the retrieve.
+      // that filters on the retrieve does not have any results.
       reasonDetail = {
         hasReasonDetail: r.retrieveHasResult === true && r.parentQueryHasResult === false,
         reasons: []
       };
 
-      // If there are results for this clause and we have queryInfo then we can look at the
+      // If there are results for this clause and we have queryInfo then we can look at each of the
+      // resources from the retrieve results and record reasons for each filter they did not satisfy
       if (reasonDetail.hasReasonDetail && r.queryInfo && detailedResult?.clauseResults) {
         const flattenedFilters = flattenFilters(r.queryInfo.filter);
         const resources = detailedResult.clauseResults?.find(
@@ -488,8 +489,7 @@ export function calculateReasonDetail(
         reasonDetail.reasons = [{ code: CareGapReasonCode.MISSING }];
       }
     } else {
-      // Handle negative improvement notation cases.
-      // TODO: this can probably be expanded to address negative improvement cases, but it will be a bit more complicated
+      // TODO: Handle negative improvement cases, similar to above but it will be a bit more complicated.
       reasonDetail = {
         hasReasonDetail: false,
         reasons: []

--- a/src/GapsInCareHelpers.ts
+++ b/src/GapsInCareHelpers.ts
@@ -370,7 +370,11 @@ export function calculateReasonDetail(
                 const isAttrContainedInInterval = interval.contains(desiredAttr.value);
 
                 if (isAttrContainedInInterval === false) {
-                  reasonDetail.reasons.push({ code: CareGapReasonCode.DATEOUTOFRANGE });
+                  reasonDetail.reasons.push({
+                    code: CareGapReasonCode.DATEOUTOFRANGE,
+                    path: duringFilter.attribute,
+                    reference: `${r.resourceType}/${r.id}`
+                  });
                 }
               });
             }
@@ -390,7 +394,11 @@ export function calculateReasonDetail(
 
                 // Use VALUEMISSING code if data is null
                 if (desiredAttr === null || desiredAttr === undefined) {
-                  reasonDetail.reasons.push({ code: CareGapReasonCode.VALUEMISSING });
+                  reasonDetail.reasons.push({
+                    code: CareGapReasonCode.VALUEMISSING,
+                    path: notNullFilter.attribute,
+                    reference: `${r.resourceType}/${r.id}`
+                  });
                 }
               });
             }

--- a/src/GapsInCareHelpers.ts
+++ b/src/GapsInCareHelpers.ts
@@ -387,7 +387,7 @@ export function calculateReasonDetail(
                     reasonDetail.reasons.push({
                       code: CareGapReasonCode.DATEOUTOFRANGE,
                       path: duringFilter.attribute,
-                      reference: `${resource.resourceType}/${resource.id}`
+                      reference: `${resource._json.resourceType}/${resource.id.value}`
                     });
                   }
                 }
@@ -406,7 +406,7 @@ export function calculateReasonDetail(
                   reasonDetail.reasons.push({
                     code: CareGapReasonCode.VALUEMISSING,
                     path: notNullFilter.attribute,
-                    reference: `${resource.resourceType}/${resource.id}`
+                    reference: `${resource._json.resourceType}/${resource.id.value}`
                   });
                 }
               } else {
@@ -427,7 +427,7 @@ export function calculateReasonDetail(
                       reasonDetail.reasons.push({
                         code: code,
                         path: (f as AttributeFilter).attribute,
-                        reference: `${resource.resourceType}/${resource.id}`
+                        reference: `${resource._json.resourceType}/${resource.id.value}`
                       });
                     } else {
                       reasonDetail.reasons.push({ code: code });

--- a/src/types/CQLExecFHIR.d.ts
+++ b/src/types/CQLExecFHIR.d.ts
@@ -6,4 +6,9 @@ declare module 'cql-exec-fhir' {
       loadBundles(bundles: R4.IBundle[]): void;
     }
   };
+  export class FHIRWrapper {
+    constructor(filePathOrXML: string);
+    wrap(fhirJson: R4, fhirResourceType?: string): any;
+    static FHIRv401(): FHIRWrapper;
+  }
 }

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -231,13 +231,26 @@ export interface GapsDataTypeQuery extends DataTypeQuery {
 }
 
 /**
- * Detailed information about a reason detail query
+ * Detailed information about a reason detail query. Contains multiple reasons for why the query failed.
  */
 export interface ReasonDetail {
   /** whether or not the query has a reason detail */
   hasReasonDetail: boolean;
-  /** codes that represent the causes of the reason detail */
-  reasonCodes: CareGapReasonCode[];
+  /** reasons with details on what was amiss about this query */
+  reasons: ReasonDetailData[];
+}
+
+/**
+ * Detailed data about a single reason why the query failed. This has the code and if there is a reference to a resource
+ * and the path in the resource the code is relevant for, that is included too.
+ */
+export interface ReasonDetailData {
+  /** The coded care gap reason. */
+  code: CareGapReasonCode;
+  /** The optional reference to the existing data on the patient with the gap. */
+  reference?: string;
+  /** The path in the resource were the gap exists. */
+  path?: string;
 }
 
 /**

--- a/test/GapsInCareHelpers.test.ts
+++ b/test/GapsInCareHelpers.test.ts
@@ -444,9 +444,9 @@ describe('Find Near Misses', () => {
             FHIRWrapper.FHIRv401().wrap({
               resourceType: 'Procedure',
               id: 'proc23',
-              performed: {
-                start: { value: '2000-01-01' },
-                end: { value: '2000-01-02' } // out of range of desired interval
+              performedPeriod: {
+                start: '2000-01-01',
+                end: '2000-01-02' // out of range of desired interval
               }
             })
           ]

--- a/test/GapsInCareHelpers.test.ts
+++ b/test/GapsInCareHelpers.test.ts
@@ -488,7 +488,7 @@ describe('Find Near Misses', () => {
 
       expect(r.reasonDetail).toBeDefined();
       expect(r.reasonDetail?.hasReasonDetail).toBe(true);
-      expect(r.reasonDetail?.reasonCodes).toEqual([CareGapReasonCode.INVALIDATTRIBUTE]);
+      expect(r.reasonDetail?.reasons).toEqual([{ code: CareGapReasonCode.INVALIDATTRIBUTE }]);
     });
 
     test('retrieve with false date filter should be code DATEOUTOFRANGE', () => {
@@ -522,7 +522,7 @@ describe('Find Near Misses', () => {
 
       expect(r.reasonDetail).toBeDefined();
       expect(r.reasonDetail?.hasReasonDetail).toBe(true);
-      expect(r.reasonDetail?.reasonCodes).toEqual([CareGapReasonCode.DATEOUTOFRANGE]);
+      expect(r.reasonDetail?.reasons).toEqual([{ code: CareGapReasonCode.DATEOUTOFRANGE }]);
     });
 
     test('retrieve with false not null filter should be code VALUEMISSING', () => {
@@ -548,7 +548,7 @@ describe('Find Near Misses', () => {
 
       expect(r.reasonDetail).toBeDefined();
       expect(r.reasonDetail?.hasReasonDetail).toBe(true);
-      expect(r.reasonDetail?.reasonCodes).toEqual([CareGapReasonCode.VALUEMISSING]);
+      expect(r.reasonDetail?.reasons).toEqual([{ code: CareGapReasonCode.VALUEMISSING }]);
     });
 
     test('retrieve with true not null filter should have default reason detail', () => {
@@ -579,7 +579,7 @@ describe('Find Near Misses', () => {
 
       expect(r.reasonDetail).toBeDefined();
       // If no specific reason details found, default is missing
-      expect(r.reasonDetail?.reasonCodes).toEqual([CareGapReasonCode.MISSING]);
+      expect(r.reasonDetail?.reasons).toEqual([{ code: CareGapReasonCode.MISSING }]);
     });
 
     test('retrieve with both false date and attribute filters should be code both INVALIDATTRIBUTE and DATEOUTOFRANGE', () => {
@@ -625,8 +625,8 @@ describe('Find Near Misses', () => {
 
       expect(r.reasonDetail).toBeDefined();
       expect(r.reasonDetail?.hasReasonDetail).toBe(true);
-      expect(r.reasonDetail?.reasonCodes?.sort()).toEqual(
-        [CareGapReasonCode.INVALIDATTRIBUTE, CareGapReasonCode.DATEOUTOFRANGE].sort()
+      expect(r.reasonDetail?.reasons?.sort()).toEqual(
+        [{ code: CareGapReasonCode.INVALIDATTRIBUTE }, { code: CareGapReasonCode.DATEOUTOFRANGE }].sort()
       );
     });
   });

--- a/test/GapsInCareHelpers.test.ts
+++ b/test/GapsInCareHelpers.test.ts
@@ -492,7 +492,9 @@ describe('Find Near Misses', () => {
 
       expect(r.reasonDetail).toBeDefined();
       expect(r.reasonDetail?.hasReasonDetail).toBe(true);
-      expect(r.reasonDetail?.reasons).toEqual([{ code: CareGapReasonCode.INVALIDATTRIBUTE }]);
+      expect(r.reasonDetail?.reasons).toEqual([
+        { code: CareGapReasonCode.INVALIDATTRIBUTE, path: 'status', reference: 'Procedure/proc23' }
+      ]);
     });
 
     test('retrieve with false date filter should be code DATEOUTOFRANGE', () => {
@@ -635,7 +637,7 @@ describe('Find Near Misses', () => {
       expect(r.reasonDetail?.hasReasonDetail).toBe(true);
       expect(r.reasonDetail?.reasons?.sort()).toEqual(
         [
-          { code: CareGapReasonCode.INVALIDATTRIBUTE },
+          { code: CareGapReasonCode.INVALIDATTRIBUTE, path: 'status', reference: 'Procedure/proc23' },
           { code: CareGapReasonCode.DATEOUTOFRANGE, path: 'performed.end', reference: 'Procedure/proc23' }
         ].sort()
       );

--- a/test/GapsInCareHelpers.test.ts
+++ b/test/GapsInCareHelpers.test.ts
@@ -385,7 +385,7 @@ describe('Find grouped queries', () => {
   });
 });
 
-describe('Find Near Misses', () => {
+describe('Find Reason Detail', () => {
   test('simple query/retrieve discrepancy near miss', () => {
     const gapQuery: GapsDataTypeQuery[] = BASE_CODE_RESULTS.map(q => ({
       ...q,

--- a/test/GapsInCareHelpers.test.ts
+++ b/test/GapsInCareHelpers.test.ts
@@ -441,6 +441,8 @@ describe('Find Near Misses', () => {
           final: FinalResult.TRUE,
           raw: [
             {
+              resourceType: 'Procedure',
+              id: 'proc23',
               performed: {
                 start: { value: '2000-01-01' },
                 end: { value: '2000-01-02' } // out of range of desired interval
@@ -455,6 +457,8 @@ describe('Find Near Misses', () => {
           final: FinalResult.TRUE,
           raw: [
             {
+              resourceType: 'Observation',
+              id: 'obs12',
               value: false
             }
           ]
@@ -522,7 +526,9 @@ describe('Find Near Misses', () => {
 
       expect(r.reasonDetail).toBeDefined();
       expect(r.reasonDetail?.hasReasonDetail).toBe(true);
-      expect(r.reasonDetail?.reasons).toEqual([{ code: CareGapReasonCode.DATEOUTOFRANGE }]);
+      expect(r.reasonDetail?.reasons).toEqual([
+        { code: CareGapReasonCode.DATEOUTOFRANGE, path: 'performed.end', reference: 'Procedure/proc23' }
+      ]);
     });
 
     test('retrieve with false not null filter should be code VALUEMISSING', () => {
@@ -548,7 +554,9 @@ describe('Find Near Misses', () => {
 
       expect(r.reasonDetail).toBeDefined();
       expect(r.reasonDetail?.hasReasonDetail).toBe(true);
-      expect(r.reasonDetail?.reasons).toEqual([{ code: CareGapReasonCode.VALUEMISSING }]);
+      expect(r.reasonDetail?.reasons).toEqual([
+        { code: CareGapReasonCode.VALUEMISSING, path: 'result', reference: 'Procedure/proc23' }
+      ]);
     });
 
     test('retrieve with true not null filter should have default reason detail', () => {
@@ -626,7 +634,10 @@ describe('Find Near Misses', () => {
       expect(r.reasonDetail).toBeDefined();
       expect(r.reasonDetail?.hasReasonDetail).toBe(true);
       expect(r.reasonDetail?.reasons?.sort()).toEqual(
-        [{ code: CareGapReasonCode.INVALIDATTRIBUTE }, { code: CareGapReasonCode.DATEOUTOFRANGE }].sort()
+        [
+          { code: CareGapReasonCode.INVALIDATTRIBUTE },
+          { code: CareGapReasonCode.DATEOUTOFRANGE, path: 'performed.end', reference: 'Procedure/proc23' }
+        ].sort()
       );
     });
   });

--- a/test/GapsInCareHelpers.test.ts
+++ b/test/GapsInCareHelpers.test.ts
@@ -1,5 +1,6 @@
 import { R4 } from '@ahryman40k/ts-fhir-types';
 import * as cql from 'cql-execution';
+import { FHIRWrapper } from 'cql-exec-fhir';
 import {
   processQueriesForGaps,
   generateDetectedIssueResources,
@@ -440,14 +441,14 @@ describe('Find Near Misses', () => {
           statementName: '',
           final: FinalResult.TRUE,
           raw: [
-            {
+            FHIRWrapper.FHIRv401().wrap({
               resourceType: 'Procedure',
               id: 'proc23',
               performed: {
                 start: { value: '2000-01-01' },
                 end: { value: '2000-01-02' } // out of range of desired interval
               }
-            }
+            })
           ]
         },
         {
@@ -456,11 +457,11 @@ describe('Find Near Misses', () => {
           statementName: '',
           final: FinalResult.TRUE,
           raw: [
-            {
+            FHIRWrapper.FHIRv401().wrap({
               resourceType: 'Observation',
               id: 'obs12',
               value: false
-            }
+            })
           ]
         }
       ],


### PR DESCRIPTION
# Summary
Captures the references to the resources that did not meet the requirements listed in the guidance response and includes that information in the extensions on the `reasonCode.coding`.

## New behavior
Gaps in care GuidanceResponses now have extensions to include the reference and path to the problem attribute that was the reason for the guidance.

## Code changes
- Reworked some of the reason detail calculation to not iterate over resources multiple times.
- Fixed gaps tests to use "real" `cql-exec-fhir` objects to match what data the real code will experience
- Added to `GapsDataTypeQuery` interface nested types to have space for collecting reference and path on the ReasonDetail.
- GuidanceResponse resource building now adds the extensions defined in the draft IG to include the resource reference and path in the reasonCode.

# Testing guidance
Run gaps on EXM130 from c-thon with denom test patient. Look for the `reasonCode` with "DateOutOfRange" in the GuidanceResponses. It should reference `Procedure/denom-EXM130-2` with path `performed.end`. Also test other measures with gaps output.