### PR TITLE
Add Gaps in Care support for multiple patient bundles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fqm-execution",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fqm-execution",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "FHIR Quality Measure Execution",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -327,7 +327,7 @@ export async function calculateGapsInCare(
   const { results, debugOutput, elmLibraries, mainLibraryName, parameters } = calculationResults;
   const measureReports = MeasureReportBuilder.buildMeasureReports(measureBundle, results, options);
 
-  let result: fhir4.Bundle = <fhir4.Bundle>{};
+  const result: fhir4.Bundle[] = [];
   const errorLog: GracefulError[] = [];
   results.forEach(res => {
     const matchingMeasureReport = measureReports.find(mr => mr.subject?.reference?.split('/')[1] === res.patientId);
@@ -370,7 +370,6 @@ export async function calculateGapsInCare(
       const populationCriteria =
         numerRelevance &&
         (improvementNotation === ImprovementNotation.POSITIVE ? denomResult && !numerResult : numerResult);
-
       if (populationCriteria) {
         const matchingGroup = measureResource.group?.find(g => g.id === dr.groupId) || measureResource.group?.[i];
 
@@ -444,19 +443,25 @@ export async function calculateGapsInCare(
         errorLog.push(...detectedIssueErrors);
 
         const patient = res.patientObject?._json as fhir4.Patient;
-        result = GapsInCareHelpers.generateGapsInCareBundle(detectedIssues, matchingMeasureReport, patient);
-
+        const gapsBundle = GapsInCareHelpers.generateGapsInCareBundle(detectedIssues, matchingMeasureReport, patient);
+        result.push(gapsBundle);
         if (debugOutput && options.enableDebugOutput) {
           debugOutput.gaps = {
             retrieves: detailedGapsRetrieves,
             bundle: result
           };
         }
+      } else {
+        result.push(<fhir4.Bundle>{});
       }
     });
   });
-
-  return { results: result, debugOutput, valueSetCache: calculationResults.valueSetCache, withErrors: errorLog };
+  return {
+    results: result.length === 1 ? result[0] : result,
+    debugOutput,
+    valueSetCache: calculationResults.valueSetCache,
+    withErrors: errorLog
+  };
 }
 
 /**

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -350,9 +350,19 @@ export interface RCalculationOutput extends CalculatorFunctionOutput {
 /**
  * dataType for calculateGapsInCare() function
  */
-export interface GICCalculationOutput extends CalculatorFunctionOutput {
-  results: fhir4.Bundle | fhir4.Bundle[];
+export interface GICCalculationOutput<T extends OneOrMultiPatient> extends CalculatorFunctionOutput {
+  results: OneOrManyBundles<T>;
 }
+
+/**
+ * type for declaring whether GICCalculation is for one or multiple patients
+ */
+export type OneOrMultiPatient = [fhir4.Bundle] | fhir4.Bundle[];
+
+/**
+ * conditional type to map OneOrMultiPatient into the return result of GIC calculation
+ */
+export type OneOrManyBundles<T extends OneOrMultiPatient> = T extends [fhir4.Bundle] ? fhir4.Bundle : fhir4.Bundle[];
 
 /**
  * dataType for calculateDataRequirements() function

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -286,7 +286,7 @@ export interface DebugOutput {
   measureReports?: fhir4.MeasureReport[];
   gaps?: {
     retrieves?: DataTypeQuery[];
-    bundle?: fhir4.Bundle;
+    bundle?: fhir4.Bundle | fhir4.Bundle[];
   };
 }
 
@@ -301,6 +301,7 @@ export interface CalculatorFunctionOutput {
     | cql.Results
     | string
     | fhir4.Bundle
+    | fhir4.Bundle[]
     | fhir4.Library
     | DataTypeQuery[];
   debugOutput?: DebugOutput;
@@ -350,7 +351,7 @@ export interface RCalculationOutput extends CalculatorFunctionOutput {
  * dataType for calculateGapsInCare() function
  */
 export interface GICCalculationOutput extends CalculatorFunctionOutput {
-  results: fhir4.Bundle;
+  results: fhir4.Bundle | fhir4.Bundle[];
 }
 
 /**


### PR DESCRIPTION
# Summary
This PR makes small changes to `calculateGapsInCare()` to allow results to be returned for multiple patient bundles.

## New behavior
Previously, `calculateGapsInCare()` would allow a patient bundles array as a parameter, but the `result` variable would only store the results for a single patient. Now, when calculating gaps in care with multiple patient bundles, an array will be returned with an entry for each patient. To avoid breaking changes, if only one patient bundle was provided, then the Bundle that is returned will not be wrapped in an array.

## Code changes
Changes were made in `calculateGapsInCare()` regarding the `result` variable. The output from `generateGapsInCareBundle()` is now pushed onto a `result` array of FHIR Bundles. 

# Testing guidance
First, try a basic request with output `"gaps"` for a single patient bundle, such as:

```
node build/cli.js -o gaps -m <PATH TO MEASURE BUNDLE> -p <PATH TO PATIENT BUNDLE>
```
The output should be the same as it appears on the master branch.

The, try sending a request with multiple patient bundles. For example, if testing with EXM 130, the command would be:

```
node build/cli.js -o gaps -m <PATH TO EXM130 MEASURE BUNDLE> -p <PATH TO EXM130 NUMERATOR PATIENT BUNDLE> <PATH TO EXM130 DENOMINATOR PATIENT BUNDLE> -s 2019-01-01 -e 2019-12-31
```
The results should be an array of length two. Note that the numerator patient's array entry will be an empty object. 