### PR TITLE
Added Date Filters to Data Requirements Output

### DIFF
--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -497,7 +497,7 @@ export async function calculateGapsInCare(
  *
  * @param measureBundle Bundle with a MeasureResource and all necessary data for execution.
  * @param options Options for calculation.
- * 
+ *
  * @returns FHIR Library of data requirements
  */
 export function calculateDataRequirements(

--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -497,7 +497,7 @@ export async function calculateGapsInCare(
  *
  * @param measureBundle Bundle with a MeasureResource and all necessary data for execution.
  * @param options Options for calculation.
-
+ * 
  * @returns FHIR Library of data requirements
  */
 export function calculateDataRequirements(

--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -31,6 +31,7 @@ import {
   UnexpectedResource,
   UnsupportedProperty
 } from '../types/errors/CustomErrors';
+import cql from 'cql-execution';
 
 /**
  * Calculate measure against a set of patients. Returning detailed results for each patient and population group.
@@ -495,17 +496,26 @@ export async function calculateGapsInCare(
  * Get data requirements for this measure
  *
  * @param measureBundle Bundle with a MeasureResource and all necessary data for execution.
+ * @param options Options for calculation.
+
  * @returns FHIR Library of data requirements
  */
-export function calculateDataRequirements(measureBundle: fhir4.Bundle): DRCalculationOutput {
+export function calculateDataRequirements(
+  measureBundle: fhir4.Bundle,
+  options: CalculationOptions
+): DRCalculationOutput {
   // Extract the library ELM, and the id of the root library, from the measure bundle
   const { cqls, rootLibIdentifier, elmJSONs } = MeasureBundleHelpers.extractLibrariesFromBundle(measureBundle);
   const rootLib = elmJSONs.find(ej => ej.library.identifier == rootLibIdentifier);
+
+  const { startCql, endCql } = Execution.getCQLIntervalEndpoints(options);
 
   // We need a root library to run dataRequirements properly. If we don't have one, error out.
   if (!rootLib?.library) {
     throw new UnexpectedResource("root library doesn't contain a library object"); //unexpected resource
   }
+
+  const parameters = { 'Measurement Period': new cql.Interval(startCql, endCql) };
   const withErrors: GracefulError[] = [];
   // get the retrieves for every statement in the root library
   const allRetrieves = rootLib.library.statements.def.flatMap(statement => {
@@ -524,12 +534,27 @@ export function calculateDataRequirements(measureBundle: fhir4.Bundle): DRCalcul
     return JSON.stringify(retrieve, ['dataType', 'valueSet', 'code', 'path']);
   });
 
+  uniqueRetrieves.forEach(retrieve => {
+    // If the retrieves have a localId for the query and a known library name, we can get more info
+    // on how the query filters the sources.
+    if (retrieve.queryLocalId && retrieve.queryLibraryName) {
+      const library = elmJSONs.find(lib => lib.library.identifier.id === retrieve.queryLibraryName);
+      if (library) {
+        retrieve.queryInfo = parseQueryInfo(library, elmJSONs, retrieve.queryLocalId, parameters);
+      }
+    }
+  });
+
   const results: fhir4.Library = {
     resourceType: 'Library',
     type: { coding: [{ code: 'module-definition', system: 'http://terminology.hl7.org/CodeSystem/library-type' }] },
     status: 'unknown'
   };
-  results.dataRequirement = uniqueRetrieves.map(retrieve => generateDataRequirement(retrieve));
+  results.dataRequirement = uniqueRetrieves.map(retrieve => {
+    const dr = generateDataRequirement(retrieve);
+    GapsInCareHelpers.addFiltersToDataRequirement(retrieve, dr, withErrors);
+    return dr;
+  });
 
   return {
     results: results,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -76,7 +76,7 @@ async function calc(
     result = await calculateGapsInCare(measureBundle, patientBundles, calcOptions, valueSetCache);
   } else if (program.outputType === 'dataRequirements') {
     // CalculateDataRequirements doesn't make use of the calcOptions object at this point
-    result = calculateDataRequirements(measureBundle);
+    result = calculateDataRequirements(measureBundle, calcOptions);
   } else if (program.outputType === 'queryInfo') {
     // calculateQueryInfo doesn't make use of the calcOptions object at this point
     result = calculateQueryInfo(measureBundle);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -75,7 +75,6 @@ async function calc(
   } else if (program.outputType === 'gaps') {
     result = await calculateGapsInCare(measureBundle, patientBundles, calcOptions, valueSetCache);
   } else if (program.outputType === 'dataRequirements') {
-    // CalculateDataRequirements doesn't make use of the calcOptions object at this point
     result = calculateDataRequirements(measureBundle, calcOptions);
   } else if (program.outputType === 'queryInfo') {
     // calculateQueryInfo doesn't make use of the calcOptions object at this point

--- a/src/execution/Execution.ts
+++ b/src/execution/Execution.ts
@@ -67,21 +67,7 @@ export async function execute(
 
   const { cqls, rootLibIdentifier, elmJSONs } = MeasureBundleHelpers.extractLibrariesFromBundle(measureBundle);
 
-  // Measure datetime stuff
-  let start;
-  let end;
-  if (options.measurementPeriodStart) {
-    start = parseTimeStringAsUTC(options.measurementPeriodStart);
-  } else {
-    start = new Date('2019-01-01');
-  }
-  if (options.measurementPeriodEnd) {
-    end = parseTimeStringAsUTC(options.measurementPeriodEnd);
-  } else {
-    end = new Date('2019-12-31');
-  }
-  const startCql = cql.DateTime.fromJSDate(start, 0); // No timezone offset for start
-  const endCql = cql.DateTime.fromJSDate(end, 0); // No timezone offset for stop
+  const { startCql, endCql } = getCQLIntervalEndpoints(options);
 
   const patientSource = new PatientSource.FHIRv401();
   patientSource.loadBundles(patientBundles);
@@ -137,4 +123,23 @@ export async function execute(
     parameters: parameters,
     ...(options.useValueSetCaching && { valueSetCache: newCache })
   };
+}
+
+export function getCQLIntervalEndpoints(options: CalculationOptions) {
+  // Measure datetime stuff
+  let start;
+  let end;
+  if (options.measurementPeriodStart) {
+    start = parseTimeStringAsUTC(options.measurementPeriodStart);
+  } else {
+    start = new Date('2019-01-01');
+  }
+  if (options.measurementPeriodEnd) {
+    end = parseTimeStringAsUTC(options.measurementPeriodEnd);
+  } else {
+    end = new Date('2019-12-31');
+  }
+  const startCql = cql.DateTime.fromJSDate(start, 0); // No timezone offset for start
+  const endCql = cql.DateTime.fromJSDate(end, 0); // No timezone offset for stop
+  return { startCql, endCql };
 }

--- a/src/execution/Execution.ts
+++ b/src/execution/Execution.ts
@@ -125,6 +125,11 @@ export async function execute(
   };
 }
 
+/**
+ * Takes in the calculation options and returns start and end dates to create a cql interval
+ * @param options calculationOptions passed in by the user
+ * @returns {starttCql: Date, endCql: Date}, the start and end date of the calculationOptions
+ */
 export function getCQLIntervalEndpoints(options: CalculationOptions) {
   // Measure datetime stuff
   let start;

--- a/src/execution/Execution.ts
+++ b/src/execution/Execution.ts
@@ -128,7 +128,7 @@ export async function execute(
 /**
  * Takes in the calculation options and returns start and end dates to create a cql interval
  * @param options calculationOptions passed in by the user
- * @returns {starttCql: Date, endCql: Date}, the start and end date of the calculationOptions
+ * @returns {startCql: Date, endCql: Date}, the start and end date of the calculationOptions
  */
 export function getCQLIntervalEndpoints(options: CalculationOptions) {
   // Measure datetime stuff

--- a/src/gaps/GapsReportBuilder.ts
+++ b/src/gaps/GapsReportBuilder.ts
@@ -504,7 +504,13 @@ function getGapReasonCode(filter: AnyFilter): CareGapReasonCode | GracefulError 
       return { message: `unknown reasonCode mapping for filter type ${filter.type}` } as GracefulError;
   }
 }
-
+/**
+ *
+ * @param q The query which contains the filters to add to the data requirement
+ * @param dataRequirement Data requirement to add date filters to
+ * @param withErrors Errors object which will eventually be returned to the user if populated
+ * @returns void, but populated the dataRequirement filters
+ */
 export function addFiltersToDataRequirement(
   q: GapsDataTypeQuery | DataTypeQuery,
   dataRequirement: fhir4.DataRequirement,


### PR DESCRIPTION
# Summary
Used existing queryFilterParsers code to add date filters to the dataRequirements output

## New behavior
Data requirements output should now include date filters where appropriate

## Code changes
- Separated out two helper methods from GapsReportBuilder.ts, and Execution.ts
- Called helper functions in dataRequirements workflow to populate dateFilters

# Testing guidance
- Run all tests with `npm run test`
- Try running the following commands in the cli in the master branch
- `ts-node --files src/cli.ts -o gaps -m PATH_TO_EXM124 -p PATH_TO_EXM124_DENOM_PATIENTS -s 2019-01-01 -e 2020-01-01 > output_master_124.json`
- `ts-node --files src/cli.ts -o gaps -m PATH_TO_EXM130 -p PATH_TO_EXM130_DENOM_PATIENTS -s 2019-01-01 -e 2020-01-01 > output_master_130.json`
- Then, switch to data-req-date-filters and run
- `ts-node --files src/cli.ts -o gaps -m PATH_TO_EXM124 -p PATH_TO_EXM124_DENOM_PATIENTS -s 2019-01-01 -e 2020-01-01 > output124.json`
- `ts-node --files src/cli.ts -o gaps -m PATH_TO_EXM124 -p PATH_TO_EXM124_DENOM_PATIENTS -s 2019-01-01 -e 2020-01-01 > output130.json`
- You can use VScode's built in diff checking to ensure the results between my branch and master are the same, except for id fields and date fields that signify when the report was generated. To do this, right click on an output file and select `select for compare`, then click on the corresponding master output file and click `compare with selected`
- Now, do the same switching the report type to `dataRequirements` and compare again. Now, you should see dateFilters and code filters added on my branch, but no other changes.
- Finally, compare the guidanceResponses from the gaps in care output and ensure each dataRequirement listed has an equivalent dataRequirement in the dataRequirements output.