### PR TITLE
Query info refactor

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 build
+connectathon

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 node_modules
 build
 coverage
+connectathon

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ Library for executing FHIR-based Electronic Clinical Quality Measures (eCQMs) wr
 `fqm-execution` can be installed into your project with npm:
 
 ``` bash
-npm install --save https://github.com/projecttacoma/fqm-execution.git
+npm install --save fqm-execution
 ```
 
 To install the global command line interface (CLI), use npm global installation:
 
 ``` bash
-npm install -g https://github.com/projecttacoma/fqm-execution.git
+npm install -g fqm-execution
 ```
 
 ## Usage
@@ -47,6 +47,7 @@ const detailedResults = await Calculator.calculate(measureBundle, patientBundles
 const measureReports = await Calculator.calculateMeasureReports(measureBundle, patientBundles, options, valueSetCache); // Get individual FHIR MeasureReports for each patient
 const gapsInCare = await Calculator.calculateGapsInCare(measureBundle, patientBundles, options, valueSetCache); // Get gaps in care for each patient, if present
 const dataRequirements = Calculator.calculateDataRequirements(measureBundle); // Get data requirements for a given measure (in a bundle)
+const queryInfo = Calculator.calculateQueryInfo(measureBundle); // Get detailed query info for all statements in a meaasure
 ```
 
 #### Require
@@ -59,6 +60,7 @@ const detailedResults = await Calculator.calculate(measureBundle, patientBundles
 const measureReports = await Calculator.calculateMeasureReports(measureBundle, patientBundles, options, valueSetCache); // Get individual FHIR MeasureReports for each patient
 const gapsInCare = await Calculator.calculateGapsInCare(measureBundle, patientBundles, options, valueSetCache); // Get gaps in care for each patient, if present
 const dataRequirements = Calculator.calculateDataRequirements(measureBundle); // Get data requirements for a given measure (in a bundle)
+const queryInfo = Calculator.calculateQueryInfo(measureBundle); // Get detailed query info for all statements in a meaasure
 ```
 
 #### Arguments
@@ -95,7 +97,7 @@ Usage: fqm-execution [options]
 
 Options:
   -d, --debug                                 enable debug output (default: false)
-  -o, --output-type <type>                    type of output, "raw", "detailed", "reports", "gaps", "dataRequirements" (default: "detailed")
+  -o, --output-type <type>                    type of output, "raw", "detailed", "reports", "gaps", "dataRequirements", "queryInfo" (default: "detailed")
   -r, --report-type <type>                    type of MeasureReport (only for output type "reports"): "summary" or "individual" (default: "individual")
   -m, --measure-bundle <measure-bundle>       path to measure bundle
   -p, --patient-bundles <patient-bundles...>  paths to patient bundle

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fqm-execution",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fqm-execution",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "FHIR Quality Measure Execution",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,7 +8,8 @@ import {
   calculateMeasureReports,
   calculateGapsInCare,
   calculateRaw,
-  calculateDataRequirements
+  calculateDataRequirements,
+  calculateQueryInfo
 } from './calculation/Calculator';
 import { clearDebugFolder, dumpCQLs, dumpELMJSONs, dumpHTMLs, dumpObject, dumpVSMap } from './helpers/DebugHelpers';
 import { CalculationOptions, CalculatorFunctionOutput } from './types/Calculator';
@@ -17,7 +18,7 @@ program
   .option('-d, --debug', 'enable debug output', false)
   .option(
     '-o, --output-type <type>',
-    'type of output, "raw", "detailed", "reports", "gaps", "dataRequirements"',
+    'type of output, "raw", "detailed", "reports", "gaps", "dataRequirements", "queryInfo"',
     'detailed'
   )
   .option('-r, --report-type <report-type>', 'type of report, "individual", "summary", "subject-list"')
@@ -76,6 +77,9 @@ async function calc(
   } else if (program.outputType === 'dataRequirements') {
     // CalculateDataRequirements doesn't make use of the calcOptions object at this point
     result = calculateDataRequirements(measureBundle);
+  } else if (program.outputType === 'queryInfo') {
+    // calculateQueryInfo doesn't make use of the calcOptions object at this point
+    result = calculateQueryInfo(measureBundle);
   }
   if (!result) {
     throw new Error(`Could not obtain result based on outputType ${program.outputType}`);
@@ -86,7 +90,7 @@ async function calc(
 const measureBundle = parseBundle(path.resolve(program.measureBundle));
 
 let patientBundles: fhir4.Bundle[];
-if (program.outputType !== 'dataRequirements') {
+if (program.outputType !== 'dataRequirements' && program.outputType !== 'queryInfo') {
   // Since patient bundles are no longer a mandatory CLI option, we should check if we were given any before
   if (!program.patientBundles) {
     console.error(`Patient bundle is a required option when output type is "${program.outputType}"`);
@@ -94,7 +98,7 @@ if (program.outputType !== 'dataRequirements') {
   }
   patientBundles = program.patientBundles.map((bundlePath: string) => parseBundle(path.resolve(bundlePath)));
 } else {
-  // data requirements doesn't care about patient bundles, so just pass an empty array if we're using that report type
+  // data requirements/queryInfo doesn't care about patient bundles, so just pass an empty array if we're using that report type
   patientBundles = [];
 }
 

--- a/src/gaps/QueryFilterParser.ts
+++ b/src/gaps/QueryFilterParser.ts
@@ -66,7 +66,7 @@ export function parseQueryInfo(
   allELM: ELM[],
   queryLocalId: string | undefined,
   parameters: { [key: string]: any } = {},
-  patient: fhir4.Patient
+  patient?: fhir4.Patient
 ): QueryInfo {
   if (!queryLocalId) {
     throw new Error('QueryLocalId was not provided');
@@ -218,7 +218,7 @@ export function interpretExpression(
   expression: ELMExpression,
   library: ELM,
   parameters: any,
-  patient: fhir4.Patient
+  patient?: fhir4.Patient
 ): AnyFilter {
   let returnFilter: AnyFilter = {
     type: 'unknown',
@@ -308,7 +308,7 @@ export function findPropertyUsage(expression: any, unknownLocalId?: string): Unk
  * @param patient The patient resource.
  * @returns The filter tree for this and expression.
  */
-export function interpretAnd(andExpression: ELMAnd, library: ELM, parameters: any, patient: fhir4.Patient): AndFilter {
+export function interpretAnd(andExpression: ELMAnd, library: ELM, parameters: any, patient?: fhir4.Patient): AndFilter {
   const andInfo: AndFilter = { type: 'and', children: [] };
   if (andExpression.operand[0].type == 'And') {
     andInfo.children.push(...interpretAnd(andExpression.operand[0] as ELMAnd, library, parameters, patient).children);
@@ -333,7 +333,7 @@ export function interpretAnd(andExpression: ELMAnd, library: ELM, parameters: an
  * @param patient The patient resource.
  * @returns The filter tree for this or expression.
  */
-export function interpretOr(orExpression: ELMOr, library: ELM, parameters: any, patient: fhir4.Patient): OrFilter {
+export function interpretOr(orExpression: ELMOr, library: ELM, parameters: any, patient?: fhir4.Patient): OrFilter {
   const orInfo: OrFilter = { type: 'or', children: [] };
   if (orExpression.operand[0].type == 'Or') {
     orInfo.children.push(...interpretOr(orExpression.operand[0] as ELMOr, library, parameters, patient).children);
@@ -782,14 +782,14 @@ export function interpretGreaterOrEqual(
   greaterOrEqualExpr: ELMGreaterOrEqual,
   library: ELM,
   parameters: any,
-  patient: fhir4.Patient
+  patient?: fhir4.Patient
 ): AnyFilter {
   // look at first param if it is function ref to calendar age in years at.
   const withError: GracefulError = { message: 'An unknown error occured while interpretting greater or equal filter' };
   if (greaterOrEqualExpr.operand[0].type === 'FunctionRef') {
     const functionRef = greaterOrEqualExpr.operand[0] as ELMFunctionRef;
     // Check if it is "Global.CalendarAgeInYearsAt"
-    if (functionRef.name === 'CalendarAgeInYearsAt' && functionRef.libraryName === 'Global') {
+    if (patient && functionRef.name === 'CalendarAgeInYearsAt' && functionRef.libraryName === 'Global') {
       const calAgeRef = functionRef as CalendarAgeInYearsAtRef;
       // ensure the first operand is the patient birthdate.
       if (

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -219,6 +219,8 @@ export interface DataTypeQuery {
   expressionStack?: ExpressionStackEntry[];
   /** path that the code or valueset object refers to */
   path?: string;
+  /** Info about query and how it is filtered. */
+  queryInfo?: QueryInfo;
 }
 
 export interface GapsDataTypeQuery extends DataTypeQuery {
@@ -226,8 +228,6 @@ export interface GapsDataTypeQuery extends DataTypeQuery {
   retrieveHasResult?: boolean;
   /** whether or not the entire query was truthy */
   parentQueryHasResult?: boolean;
-  /** Info about query and how it is filtered. */
-  queryInfo?: QueryInfo;
   /** Info about the reason detail query */
   reasonDetail?: ReasonDetail;
 }
@@ -295,7 +295,8 @@ export interface CalculatorFunctionOutput {
     | cql.Results
     | string
     | fhir4.Bundle
-    | fhir4.Library;
+    | fhir4.Library
+    | DataTypeQuery[];
   debugOutput?: DebugOutput;
   valueSetCache?: fhir4.ValueSet[];
   withErrors?: GracefulError[];
@@ -351,4 +352,11 @@ export interface GICCalculationOutput extends CalculatorFunctionOutput {
  */
 export interface DRCalculationOutput extends Omit<CalculatorFunctionOutput, 'valueSetCache'> {
   results: fhir4.Library;
+}
+
+/**
+ * dataType for calculateQueryInfo() function
+ */
+export interface QICalculationOutput extends CalculatorFunctionOutput {
+  results: DataTypeQuery[];
 }


### PR DESCRIPTION
# Summary

This PR refactors the query filter parsing that we do to be able to run without the context of a patient. This will allow us to re-use the logic for enhancements to the dataRequirements calculation, as well as allow query parsing to run on just measure logic for other use cases (e.g. analyzing all attributes accessed by the measure)

## New behavior

New function `calculateQueryInfo` exposed in Calculator that can be called directly or with the `-o queryInfo` flag in the CLI

## Code changes

* Modify types to allow queryInfo property on base DataTypeQuery, not just gaps
* Make patient argument optional for query filter parser
* Add calculateQueryInfo that returns the query info for all statements in the library (similar to data requirements, but does not return a FHIR library)
* Update docs
* Bump version

# Testing guidance

* Ensure that existing gaps in care functionality is completely unaffected (gaps output for EXM130 denom on master and on this branch should be 100% identical)
* Run CLI with the `queryInfo` output type and inspect results. Should include detailed query info for each query (e.g. `./src/cli.ts -m path/to/connectathon/fhir401/bundles/measure/EXM130-7.3.000/EXM130-7.3.000-bundle.json -o queryInfo -d  -s 2019-01-01 -e 2019-12-31`
