### PR TITLE
Defaulted calc options to {} in data requirements function

### DIFF
--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -469,7 +469,7 @@ export async function calculateGapsInCare(
  */
 export function calculateDataRequirements(
   measureBundle: fhir4.Bundle,
-  options: CalculationOptions
+  options: CalculationOptions = {}
 ): DRCalculationOutput {
   // Extract the library ELM, and the id of the root library, from the measure bundle
   const { cqls, rootLibIdentifier, elmJSONs } = MeasureBundleHelpers.extractLibrariesFromBundle(measureBundle);


### PR DESCRIPTION
# Summary

Introducing `calculationOptions` as an argument to the data requirements function actually introduced a breaking change to JS users of the library where the omission of the `options` parameter would throw a runtime error when trying to find the measurements period.

This PR just defaults it to `{}` to prevent that breaking change. The argument can still be left blank and the measurement period will be defaulted to 2019 as it always has 

## New behavior

None

## Code changes

Default arg to `{}`

# Testing guidance

run DR calculation and ensure it does stuff
