### PR TITLE
Added support QICore measures that output CQL System Codes for SDEs

### DIFF
--- a/src/calculation/MeasureReportBuilder.ts
+++ b/src/calculation/MeasureReportBuilder.ts
@@ -323,6 +323,13 @@ export default class MeasureReportBuilder {
               code: rr.code.value,
               display: rr.display.value
             });
+          } else if (rr.isCode) {
+            // if a CQL system code is returned
+            observation.valueCodeableConcept?.coding?.push({
+              system: rr.system,
+              code: rr.code,
+              display: rr.display
+            });
           }
         });
       } else if (sd.rawResult.isCode) {

--- a/test/MeasureReportBuilder.addSDE.test.ts
+++ b/test/MeasureReportBuilder.addSDE.test.ts
@@ -1,0 +1,181 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+
+import { PatientSource } from 'cql-exec-fhir';
+import MeasureReportBuilder from '../src/calculation/MeasureReportBuilder';
+import { getJSONFixture } from './helpers/testHelpers';
+import { ExecutionResult } from '../src/types/Calculator';
+import { PopulationType } from '../src/types/Enums';
+
+const patient1 = getJSONFixture(
+  'EXM130-8.0.000/EXM130-8.0.000-patients/numerator/Adeline686_Prohaska837_ee009b12-7dbe-4610-abc4-5f92ad5b2804.json'
+);
+const patientSource = PatientSource.FHIRv401();
+patientSource.loadBundles([patient1]);
+// ids from fixture patients
+const patient1Id = '3413754c-73f0-4559-9f67-df8e593ce7e1';
+
+const simpleMeasure = getJSONFixture('measure/simple-measure.json') as fhir4.Measure;
+const simpleMeasureBundle: fhir4.Bundle = {
+  resourceType: 'Bundle',
+  type: 'collection',
+  entry: [
+    {
+      resource: simpleMeasure
+    }
+  ]
+};
+
+const executionResultsTemplate: ExecutionResult[] = [
+  {
+    patientId: patient1Id,
+    detailedResults: [
+      {
+        groupId: 'group-1',
+        statementResults: [],
+        populationResults: [
+          {
+            populationType: PopulationType.NUMER,
+            result: false
+          },
+          {
+            populationType: PopulationType.DENOM,
+            result: true
+          },
+          {
+            populationType: PopulationType.IPP,
+            result: true
+          },
+          {
+            populationType: PopulationType.DENEX,
+            result: false
+          }
+        ],
+        html: 'example-html'
+      }
+    ],
+    supplementalData: [
+      {
+        name: 'sde-code',
+        rawResult: {
+          isCode: true,
+          code: 'example',
+          system: 'http://example.com',
+          display: 'Example'
+        }
+      }
+    ]
+  }
+];
+
+describe('MeasureReportBuilder Class', () => {
+  let builder: MeasureReportBuilder;
+  let executionResult: ExecutionResult;
+  beforeEach(() => {
+    builder = new MeasureReportBuilder(simpleMeasureBundle, {
+      reportType: 'individual',
+      calculateSDEs: true
+    });
+    executionResult = JSON.parse(JSON.stringify(executionResultsTemplate[0]));
+  });
+
+  describe('addSDE', () => {
+    test('Should allow for SDE Results to be single CQL system code', () => {
+      executionResult.supplementalData = [
+        {
+          name: 'sde-code',
+          rawResult: {
+            isCode: true,
+            code: 'example',
+            system: 'http://example.com',
+            display: 'Example'
+          }
+        }
+      ];
+      builder.addPatientResults(executionResult);
+      const report = builder.getReport();
+
+      expect(report.contained as fhir4.FhirResource[]).toHaveLength(1);
+
+      const sdeObserv = (report.contained as fhir4.FhirResource[])[0] as fhir4.Observation;
+      expect(sdeObserv.code.text).toBe('sde-code');
+      expect(sdeObserv.valueCodeableConcept).toEqual({
+        coding: [
+          {
+            system: 'http://example.com',
+            code: 'example',
+            display: 'Example'
+          }
+        ]
+      });
+    });
+
+    test('Should allow for SDE Results to be list of CQL system code', () => {
+      executionResult.supplementalData = [
+        {
+          name: 'sde-code',
+          rawResult: [
+            {
+              isCode: true,
+              code: 'example',
+              system: 'http://example.com',
+              display: 'Example'
+            }
+          ]
+        }
+      ];
+      builder.addPatientResults(executionResult);
+      const report = builder.getReport();
+
+      expect(report.contained as fhir4.FhirResource[]).toHaveLength(1);
+
+      const sdeObserv = (report.contained as fhir4.FhirResource[])[0] as fhir4.Observation;
+      expect(sdeObserv.code.text).toBe('sde-code');
+      expect(sdeObserv.valueCodeableConcept).toEqual({
+        coding: [
+          {
+            system: 'http://example.com',
+            code: 'example',
+            display: 'Example'
+          }
+        ]
+      });
+    });
+
+    test('Should allow for SDE Results to be list of FHIR coding', () => {
+      executionResult.supplementalData = [
+        {
+          name: 'sde-code',
+          rawResult: [
+            {
+              system: {
+                value: 'urn:oid:2.16.840.1.113883.6.238'
+              },
+              code: {
+                value: '2028-9'
+              },
+              display: {
+                value: 'Asian'
+              }
+            }
+          ]
+        }
+      ];
+      builder.addPatientResults(executionResult);
+      const report = builder.getReport();
+
+      expect(report.contained as fhir4.FhirResource[]).toHaveLength(1);
+
+      const sdeObserv = (report.contained as fhir4.FhirResource[])[0] as fhir4.Observation;
+      expect(sdeObserv.code.text).toBe('sde-code');
+      expect(sdeObserv.valueCodeableConcept).toEqual({
+        coding: [
+          {
+            system: 'urn:oid:2.16.840.1.113883.6.238',
+            code: '2028-9',
+            display: 'Asian'
+          }
+        ]
+      });
+    });
+  });
+});


### PR DESCRIPTION
# Summary

QICore measures return CQL System Codes instead of FHIR Codings for some SDEs. This expands support for this in the measure report builder. The builder already supported singular CQL Codes but it wasn't supported as an array.

## New behavior

Allows for SDEs that return list of CQL System Codes to be used in SDE compilation in MeasureReportBuilder.

## Code changes

In `MeasureReportBuilder.addSDE` allows for CQL System Codes to be returned in execution results to be valid and converted to SDEs. Adds a new test file for this

# Testing guidance

This one is a doozy. Running unit tests as-is is one way. To test with a real QICore measure we need to use a temporary patch to `cql-exec-fhir` and use patched test data.
- Setup the `cql-exec-fhir` dependency to use `https://github.com/projecttacoma/cql-exec-fhir/tree/profile-fallback`
  - Check out the `profile-fallback` branch in `projecttacoma` fork.
  - Run `npm install`.
  - Use `npm link` or change the dependency in package.lock to `file:/../path/to/cql-exec-fhir` clone.
- Run QICore EXM124 individual MeasureReport calculation with patient bundle from @hossenlopp on slack.
  - https://github.com/cqframework/ecqm-content-qicore-2020/blob/master/bundles/measure/EXM124v7QICore4/EXM124v7QICore4-bundle.json
- Look for the SDE Race and SDE Ethnicity Observation resources contained in the MeasureReport. Ensure these have codes in the `valueCodableConcept` attribute. Without this fix, the SDEs will not be populated with codes in the `valueCodableConcept` of the SDE Observations.