### PR TITLE
Switch to @types/fhir for FHIR TypeScript Definitions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,11 +21,3 @@ jobs:
         echo ${GITHUB_SHA}
         echo "gitleaks --repo=${REPO} -v --pretty --redact --commit=${GITHUB_SHA} --config=gitleaks.toml"
         ./gitleaks --repo=${REPO} -v --pretty --redact --commit=${GITHUB_SHA} --config=gitleaks.toml --access-token=${{ secrets.ACCESS_TOKEN_GITLEAKS }}
-    - name: Slack notification
-      if: failure()
-      env:
-        SLACK_WEBHOOK_GITLEAKS: ${{ secrets.SLACK_WEBHOOK_GITLEAKS }}
-      uses: Ilshidur/action-slack@master
-      with:
-        args: 'Potential Secrets found in: https://github.com/{{ GITHUB_REPOSITORY }}/commit/{{ GITHUB_SHA }} Link to build with full gitleaks output: https://github.com/{{ GITHUB_REPOSITORY }}/commit/{{ GITHUB_SHA }}/checks'
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,16 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@ahryman40k/ts-fhir-types": {
-      "version": "4.0.34",
-      "resolved": "https://registry.npmjs.org/@ahryman40k/ts-fhir-types/-/ts-fhir-types-4.0.34.tgz",
-      "integrity": "sha512-G/o0wmYoqOfvgSids46U6ge767OjQfNkr8lUcqblZsLpOZF/xiXE46eXmfmnxzjYD2FvlpUQM4LxmK4f0feWkA==",
-      "requires": {
-        "fp-ts": "^2.8.3",
-        "io-ts": "^2.0.0",
-        "reflect-metadata": "^0.1.13"
-      }
-    },
     "@babel/cli": {
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.14.5.tgz",
@@ -3735,6 +3725,11 @@
       "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
       "dev": true
     },
+    "@types/fhir": {
+      "version": "0.0.34",
+      "resolved": "https://registry.npmjs.org/@types/fhir/-/fhir-0.0.34.tgz",
+      "integrity": "sha512-8pCGwxYMKbxHzFmekh4HnhLvolDB+Tj61LT6yFkL+ERSFtbUvEdvcxMip52pd0vW4PLUyUk1otRvZq07HKCSzQ=="
+    },
     "@types/graceful-fs": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.4.tgz",
@@ -5761,11 +5756,6 @@
         "mime-types": "^2.1.12"
       }
     },
-    "fp-ts": {
-      "version": "2.8.5",
-      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.8.5.tgz",
-      "integrity": "sha512-g6do+Q/IQsxgsd2qU6+QnAbZaPR533seIbFyLGqWSxhNX4+F+cY37QdaYmMUOzekLOv/yg/2f15tc26tzDatgw=="
-    },
     "fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -6076,11 +6066,6 @@
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
       "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
       "dev": true
-    },
-    "io-ts": {
-      "version": "2.2.12",
-      "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-2.2.12.tgz",
-      "integrity": "sha512-pZh43E3xs1RUmv3voC58Mbb6Ihjo3UdDU6WWi578Zpe2BxVue1SlSQCioSymZxk9HoXa370nSfFzp5LrLA2F8g=="
     },
     "ip-regex": {
       "version": "2.1.0",
@@ -8696,11 +8681,6 @@
       "requires": {
         "resolve": "^1.1.6"
       }
-    },
-    "reflect-metadata": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
-      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
     },
     "regenerate": {
       "version": "1.4.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8470,9 +8470,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "performance-now": {
       "version": "2.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3728,7 +3728,8 @@
     "@types/fhir": {
       "version": "0.0.34",
       "resolved": "https://registry.npmjs.org/@types/fhir/-/fhir-0.0.34.tgz",
-      "integrity": "sha512-8pCGwxYMKbxHzFmekh4HnhLvolDB+Tj61LT6yFkL+ERSFtbUvEdvcxMip52pd0vW4PLUyUk1otRvZq07HKCSzQ=="
+      "integrity": "sha512-8pCGwxYMKbxHzFmekh4HnhLvolDB+Tj61LT6yFkL+ERSFtbUvEdvcxMip52pd0vW4PLUyUk1otRvZq07HKCSzQ==",
+      "dev": true
     },
     "@types/graceful-fs": {
       "version": "4.1.4",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build/*"
   ],
   "dependencies": {
-    "@ahryman40k/ts-fhir-types": "^4.0.32",
+    "@types/fhir": "0.0.34",
     "atob": "^2.1.2",
     "axios": "^0.21.1",
     "commander": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "build/*"
   ],
   "dependencies": {
-    "@types/fhir": "0.0.34",
     "atob": "^2.1.2",
     "axios": "^0.21.1",
     "commander": "^6.1.0",
@@ -23,6 +22,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
+    "@types/fhir": "0.0.34",
     "@types/handlebars": "^4.1.0",
     "@types/jest": "^26.0.5",
     "@types/lodash": "^4.14.170",

--- a/src/calculation/ClauseResultsBuilder.ts
+++ b/src/calculation/ClauseResultsBuilder.ts
@@ -5,7 +5,7 @@ import { ELM, LibraryDependencyInfo } from '../types/ELMTypes';
 import * as cql from '../types/CQLTypes';
 import * as cqlSystemTypes from 'cql-execution';
 import moment from 'moment';
-import { R4 } from '@ahryman40k/ts-fhir-types';
+
 import { FinalResult, PopulationType, Relevance } from '../types/Enums';
 import {
   ClauseResult,
@@ -41,20 +41,20 @@ import {
  * determine the relevance of the population defining statement and its dependent statements.
  *
  * @public
- * @param {R4.IMeasure} measure - The measure.
+ * @param {fhir4.Measure} measure - The measure.
  * @param {PopulationResult[]} populationRelevanceSet - The population relevance results, used at the starting point.
  * @param {string} mainLibraryId - The identifier of the main library.
  * @param {ELM[]} elmLibraries - All ELM libraries for the measure.
- * @param {R4.IMeasure_Group} populationGroup - The population group being calculated.
+ * @param {fhir4.MeasureGroup} populationGroup - The population group being calculated.
  * @param {boolean} calculateSDEs - Wether or not to treat SDEs as calculed/relevant or not.
  * @returns {StatementResult[]} The StatementResults list for each statement with it its relevance status populated.
  */
 export function buildStatementRelevanceMap(
-  measure: R4.IMeasure,
+  measure: fhir4.Measure,
   populationRelevanceSet: PopulationResult[],
   mainLibraryId: string,
   elmLibraries: ELM[],
-  populationGroup: R4.IMeasure_Group,
+  populationGroup: fhir4.MeasureGroup,
   calculateSDEs: boolean
 ): StatementResult[] {
   // build statement results defaulting to not applicable (NA)
@@ -222,7 +222,7 @@ export function getStatementResult(
  * This function relies very heavily on the StatementResult `relevance` field to determine the final results.
  *
  * @public
- * @param {R4.IMeasure} measure - The measure.
+ * @param {fhir4.Measure} measure - The measure.
  * @param {ELM[]} elmLibraries - List of all ELM Library JSONs.
  * @param {any} rawClauseResults - The raw clause results from the calculation engine.
  * @param {StatementResult[]} statementResults - The `statement_relevance` map. Used to determine if they were hit or not.
@@ -230,7 +230,7 @@ export function getStatementResult(
  * @returns {object} Object with the statement_results and clause_results structures, keyed as such.
  */
 export function buildStatementAndClauseResults(
-  measure: R4.IMeasure,
+  measure: fhir4.Measure,
   elmLibraries: ELM[],
   rawClauseResults: cql.LocalIdResults,
   statementResults: StatementResult[],
@@ -589,7 +589,7 @@ export function doesResultPass(result: any | null): boolean {
  * @returns {PopulationResult[]} List denoting if population calculation was considered/relevant in any episode
  */
 export function buildPopulationRelevanceForAllEpisodes(
-  populationGroup: R4.IMeasure_Group,
+  populationGroup: fhir4.MeasureGroup,
   episodeResultsSet: EpisodeResults[]
 ): PopulationResult[] {
   const masterRelevanceResults: PopulationResult[] =
@@ -733,7 +733,7 @@ export function buildPopulationRelevanceMap(results: PopulationResult[]): Popula
 }
 
 export function buildPopulationGroupRelevanceMap(
-  group: R4.IMeasure_Group,
+  group: fhir4.MeasureGroup,
   results: DetailedPopulationGroupResult
 ): PopulationResult[] {
   // Episode of care measure
@@ -789,7 +789,7 @@ export function createOrSetResult(
 }
 
 // Get raw results of matching SDE expressions for each SDE in the Measure
-export function getSDEValues(measure: R4.IMeasure, statementResults: cql.StatementResults): SDEResult[] {
+export function getSDEValues(measure: fhir4.Measure, statementResults: cql.StatementResults): SDEResult[] {
   const results: SDEResult[] = [];
   if (measure.supplementalData) {
     measure.supplementalData.forEach(sde => {

--- a/src/calculation/ClauseResultsHelpers.ts
+++ b/src/calculation/ClauseResultsHelpers.ts
@@ -1,5 +1,4 @@
 import { ELM, ELMStatement } from '../types/ELMTypes';
-import { R4 } from '@ahryman40k/ts-fhir-types';
 
 /**
  * Finds all localIds in a statement by it's library and statement name.
@@ -314,12 +313,12 @@ export function isStatementFunction(library: ELM, statementName: string): boolea
 /**
  * Figure out if a statement is in a Supplemental Data Element given the statement name.
  * @public
- * @param {R4.IMeasure_SupplementalData[]} supplementalDataElements
+ * @param {fhir4.MeasureSupplementalData[]} supplementalDataElements
  * @param {string} statementName - The statement to search for.
  * @return {boolean} Statement does or does not belong to a Supplemental Data Element.
  */
 export function isSupplementalDataElementStatement(
-  supplementalDataElements: R4.IMeasure_SupplementalData[] | undefined,
+  supplementalDataElements: fhir4.MeasureSupplementalData[] | undefined,
   statementName: string
 ): boolean {
   if (supplementalDataElements != undefined) {

--- a/src/calculation/DetailedResultsBuilder.ts
+++ b/src/calculation/DetailedResultsBuilder.ts
@@ -1,4 +1,3 @@
-import { R4 } from '@ahryman40k/ts-fhir-types';
 import { DetailedPopulationGroupResult, EpisodeResults, PopulationResult, StratifierResult } from '../types/Calculator';
 import * as MeasureBundleHelpers from '../helpers/MeasureBundleHelpers';
 import { getResult, hasResult, setResult, createOrSetResult } from './ClauseResultsBuilder';
@@ -11,15 +10,15 @@ import * as cql from '../types/CQLTypes';
  * calculator. This creates the DetailedPopulationGroupResult for the patient that will be filed my most of the
  * results processing functions.
  *
- * @param {R4.IMeasure} measure - The measure we are getting the values for.
- * @param {R4.IMeasure_Group} populationGroup - The population group that we are creating results to.
+ * @param {fhir4.Measure} measure - The measure we are getting the values for.
+ * @param {fhir4.MeasureGroup} populationGroup - The population group that we are creating results to.
  * @param {cql.StatementResults} patientResults - The raw results object from the calculation engine for a patient.
  * @returns {DetailedPopulationGroupResult} The population group results object with the populationResults, stratifierResults,
  *   and episodeResults (if episode of care measure) populated.
  */
 export function createPopulationValues(
-  measure: R4.IMeasure,
-  populationGroup: R4.IMeasure_Group,
+  measure: fhir4.Measure,
+  populationGroup: fhir4.MeasureGroup,
   patientResults: cql.StatementResults
 ): DetailedPopulationGroupResult {
   let populationResults: PopulationResult[] = [];
@@ -151,12 +150,12 @@ export function handlePopulationValues(populationResults: PopulationResult[]): P
 /**
  * Create patient population values (aka results) for all populations in the population group using the results from the
  * calculator.
- * @param {R4.IMeasure_Group} populationGroup - The population group we are getting the values for.
+ * @param {fhir4.MeasureGroup} populationGroup - The population group we are getting the values for.
  * @param {cql.StatementResults} patientResults - The raw results object for a patient from the calculation engine.
  * @returns {PopulationResult[]} The population results list.
  */
 export function createPatientPopulationValues(
-  populationGroup: R4.IMeasure_Group,
+  populationGroup: fhir4.MeasureGroup,
   patientResults: cql.StatementResults
 ): {
   populationResults: PopulationResult[];
@@ -223,13 +222,13 @@ function isStatementValueTruthy(value: any): boolean {
 /**
  * Create population results for all episodes using the results from the calculator. This is
  * used only for the episode of care measures.
- * @param {R4.IMeasure_Group} populationGroup - The population group we are getting the values for.
+ * @param {fhir4.MeasureGroup} populationGroup - The population group we are getting the values for.
  * @param {cql.StatementResults} patientResults - The raw results object for the patient from the calculation engine.
  * @returns {EpisodeResults[]} The episode results list. Structure with episode id population results for each episode.
  *   If this is a continuous variable measure the observations are included.
  */
 export function createEpisodePopulationValues(
-  populationGroup: R4.IMeasure_Group,
+  populationGroup: fhir4.MeasureGroup,
   patientResults: cql.StatementResults
 ): EpisodeResults[] {
   const episodeResultsSet: EpisodeResults[] = [];
@@ -318,14 +317,14 @@ export function createEpisodePopulationValues(
  *
  * @param {any} rawEpisodeResults - Raw population defining statement result. This result should be a list.
  * @param {EpisodeResults[]} episodeResultsSet - EpisodeResults set to populate.
- * @param {R4.IMeasure_Group} populationGroup - The population group. Used to populate default values for a new encounter.
+ * @param {fhir4.MeasureGroup} populationGroup - The population group. Used to populate default values for a new encounter.
  * @param {PopulationType} populationType - If this is a regular population the type must be provided.
  * @param {string} strataCode - If this is a stratifier result, the code of the strata must be provided.
  */
 function createOrSetValueOfEpisodes(
   rawEpisodeResults: any,
   episodeResultsSet: EpisodeResults[],
-  populationGroup: R4.IMeasure_Group,
+  populationGroup: fhir4.MeasureGroup,
   populationType?: PopulationType,
   strataCode?: string
 ): void {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env ts-node --files
 
-import { R4 } from '@ahryman40k/ts-fhir-types';
 import { program } from 'commander';
 import fs from 'fs';
 import path from 'path';
@@ -45,12 +44,12 @@ program
   .option('-c, --cache-valuesets', 'Whether or not to cache ValueSets retrieved from the ValueSet service', false)
   .parse(process.argv);
 
-function parseBundle(filePath: string): R4.IBundle {
+function parseBundle(filePath: string): fhir4.Bundle {
   const contents = fs.readFileSync(filePath, 'utf8');
-  return JSON.parse(contents) as R4.IBundle;
+  return JSON.parse(contents) as fhir4.Bundle;
 }
 
-function getCachedValueSets(cacheDir: string): R4.IValueSet[] {
+function getCachedValueSets(cacheDir: string): fhir4.ValueSet[] {
   if (fs.existsSync(cacheDir)) {
     return fs.readdirSync(cacheDir).map(vs => JSON.parse(fs.readFileSync(path.join(cacheDir, vs), 'utf8')));
   }
@@ -59,10 +58,10 @@ function getCachedValueSets(cacheDir: string): R4.IValueSet[] {
 }
 
 async function calc(
-  measureBundle: R4.IBundle,
-  patientBundles: R4.IBundle[],
+  measureBundle: fhir4.Bundle,
+  patientBundles: fhir4.Bundle[],
   calcOptions: CalculationOptions,
-  valueSetCache: R4.IValueSet[] = []
+  valueSetCache: fhir4.ValueSet[] = []
 ): Promise<CalculatorFunctionOutput> {
   let result;
   if (program.outputType === 'raw') {
@@ -86,7 +85,7 @@ async function calc(
 
 const measureBundle = parseBundle(path.resolve(program.measureBundle));
 
-let patientBundles: R4.IBundle[];
+let patientBundles: fhir4.Bundle[];
 if (program.outputType !== 'dataRequirements') {
   // Since patient bundles are no longer a mandatory CLI option, we should check if we were given any before
   if (!program.patientBundles) {
@@ -177,7 +176,7 @@ calc(
       if (!fs.existsSync('./cache/terminology')) {
         fs.mkdirSync('./cache/terminology/', { recursive: true });
       }
-      (result.valueSetCache as R4.IValueSet[]).forEach(vs => {
+      (result.valueSetCache as fhir4.ValueSet[]).forEach(vs => {
         fs.writeFileSync(`./cache/terminology/${vs.id}.json`, JSON.stringify(vs), 'utf8');
       });
     }

--- a/src/execution/Execution.ts
+++ b/src/execution/Execution.ts
@@ -1,4 +1,3 @@
-import { R4 } from '@ahryman40k/ts-fhir-types';
 import { CalculationOptions, RawExecutionData, DebugOutput } from '../types/Calculator';
 
 // import { PatientSource } from 'cql-exec-fhir';
@@ -11,10 +10,10 @@ import { generateELMJSONFunction } from '../calculation/DetailedResultsBuilder';
 import { ValueSetResolver } from './ValueSetResolver';
 
 export async function execute(
-  measureBundle: R4.IBundle,
-  patientBundles: R4.IBundle[],
+  measureBundle: fhir4.Bundle,
+  patientBundles: fhir4.Bundle[],
   options: CalculationOptions,
-  valueSetCache: R4.IValueSet[] = [],
+  valueSetCache: fhir4.ValueSet[] = [],
   debugObject?: DebugOutput
 ): Promise<RawExecutionData> {
   // Determine "root" library by looking at which lib is referenced by populations, and pull out the ELM
@@ -26,8 +25,8 @@ export async function execute(
   const measure = MeasureBundleHelpers.extractMeasureFromBundle(measureBundle);
 
   // check for any missing valuesets
-  const valueSets: R4.IValueSet[] = [];
-  const newCache: R4.IValueSet[] = [];
+  const valueSets: fhir4.ValueSet[] = [];
+  const newCache: fhir4.ValueSet[] = [];
 
   // Pass in existing cache to attempt any missing resolutions
   const missingVS = getMissingDependentValuesets(measureBundle, [...valueSetCache]);
@@ -55,7 +54,7 @@ export async function execute(
 
   measureBundle.entry?.forEach(e => {
     if (e.resource?.resourceType === 'ValueSet') {
-      valueSets.push(e.resource as R4.IValueSet);
+      valueSets.push(e.resource as fhir4.ValueSet);
     }
   });
 

--- a/src/execution/ValueSetHelper.ts
+++ b/src/execution/ValueSetHelper.ts
@@ -1,4 +1,3 @@
-import { R4 } from '@ahryman40k/ts-fhir-types';
 import { CQLCode, ValueSetMap } from '../types/CQLTypes';
 import moment from 'moment';
 
@@ -12,7 +11,7 @@ import moment from 'moment';
  * @param valueSetResources FHIR ValueSets.
  * @returns The value set DB structure needed for the cql-execution CodeService.
  */
-export function valueSetsForCodeService(valueSetResources: R4.IValueSet[]): ValueSetMap {
+export function valueSetsForCodeService(valueSetResources: fhir4.ValueSet[]): ValueSetMap {
   const valueSets: ValueSetMap = {};
   let valueSetId: string;
   let version: string;
@@ -63,7 +62,7 @@ export function valueSetsForCodeService(valueSetResources: R4.IValueSet[]): Valu
   return valueSets;
 }
 
-function getHierarchicalCodes(contains: R4.IValueSet_Contains[]): CQLCode[] {
+function getHierarchicalCodes(contains: fhir4.ValueSetExpansionContains[]): CQLCode[] {
   const codes: CQLCode[] = [];
   contains.forEach(contain => {
     if (!contain.abstract && !contain.inactive && contain.code && contain.system) {
@@ -95,11 +94,14 @@ export function parseTimeStringAsUTCConvertingToEndOfYear(timeValue: string): Da
  * Collates dependent valuesets from a measure by going through all of the measure bundle's libraries' dataCriteria's codeFilters' valueset.
  * Then finds all valuesets that are not already contained in the measure bundle.
  *
- * @param {R4.IBundle} measureBundle - A measure bundle object that contains all libraries and valuesets used by the measure
- * @param {R4.IValueSet[]} valueSetCache - Cache of existing valueset objects on disk to include in lookup
+ * @param {fhir4.Bundle} measureBundle - A measure bundle object that contains all libraries and valuesets used by the measure
+ * @param {fhir4.ValueSet[]} valueSetCache - Cache of existing valueset objects on disk to include in lookup
  * @returns {string[]} An array of all dependent valueset urls in the measure that are used by the measure's libraries but not contained in the measure bundle
  */
-export function getMissingDependentValuesets(measureBundle: R4.IBundle, valueSetCache: R4.IValueSet[] = []): string[] {
+export function getMissingDependentValuesets(
+  measureBundle: fhir4.Bundle,
+  valueSetCache: fhir4.ValueSet[] = []
+): string[] {
   if (!measureBundle.entry) {
     throw new Error('Expected measure bundle to contain entries');
   }
@@ -109,7 +111,7 @@ export function getMissingDependentValuesets(measureBundle: R4.IBundle, valueSet
 
   // create an array of valueset urls
   const vsURLs: string[] = libraryEntries.reduce((acc, lib) => {
-    const libraryResource = lib.resource as R4.ILibrary;
+    const libraryResource = lib.resource as fhir4.Library;
     if (!libraryResource || !libraryResource.dataRequirement || !(libraryResource.dataRequirement.length > 0)) {
       throw new Error('Expected library entry to have resource with dataRequirements that have codeFilters');
     }
@@ -136,7 +138,7 @@ export function getMissingDependentValuesets(measureBundle: R4.IBundle, valueSet
   // full array of all valueset URLs present across measureBundle and cache
   const existingValueSets = measureBundle.entry
     .filter(e => e.resource?.resourceType === 'ValueSet')
-    .map(e => e.resource as R4.IValueSet)
+    .map(e => e.resource as fhir4.ValueSet)
     .concat(valueSetCache)
     .map(vs => vs.url as string);
 

--- a/src/execution/ValueSetResolver.ts
+++ b/src/execution/ValueSetResolver.ts
@@ -1,4 +1,3 @@
-import { R4 } from '@ahryman40k/ts-fhir-types';
 import axios, { AxiosInstance } from 'axios';
 import { isVSACUrl, normalizeCanonical } from './VSACHelper';
 
@@ -23,8 +22,8 @@ export class ValueSetResolver {
     return Buffer.from(`apikey:${this.apiKey}`).toString('base64');
   }
 
-  async getExpansionForValuesetUrls(urls: string[]): Promise<[R4.IValueSet[], string[]]> {
-    const valuesets: R4.IValueSet[] = [];
+  async getExpansionForValuesetUrls(urls: string[]): Promise<[fhir4.ValueSet[], string[]]> {
+    const valuesets: fhir4.ValueSet[] = [];
     const errors: string[] = [];
 
     // Make the actual requests. We use 'for.. of' here because we want to send requests individually
@@ -39,7 +38,7 @@ export class ValueSetResolver {
           normalizedUrl = normalizeCanonical(url) || url;
         }
 
-        const res = await this.instance.get<R4.IValueSet>(`${normalizedUrl}/$expand`);
+        const res = await this.instance.get<fhir4.ValueSet>(`${normalizedUrl}/$expand`);
         valuesets.push(res.data);
       } catch (e) {
         errors.push(`Valueset with URL ${normalizedUrl} could not be retrieved. Reason: ${e.message}`);
@@ -56,7 +55,7 @@ export class ValueSetResolver {
     return [valuesets, missingValuesets];
   }
 
-  findMissingValuesets(missingVSURLs: string[], expansions: R4.IValueSet[]): string[] {
+  findMissingValuesets(missingVSURLs: string[], expansions: fhir4.ValueSet[]): string[] {
     const stillMissingValuesets: string[] = [...missingVSURLs];
     // remove any valuesets we got from their URLs from the "missing" list
     expansions.forEach(vs => {

--- a/src/gaps/QueryFilterParser.ts
+++ b/src/gaps/QueryFilterParser.ts
@@ -1,4 +1,3 @@
-import { R4 } from '@ahryman40k/ts-fhir-types';
 import cql from 'cql-execution';
 import {
   ELM,
@@ -66,7 +65,7 @@ export function parseQueryInfo(
   allELM: ELM[],
   queryLocalId: string | undefined,
   parameters: { [key: string]: any } = {},
-  patient: R4.IPatient
+  patient: fhir4.Patient
 ): QueryInfo {
   if (!queryLocalId) {
     throw new Error('QueryLocalId was not provided');
@@ -218,7 +217,7 @@ export function interpretExpression(
   expression: ELMExpression,
   library: ELM,
   parameters: any,
-  patient: R4.IPatient
+  patient: fhir4.Patient
 ): AnyFilter {
   let returnFilter: AnyFilter = {
     type: 'unknown',
@@ -308,7 +307,7 @@ export function findPropertyUsage(expression: any, unknownLocalId?: string): Unk
  * @param patient The patient resource.
  * @returns The filter tree for this and expression.
  */
-export function interpretAnd(andExpression: ELMAnd, library: ELM, parameters: any, patient: R4.IPatient): AndFilter {
+export function interpretAnd(andExpression: ELMAnd, library: ELM, parameters: any, patient: fhir4.Patient): AndFilter {
   const andInfo: AndFilter = { type: 'and', children: [] };
   if (andExpression.operand[0].type == 'And') {
     andInfo.children.push(...interpretAnd(andExpression.operand[0] as ELMAnd, library, parameters, patient).children);
@@ -333,7 +332,7 @@ export function interpretAnd(andExpression: ELMAnd, library: ELM, parameters: an
  * @param patient The patient resource.
  * @returns The filter tree for this or expression.
  */
-export function interpretOr(orExpression: ELMOr, library: ELM, parameters: any, patient: R4.IPatient): OrFilter {
+export function interpretOr(orExpression: ELMOr, library: ELM, parameters: any, patient: fhir4.Patient): OrFilter {
   const orInfo: OrFilter = { type: 'or', children: [] };
   if (orExpression.operand[0].type == 'Or') {
     orInfo.children.push(...interpretOr(orExpression.operand[0] as ELMOr, library, parameters, patient).children);
@@ -497,10 +496,10 @@ export function interpretEquivalent(equal: ELMEquivalent, library: ELM): EqualsF
  * @param library The library elm the concept should be found in.
  * @returns A list of codings in the concept
  */
-export function getCodesInConcept(name: string, library: ELM): R4.ICoding[] {
+export function getCodesInConcept(name: string, library: ELM): fhir4.Coding[] {
   const concept = library.library.concepts?.def.find(concept => concept.name === name);
   if (concept) {
-    const codes: R4.ICoding[] = [];
+    const codes: fhir4.Coding[] = [];
     concept.code.map(codeRef => {
       const code = library.library.codes?.def.find(code => code.name == codeRef.name);
       if (code) {
@@ -782,7 +781,7 @@ export function interpretGreaterOrEqual(
   greaterOrEqualExpr: ELMGreaterOrEqual,
   library: ELM,
   parameters: any,
-  patient: R4.IPatient
+  patient: fhir4.Patient
 ): AnyFilter {
   // look at first param if it is function ref to calendar age in years at.
   const withError: GracefulError = { message: 'An unknown error occured while interpretting greater or equal filter' };

--- a/src/helpers/DataRequirementHelpers.ts
+++ b/src/helpers/DataRequirementHelpers.ts
@@ -1,4 +1,3 @@
-import { R4 } from '@ahryman40k/ts-fhir-types';
 import { DataTypeQuery } from '../types/Calculator';
 import { GracefulError } from '../types/GracefulError';
 import {
@@ -39,7 +38,7 @@ export function flattenFilters(filter: AnyFilter): AnyFilter[] {
 export function generateDetailedCodeFilter(
   filter: EqualsFilter | InFilter,
   dataType?: string
-): R4.IDataRequirement_CodeFilter | null {
+): fhir4.DataRequirementCodeFilter | null {
   const system: string | null = dataType ? codeLookup(dataType, filter.attribute) : null;
   if (filter.type === 'equals') {
     const equalsFilter = filter as EqualsFilter;
@@ -82,7 +81,7 @@ export function generateDetailedCodeFilter(
  * @param filter the "during" filter to map
  * @returns dateFilter for the dateFilter list of dataRequirement
  */
-export function generateDetailedDateFilter(filter: DuringFilter): R4.IDataRequirement_DateFilter {
+export function generateDetailedDateFilter(filter: DuringFilter): fhir4.DataRequirementDateFilter {
   return {
     path: filter.attribute,
     valuePeriod: { start: filter.valuePeriod.start, end: filter.valuePeriod.end }
@@ -95,7 +94,7 @@ export function generateDetailedDateFilter(filter: DuringFilter): R4.IDataRequir
  * @param filter the filter to map
  * @returns extension for the valueFilter list of dataRequirement
  */
-export function generateDetailedValueFilter(filter: Filter): R4.IExtension | GracefulError {
+export function generateDetailedValueFilter(filter: Filter): fhir4.Extension | GracefulError {
   if (filter.type === 'notnull') {
     const notnullFilter = filter as NotNullFilter;
     return {
@@ -117,9 +116,9 @@ export function generateDetailedValueFilter(filter: Filter): R4.IExtension | Gra
  * that would be requested from a FHIR server for that query.
  * Currently supports
  * @param retrieve a DataTypeQuery that represents a retrieve for a FHIR Resource with certain attributes
- * @returns R4.IDataRequirement with as much attribute data as we can add
+ * @returns fhir4.DataRequirement with as much attribute data as we can add
  */
-export function generateDataRequirement(retrieve: DataTypeQuery): R4.IDataRequirement {
+export function generateDataRequirement(retrieve: DataTypeQuery): fhir4.DataRequirement {
   if (retrieve.valueSet) {
     return {
       type: retrieve.dataType,
@@ -136,7 +135,7 @@ export function generateDataRequirement(retrieve: DataTypeQuery): R4.IDataRequir
       codeFilter: [
         {
           path: retrieve.path,
-          code: [retrieve.code as R4.ICoding]
+          code: [retrieve.code as fhir4.Coding]
         }
       ]
     };

--- a/src/types/CQLExecFHIR.d.ts
+++ b/src/types/CQLExecFHIR.d.ts
@@ -1,9 +1,8 @@
 declare module 'cql-exec-fhir' {
-  import { R4 } from '@ahryman40k/ts-fhir-types';
   export const PatientSource = {
     FHIRv401: class {
       constructor();
-      loadBundles(bundles: R4.IBundle[]): void;
+      loadBundles(bundles: fhir4.Bundle[]): void;
     }
   };
   export class FHIRWrapper {

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -1,4 +1,3 @@
-import { R4 } from '@ahryman40k/ts-fhir-types';
 import { PopulationType, FinalResult, Relevance, CareGapReasonCode } from './Enums';
 import * as cql from './CQLTypes';
 import { ELM } from './ELMTypes';
@@ -54,7 +53,7 @@ export interface RawExecutionData {
     [key: string]: any;
   };
   /** Cache of VSAC ValueSets */
-  valueSetCache?: R4.IValueSet[];
+  valueSetCache?: fhir4.ValueSet[];
 }
 
 /**
@@ -64,13 +63,13 @@ export interface ExecutionResult {
   /** ID of the patient this calculation result belongs to. */
   patientId: string;
   /** FHIR MeasureReport of type 'individual' for this patient. */
-  measureReport?: R4.IMeasureReport;
+  measureReport?: fhir4.MeasureReport;
   /** Detailed results for each population group and stratifier. */
   detailedResults?: DetailedPopulationGroupResult[];
   /** SDE values, if specified for calculation */
   supplementalData?: SDEResult[];
   /** Resources evaluated during execution */
-  evaluatedResource?: R4.IResourceList[];
+  evaluatedResource?: fhir4.Resource[];
 }
 
 /**
@@ -278,10 +277,10 @@ export interface DebugOutput {
   html?: { name: string; html: string }[];
   rawResults?: cql.Results | string;
   detailedResults?: ExecutionResult[];
-  measureReports?: R4.IMeasureReport[];
+  measureReports?: fhir4.MeasureReport[];
   gaps?: {
     retrieves?: DataTypeQuery[];
-    bundle?: R4.IBundle;
+    bundle?: fhir4.Bundle;
   };
 }
 
@@ -291,14 +290,14 @@ export interface DebugOutput {
 export interface CalculatorFunctionOutput {
   results:
     | ExecutionResult[]
-    | R4.IMeasureReport
-    | R4.IMeasureReport[]
+    | fhir4.MeasureReport
+    | fhir4.MeasureReport[]
     | cql.Results
     | string
-    | R4.IBundle
-    | R4.ILibrary;
+    | fhir4.Bundle
+    | fhir4.Library;
   debugOutput?: DebugOutput;
-  valueSetCache?: R4.IValueSet[];
+  valueSetCache?: fhir4.ValueSet[];
   withErrors?: GracefulError[];
 }
 
@@ -316,21 +315,21 @@ export interface CalculationOutput extends CalculatorFunctionOutput {
  * dataType for calculateMeasureReports() function
  */
 export interface MRCalculationOutput extends CalculatorFunctionOutput {
-  results: R4.IMeasureReport | R4.IMeasureReport[];
+  results: fhir4.MeasureReport | fhir4.MeasureReport[];
 }
 
 /**
  * dataType for calculateAggregateMeasureReports() function
  */
 export interface AMRCalculationOutput extends MRCalculationOutput {
-  results: R4.IMeasureReport;
+  results: fhir4.MeasureReport;
 }
 
 /**
  * dataType for calculateIndividualMeasureReports() function
  */
 export interface IMRCalculationOutput extends MRCalculationOutput {
-  results: R4.IMeasureReport[];
+  results: fhir4.MeasureReport[];
 }
 
 /**
@@ -344,12 +343,12 @@ export interface RCalculationOutput extends CalculatorFunctionOutput {
  * dataType for calculateGapsInCare() function
  */
 export interface GICCalculationOutput extends CalculatorFunctionOutput {
-  results: R4.IBundle;
+  results: fhir4.Bundle;
 }
 
 /**
  * dataType for calculateDataRequirements() function
  */
 export interface DRCalculationOutput extends Omit<CalculatorFunctionOutput, 'valueSetCache'> {
-  results: R4.ILibrary;
+  results: fhir4.Library;
 }

--- a/src/types/QueryFilterTypes.ts
+++ b/src/types/QueryFilterTypes.ts
@@ -1,4 +1,3 @@
-import { R4 } from '@ahryman40k/ts-fhir-types';
 import * as cql from 'cql-execution';
 import { GracefulError } from './GracefulError';
 
@@ -77,7 +76,7 @@ export interface AttributeFilter extends Filter {
  */
 export interface InFilter extends AttributeFilter {
   type: 'in';
-  valueCodingList?: R4.ICoding[];
+  valueCodingList?: fhir4.Coding[];
   valueList?: (string | number)[];
 }
 

--- a/test/ClauseResultsBuilder.test.ts
+++ b/test/ClauseResultsBuilder.test.ts
@@ -1,12 +1,12 @@
 import * as ClauseResultsBuilder from '../src/calculation/ClauseResultsBuilder';
 import { getJSONFixture, getELMFixture } from './helpers/testHelpers';
-import { R4 } from '@ahryman40k/ts-fhir-types';
+
 import { PopulationResult, StatementResult } from '../src/types/Calculator';
 import { PopulationType, Relevance, FinalResult } from '../src/types/Enums';
 import * as cql from '../src/types/CQLTypes';
 
-type MeasureWithGroup = R4.IMeasure & {
-  group: R4.IMeasure_Group[];
+type MeasureWithGroup = fhir4.Measure & {
+  group: fhir4.MeasureGroup[];
 };
 
 const simpleMeasure = getJSONFixture('measure/simple-measure.json') as MeasureWithGroup;

--- a/test/DataRequirementHelpers.test.ts
+++ b/test/DataRequirementHelpers.test.ts
@@ -7,7 +7,7 @@ import {
   NotNullFilter,
   UnknownFilter
 } from '../src/types/QueryFilterTypes';
-import { R4 } from '@ahryman40k/ts-fhir-types';
+
 import { DataTypeQuery } from '../src/types/Calculator';
 import { GracefulError } from '../src/types/GracefulError';
 
@@ -97,7 +97,7 @@ describe('DataRequirementHelpers', () => {
         value: 'value-1'
       };
 
-      const expectedCodeFilter: R4.IDataRequirement_CodeFilter = {
+      const expectedCodeFilter: fhir4.DataRequirementCodeFilter = {
         path: 'attr-1',
         code: [
           {
@@ -117,7 +117,7 @@ describe('DataRequirementHelpers', () => {
         valueList: ['value-1', 'value-2', 'value-3']
       };
 
-      const expectedCodeFilter: R4.IDataRequirement_CodeFilter = {
+      const expectedCodeFilter: fhir4.DataRequirementCodeFilter = {
         path: 'attr-1',
         code: [
           {
@@ -159,7 +159,7 @@ describe('DataRequirementHelpers', () => {
           }
         ]
       };
-      const expectedCodeFilter: R4.IDataRequirement_CodeFilter = {
+      const expectedCodeFilter: fhir4.DataRequirementCodeFilter = {
         path: 'attr-1',
         code: [
           {
@@ -181,7 +181,7 @@ describe('DataRequirementHelpers', () => {
         value: 'value1'
       };
 
-      const expectedCodeFilter: R4.IDataRequirement_CodeFilter = {
+      const expectedCodeFilter: fhir4.DataRequirementCodeFilter = {
         path: 'status',
         code: [
           {
@@ -202,7 +202,7 @@ describe('DataRequirementHelpers', () => {
         value: 'value1'
       };
 
-      const expectedCodeFilter: R4.IDataRequirement_CodeFilter = {
+      const expectedCodeFilter: fhir4.DataRequirementCodeFilter = {
         path: 'status',
         code: [
           {
@@ -222,7 +222,7 @@ describe('DataRequirementHelpers', () => {
         valueList: ['value-1', 'value-2', 'value-3']
       };
 
-      const expectedCodeFilter: R4.IDataRequirement_CodeFilter = {
+      const expectedCodeFilter: fhir4.DataRequirementCodeFilter = {
         path: 'status',
         code: [
           {
@@ -249,7 +249,7 @@ describe('DataRequirementHelpers', () => {
         valueList: ['value1']
       };
 
-      const expectedCodeFilter: R4.IDataRequirement_CodeFilter = {
+      const expectedCodeFilter: fhir4.DataRequirementCodeFilter = {
         path: 'status',
         code: [
           {
@@ -275,7 +275,7 @@ describe('DataRequirementHelpers', () => {
         }
       };
 
-      const expectedDateFilter: R4.IDataRequirement_DateFilter = {
+      const expectedDateFilter: fhir4.DataRequirementDateFilter = {
         path: 'attr-1',
         valuePeriod: {
           start: '2021-01-01',
@@ -295,7 +295,7 @@ describe('DataRequirementHelpers', () => {
         attribute: 'attr-1'
       };
 
-      const expectedDetailFilter: R4.IExtension = {
+      const expectedDetailFilter: fhir4.Extension = {
         url: 'http://example.com/dr-value',
         extension: [
           { url: 'dr-value-attribute', valueString: 'attr-1' },
@@ -326,7 +326,7 @@ describe('DataRequirementHelpers', () => {
         valueSet: 'http://example.com/valueset'
       };
 
-      const expectedDataReq: R4.IDataRequirement = {
+      const expectedDataReq: fhir4.DataRequirement = {
         type: dtq.dataType,
         codeFilter: [
           {
@@ -346,12 +346,12 @@ describe('DataRequirementHelpers', () => {
         code: { code: 'a_code', system: 'http://example.com/system' }
       };
 
-      const expectedDataReq: R4.IDataRequirement = {
+      const expectedDataReq: fhir4.DataRequirement = {
         type: dtq.dataType,
         codeFilter: [
           {
             path: dtq.path,
-            code: [dtq.code as R4.ICoding]
+            code: [dtq.code as fhir4.Coding]
           }
         ]
       };
@@ -365,7 +365,7 @@ describe('DataRequirementHelpers', () => {
         path: 'a.path'
       };
 
-      const expectedDataReq: R4.IDataRequirement = {
+      const expectedDataReq: fhir4.DataRequirement = {
         type: dtq.dataType
       };
 

--- a/test/DetailedResultsBuilder.test.ts
+++ b/test/DetailedResultsBuilder.test.ts
@@ -1,13 +1,13 @@
 import * as DetailedResultsBuilder from '../src/calculation/DetailedResultsBuilder';
-import { R4 } from '@ahryman40k/ts-fhir-types';
+
 import { getJSONFixture } from './helpers/testHelpers';
 import { PopulationType } from '../src/types/Enums';
 import { StatementResults } from '../src/types/CQLTypes';
 import { PopulationResult } from '../src/types/Calculator';
 import { ELMExpressionRef, ELMQuery, ELMTuple } from '../src/types/ELMTypes';
 
-type MeasureWithGroup = R4.IMeasure & {
-  group: R4.IMeasure_Group[];
+type MeasureWithGroup = fhir4.Measure & {
+  group: fhir4.MeasureGroup[];
 };
 
 const simpleMeasure = getJSONFixture('measure/simple-measure.json') as MeasureWithGroup;

--- a/test/GapsInCareHelpers.test.ts
+++ b/test/GapsInCareHelpers.test.ts
@@ -1,4 +1,3 @@
-import { R4 } from '@ahryman40k/ts-fhir-types';
 import * as cql from 'cql-execution';
 import { FHIRWrapper } from 'cql-exec-fhir';
 import {
@@ -249,14 +248,16 @@ const EXAMPLE_DETAILED_RESULTS: DetailedPopulationGroupResult = {
   ]
 };
 
-const SIMPLE_MEASURE_REPORT: R4.IMeasureReport = {
+const SIMPLE_MEASURE_REPORT: fhir4.MeasureReport = {
   resourceType: 'MeasureReport',
   id: 'example',
   measure: 'Measure/example',
   period: {
     start: '2020-01-01',
     end: '2020-12-31'
-  }
+  },
+  status: 'complete',
+  type: 'individual'
 };
 
 describe('Process detailed queries', () => {
@@ -761,7 +762,7 @@ describe('FHIR Bundle Generation', () => {
       })
     );
 
-    EXAMPLE_DETECTED_ISSUE.forEach((e: R4.IDetectedIssue) => {
+    EXAMPLE_DETECTED_ISSUE.forEach((e: fhir4.DetectedIssue) => {
       expect(bundle.entry).toContainEqual(
         expect.objectContaining({
           resource: e
@@ -780,7 +781,7 @@ describe('Guidance Response', () => {
   };
 
   test('should generate data requirement with equals attribute codeFilter', () => {
-    const drWithAttributeFilter: R4.IDataRequirement[] = [
+    const drWithAttributeFilter: fhir4.DataRequirement[] = [
       {
         type: 'Procedure',
         codeFilter: [
@@ -829,7 +830,7 @@ describe('Guidance Response', () => {
   });
 
   test('should generate data requirement with "in" attribute codeFilter', () => {
-    const drWithAttributeFilter: R4.IDataRequirement[] = [
+    const drWithAttributeFilter: fhir4.DataRequirement[] = [
       {
         type: 'Procedure',
         codeFilter: [
@@ -882,7 +883,7 @@ describe('Guidance Response', () => {
   });
 
   test('should generate data requirement with "in" codings attribute codeFilter', () => {
-    const drWithAttributeFilter: R4.IDataRequirement[] = [
+    const drWithAttributeFilter: fhir4.DataRequirement[] = [
       {
         type: 'Procedure',
         codeFilter: [
@@ -944,7 +945,7 @@ describe('Guidance Response', () => {
   });
 
   test('should generate data requirement with dateFilter', () => {
-    const drWithDate: R4.IDataRequirement[] = [
+    const drWithDate: fhir4.DataRequirement[] = [
       {
         type: 'Procedure',
         codeFilter: [
@@ -996,7 +997,7 @@ describe('Guidance Response', () => {
   });
 
   test('should generate data requirement with valueFilter for not-null filter', () => {
-    const drWithValue: R4.IDataRequirement[] = [
+    const drWithValue: fhir4.DataRequirement[] = [
       {
         type: 'Observation',
         codeFilter: [
@@ -1053,7 +1054,7 @@ describe('Guidance Response', () => {
   });
 
   test('should generate combo data requirement with codeFilter and dateFilter. including reason detail', () => {
-    const drWithDateAndCode: R4.IDataRequirement[] = [
+    const drWithDateAndCode: fhir4.DataRequirement[] = [
       {
         type: 'Procedure',
         codeFilter: [
@@ -1125,7 +1126,7 @@ describe('Guidance Response', () => {
       }
     };
 
-    const expectedReasonCodeableConcept: R4.ICodeableConcept[] = [
+    const expectedReasonCodeableConcept: fhir4.CodeableConcept[] = [
       {
         coding: [
           {
@@ -1171,7 +1172,7 @@ describe('Guidance Response ReasonCode Coding', () => {
     const reasonDetail: ReasonDetailData = {
       code: CareGapReasonCode.MISSING
     };
-    const expectedCoding: R4.ICoding = {
+    const expectedCoding: fhir4.Coding = {
       system: 'CareGapReasonCodeSystem',
       code: 'Missing',
       display: 'No Data Element found from Value Set'
@@ -1184,7 +1185,7 @@ describe('Guidance Response ReasonCode Coding', () => {
       code: CareGapReasonCode.PRESENT,
       reference: 'Procedure/denom-EXM130-2'
     };
-    const expectedCoding: R4.ICoding = {
+    const expectedCoding: fhir4.Coding = {
       system: 'CareGapReasonCodeSystem',
       code: 'Present',
       display: 'Data element was found',
@@ -1211,7 +1212,7 @@ describe('Guidance Response ReasonCode Coding', () => {
       reference: 'Procedure/denom-EXM130-2',
       path: 'performed.end'
     };
-    const expectedCoding: R4.ICoding = {
+    const expectedCoding: fhir4.Coding = {
       system: 'CareGapReasonCodeSystem',
       code: 'DateOutOfRange',
       display: 'Key date was not in the expected range',

--- a/test/MeasureReportBuilder.test.ts
+++ b/test/MeasureReportBuilder.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { R4 } from '@ahryman40k/ts-fhir-types';
+
 import MeasureReportBuilder from '../src/calculation/MeasureReportBuilder';
 import { getJSONFixture } from './helpers/testHelpers';
 import { ExecutionResult, CalculationOptions } from '../src/types/Calculator';
@@ -15,12 +15,12 @@ const patient2 = getJSONFixture('EXM111-9.1.000/Armando772_Almanza534_08fc9439-b
 const patient1Id = '3413754c-73f0-4559-9f67-df8e593ce7e1';
 const patient2Id = '08fc9439-b7ff-4309-b409-4d143388594c';
 
-const simpleMeasure = getJSONFixture('measure/simple-measure.json') as R4.IMeasure;
-const cvMeasure = getJSONFixture('measure/cv-measure.json') as R4.IMeasure;
+const simpleMeasure = getJSONFixture('measure/simple-measure.json') as fhir4.Measure;
+const cvMeasure = getJSONFixture('measure/cv-measure.json') as fhir4.Measure;
 
-const simpleMeasureBundle: R4.IBundle = {
+const simpleMeasureBundle: fhir4.Bundle = {
   resourceType: 'Bundle',
-  type: R4.BundleTypeKind._collection,
+  type: 'collection',
   entry: [
     {
       resource: simpleMeasure
@@ -28,9 +28,9 @@ const simpleMeasureBundle: R4.IBundle = {
   ]
 };
 
-const cvMeasureBundle: R4.IBundle = {
+const cvMeasureBundle: fhir4.Bundle = {
   resourceType: 'Bundle',
-  type: R4.BundleTypeKind._collection,
+  type: 'collection',
   entry: [
     {
       resource: cvMeasure
@@ -131,7 +131,7 @@ const calculationOptions: CalculationOptions = {
 
 describe('MeasureReportBuilder Static', () => {
   describe('Simple Measure Report', () => {
-    let measureReports: R4.IMeasureReport[];
+    let measureReports: fhir4.MeasureReport[];
     beforeAll(() => {
       measureReports = MeasureReportBuilder.buildMeasureReports(
         simpleMeasureBundle,
@@ -149,8 +149,8 @@ describe('MeasureReportBuilder Static', () => {
     test('should set basic options correctly', () => {
       const [mr] = measureReports;
 
-      expect(mr.status).toEqual(R4.MeasureReportStatusKind._complete);
-      expect(mr.type).toEqual(R4.MeasureReportTypeKind._individual);
+      expect(mr.status).toEqual('complete');
+      expect(mr.type).toEqual('individual');
 
       expect(mr.period).toEqual({
         start: calculationOptions.measurementPeriodStart,
@@ -192,9 +192,9 @@ describe('MeasureReportBuilder Static', () => {
       expect(mr.contained).toBeDefined();
       expect(mr.contained).toHaveLength(1);
 
-      const sde = mr.contained?.[0] as R4.IObservation;
+      const sde = mr.contained?.[0] as fhir4.Observation;
 
-      expect(sde.status).toEqual(R4.ObservationStatusKind._final);
+      expect(sde.status).toEqual('final');
       expect(sde.code).toEqual({
         text: 'sde-code'
       });
@@ -215,7 +215,7 @@ describe('MeasureReportBuilder Static', () => {
   });
 
   describe('CV stratifier Measure Report', () => {
-    let measureReports: R4.IMeasureReport[];
+    let measureReports: fhir4.MeasureReport[];
     beforeAll(() => {
       measureReports = MeasureReportBuilder.buildMeasureReports(
         cvMeasureBundle,
@@ -258,12 +258,13 @@ describe('MeasureReportBuilder Static', () => {
 });
 
 describe('MeasureReportBuilder Class', () => {
-  let measureBundle: R4.IBundle;
-  let patientResource: R4.IPatient;
+  let measureBundle: fhir4.Bundle;
+  let patientResource: fhir4.Patient;
   beforeAll(() => {
     measureBundle = {
       resourceType: 'Bundle',
-      entry: [{ resource: simpleMeasure }]
+      entry: [{ resource: simpleMeasure }],
+      type: 'transaction'
     };
 
     patientResource = patient1.entry[0].resource;
@@ -319,8 +320,8 @@ describe('MeasureReportBuilder Class', () => {
       end: '2021-12-31'
     });
 
-    expect(report.status).toEqual(R4.MeasureReportStatusKind._complete);
-    expect(report.type).toEqual(R4.MeasureReportTypeKind._individual);
+    expect(report.status).toEqual('complete');
+    expect(report.type).toEqual('individual');
 
     expect(report.measure).toEqual(simpleMeasure.url);
 
@@ -344,8 +345,8 @@ describe('MeasureReportBuilder Class', () => {
       end: '2021-12-31'
     });
 
-    expect(report.status).toEqual(R4.MeasureReportStatusKind._complete);
-    expect(report.type).toEqual(R4.MeasureReportTypeKind._summary);
+    expect(report.status).toEqual('complete');
+    expect(report.type).toEqual('summary');
 
     expect(report.measure).toEqual(simpleMeasure.url);
 

--- a/test/ValueSetHelper.test.ts
+++ b/test/ValueSetHelper.test.ts
@@ -1,13 +1,12 @@
-import { R4 } from '@ahryman40k/ts-fhir-types';
 import { valueSetsForCodeService, getMissingDependentValuesets } from '../src/execution/ValueSetHelper';
 import { getJSONFixture } from './helpers/testHelpers';
 
-type ValueSetWithNoUndefined = R4.IValueSet & {
+type ValueSetWithNoUndefined = fhir4.ValueSet & {
   url: string;
   version: string;
   compose: {
-    include: (R4.IValueSet_Include & {
-      concept: R4.IValueSet_Concept;
+    include: (fhir4.ValueSetComposeInclude & {
+      concept: fhir4.ValueSetComposeIncludeConcept;
       system: string;
       version: string;
     })[];
@@ -21,12 +20,12 @@ const exampleExpandedValueset = getJSONFixture('valuesets/example-expanded-vs.js
 describe('ValueSetHelper', () => {
   describe('getAllDependentValuesets', () => {
     test('Finds all valuesets that are missing in the standard measure bundle', () => {
-      const measureBundle: R4.IBundle = getJSONFixture('EXM130-7.3.000-bundle-nocodes.json');
+      const measureBundle: fhir4.Bundle = getJSONFixture('EXM130-7.3.000-bundle-nocodes.json');
       const vs = getMissingDependentValuesets(measureBundle);
       expect(vs.length).toEqual(0);
     });
     test('Finds all valuesets that are missing in the missingVS measure bundle', () => {
-      const measureBundle: R4.IBundle = getJSONFixture('EXM130-7.3.000-bundle-nocodes-missingVS.json');
+      const measureBundle: fhir4.Bundle = getJSONFixture('EXM130-7.3.000-bundle-nocodes-missingVS.json');
       const vs = getMissingDependentValuesets(measureBundle);
       expect(vs.length).toEqual(1);
       expect(vs[0]).toEqual('http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016');

--- a/test/ValueSetResolver.test.ts
+++ b/test/ValueSetResolver.test.ts
@@ -1,14 +1,13 @@
-import { R4 } from '@ahryman40k/ts-fhir-types';
 import { ValueSetResolver } from '../src/execution/ValueSetResolver';
 import { getJSONFixture } from './helpers/testHelpers';
 import MockAdapter from 'axios-mock-adapter';
 
-type ValueSetWithNoUndefined = R4.IValueSet & {
+type ValueSetWithNoUndefined = fhir4.ValueSet & {
   url: string;
   version: string;
   compose: {
-    include: (R4.IValueSet_Include & {
-      concept: R4.IValueSet_Concept;
+    include: (fhir4.ValueSetComposeInclude & {
+      concept: fhir4.ValueSetComposeIncludeConcept;
       system: string;
       version: string;
     })[];

--- a/test/integration-tests/fhirInteractions.ts
+++ b/test/integration-tests/fhirInteractions.ts
@@ -1,6 +1,5 @@
 import { calculateIndividualMeasureReports } from '../../src/calculation/Calculator';
 import { CalculationOptions } from '../../src/types/Calculator';
-import { R4 } from '@ahryman40k/ts-fhir-types';
 import fs from 'fs';
 
 const PERIOD_START = '2019-01-01';
@@ -32,9 +31,9 @@ const PERIOD_END = '2019-12-31';
  * Run Measure/{id}/$evaluate-measure on fqm execution and return the MeasureReport as a JS object.
  *
  * @param {String} measureId The id of the measure to execute on fqm execution.
- * @returns {Promise<R4.IMeasureReport>} The patient-list MeasureReport.
+ * @returns {Promise<fhir4.MeasureReport>} The patient-list MeasureReport.
  */
-export async function getMeasureReport(measureId: string, measureBundle: R4.IBundle, patientBundle: R4.IBundle) {
+export async function getMeasureReport(measureId: string, measureBundle: fhir4.Bundle, patientBundle: fhir4.Bundle) {
   // Start a timer
   const calcOptions: CalculationOptions = setupCalcOptions();
   const report = await calculateIndividualMeasureReports(measureBundle, [patientBundle], calcOptions);
@@ -56,6 +55,6 @@ function setupCalcOptions(/* string paramName, boolean value*/): CalculationOpti
 }
 export function loadPatientBundle(patientBundlePath: string) {
   const patientBundle = fs.readFileSync(patientBundlePath, 'utf8');
-  const bundleStream = JSON.parse(patientBundle) as R4.IBundle;
+  const bundleStream = JSON.parse(patientBundle) as fhir4.Bundle;
   return bundleStream;
 }

--- a/test/integration-tests/measureReportCompare.ts
+++ b/test/integration-tests/measureReportCompare.ts
@@ -1,4 +1,3 @@
-import { R4 } from '@ahryman40k/ts-fhir-types';
 import { BadPatient } from './testDataHelpers';
 const debug = process.env.DEBUG;
 /**
@@ -8,7 +7,7 @@ const debug = process.env.DEBUG;
  * @param {FHIR.MeasureReport} report The MeasureReport to find the group in.
  * @returns {Object} The corresponding group.
  */
-function findCorrespondingGroup(referenceGroup: R4.IMeasureReport_Group, report: R4.IMeasureReport) {
+function findCorrespondingGroup(referenceGroup: fhir4.MeasureReportGroup, report: fhir4.MeasureReport) {
   return report.group?.find(group => {
     return referenceGroup.id == group.id;
   });
@@ -22,8 +21,8 @@ function findCorrespondingGroup(referenceGroup: R4.IMeasureReport_Group, report:
  * @returns {Object} The corresponding population.
  */
 function findCorrespondingPopulation(
-  referencePopulation: R4.IMeasureReport_Population,
-  group: R4.IMeasureReport_Group | undefined
+  referencePopulation: fhir4.MeasureReportGroupPopulation,
+  group: fhir4.MeasureReportGroup | undefined
 ) {
   return group?.population?.find(population => {
     if (referencePopulation.code?.coding && population.code?.coding) {
@@ -67,7 +66,11 @@ function addBadPatientEntry(
  * @param {FHIR.MeasureReport} report The report coming from execution.
  * @returns {BadPatient[]} List of bad patients and the issues with them.
  */
-export function compareMeasureReports(referenceReport: R4.IMeasureReport, report: R4.IMeasureReport, fileName: string) {
+export function compareMeasureReports(
+  referenceReport: fhir4.MeasureReport,
+  report: fhir4.MeasureReport,
+  fileName: string
+) {
   /** @type {BadPatient[]} */
   const badPatientsList: BadPatient[] = [];
   const patientName = fileName.substring(0, fileName.lastIndexOf('-'));

--- a/test/integration-tests/run_tests.ts
+++ b/test/integration-tests/run_tests.ts
@@ -4,18 +4,18 @@ import path from 'path';
 import process from 'process';
 import { BadPatient, getTestMeasureList, loadReferenceMeasureReport, loadTestDataFolder } from './testDataHelpers';
 import { getMeasureReport } from './fhirInteractions';
-import { R4 } from '@ahryman40k/ts-fhir-types';
+
 import { compareMeasureReports } from './measureReportCompare';
 
-function parseBundle(filePath: string): R4.IBundle {
-  let bundle: R4.IBundle | undefined;
+function parseBundle(filePath: string): fhir4.Bundle {
+  let bundle: fhir4.Bundle | undefined;
   if (fs.existsSync(filePath)) {
     const contents = fs.readFileSync(filePath, 'utf8');
-    bundle = JSON.parse(contents) as R4.IBundle;
+    bundle = JSON.parse(contents) as fhir4.Bundle;
   } else {
     bundle = {
       resourceType: 'Bundle',
-      type: R4.BundleTypeKind._document,
+      type: 'document',
       entry: []
     };
   }

--- a/test/integration-tests/testDataHelpers.ts
+++ b/test/integration-tests/testDataHelpers.ts
@@ -1,4 +1,3 @@
-import { R4 } from '@ahryman40k/ts-fhir-types';
 import fs from 'fs';
 import path, { join } from 'path';
 import { loadPatientBundle } from './fhirInteractions';
@@ -101,7 +100,7 @@ export function loadTestDataFolder(testDataFolder: string) {
     });
 
   /** @type {BundleLoadInfo[]} */
-  const bundleResourceInfos: { fileName: string; bundle: R4.IBundle }[] = [];
+  const bundleResourceInfos: { fileName: string; bundle: fhir4.Bundle }[] = [];
   // Iterate over sub folders
   for (const subfolder of subfolders) {
     const subfolderPath = testDataFolder + '/' + subfolder;

--- a/test/queryFilters/interpretExpression.test.ts
+++ b/test/queryFilters/interpretExpression.test.ts
@@ -1,12 +1,11 @@
 import { getELMFixture } from '../helpers/testHelpers';
 import * as QueryFilter from '../../src/gaps/QueryFilterParser';
 import { ELMFunctionRef } from '../../src/types/ELMTypes';
-import { R4 } from '@ahryman40k/ts-fhir-types';
 
 // to use as a library parameter for tests
 const complexQueryELM = getELMFixture('elm/queries/ComplexQueries.json');
 
-const PATIENT: R4.IPatient = {
+const PATIENT: fhir4.Patient = {
   resourceType: 'Patient',
   birthDate: '1988-09-08'
 };

--- a/test/queryFilters/interpretGreaterOrEqual.test.ts
+++ b/test/queryFilters/interpretGreaterOrEqual.test.ts
@@ -1,7 +1,7 @@
 import { getELMFixture } from '../helpers/testHelpers';
 import * as QueryFilter from '../../src/gaps/QueryFilterParser';
 import { ELMGreaterOrEqual } from '../../src/types/ELMTypes';
-import { R4 } from '@ahryman40k/ts-fhir-types';
+
 import { DuringFilter, UnknownFilter } from '../../src/types/QueryFilterTypes';
 import { removeIntervalFromFilter } from '../helpers/queryFilterTestHelpers';
 
@@ -277,12 +277,12 @@ const GREATEROREQUAL_LITERAL_TO_VALUE: ELMGreaterOrEqual = {
   ]
 };
 
-const PATIENT: R4.IPatient = {
+const PATIENT: fhir4.Patient = {
   resourceType: 'Patient',
   birthDate: '1988-09-08'
 };
 
-const PATIENT_NO_BIRTHDATE: R4.IPatient = {
+const PATIENT_NO_BIRTHDATE: fhir4.Patient = {
   resourceType: 'Patient'
 };
 

--- a/test/queryFilters/parseQueryInfo.test.ts
+++ b/test/queryFilters/parseQueryInfo.test.ts
@@ -3,7 +3,6 @@ import { parseQueryInfo } from '../../src/gaps/QueryFilterParser';
 import * as cql from 'cql-execution';
 import { QueryInfo, DuringFilter, AndFilter } from '../../src/types/QueryFilterTypes';
 import { removeIntervalFromFilter } from '../helpers/queryFilterTestHelpers';
-import { R4 } from '@ahryman40k/ts-fhir-types';
 
 const simpleQueryELM = getELMFixture('elm/queries/SimpleQueries.json');
 const complexQueryELM = getELMFixture('elm/queries/ComplexQueries.json');
@@ -367,7 +366,7 @@ const EXPECTED_QUERY_REFERENCES_QUERY_IN_ANOTHER_LIBRARY: QueryInfo = {
   }
 };
 
-const PATIENT: R4.IPatient = {
+const PATIENT: fhir4.Patient = {
   resourceType: 'Patient',
   birthDate: '1988-09-08'
 };


### PR DESCRIPTION
# Summary
Replaced `@ahryman40k/ts-fhir-types` usage with `@types/fhir` for FHIR JSON type defs.

## New behavior
Nothing except for the Composition.status that we now include in gaps reports. Turns out that was a required field.

## Code changes
- Every file that worked with FHIR JSON was updated to make use of the new `@types/fhir` definitions.
- These definitions do not require explicit inclusion in each file. They provide a global namespace `fhir4` that is used to access them.
- Some complex sub-structures had simplistic names in the old library. The new library is a bit more explicit in their naming by including the entire path.
- Enums for FHIR codes were replaced with simply a list of expected strings, this changed they way in how we set the code fields slightly.
 
# Testing guidance
Run unit tests. Try various run configurations.