### PR TITLE
Update CQFM valueFilter extension in generateDetailedValueFilter()

### DIFF
--- a/src/helpers/DataRequirementHelpers.ts
+++ b/src/helpers/DataRequirementHelpers.ts
@@ -103,10 +103,11 @@ export function generateDetailedValueFilter(filter: Filter): fhir4.Extension | G
   if (filter.type === 'notnull') {
     const notnullFilter = filter as NotNullFilter;
     return {
-      url: 'http://example.com/dr-value',
+      url: 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-valueFilter',
       extension: [
-        { url: 'dr-value-attribute', valueString: notnullFilter.attribute },
-        { url: 'dr-value-filter', valueString: 'not null' }
+        { url: 'path', valueString: notnullFilter.attribute },
+        { url: 'comparator', valueCode: 'eq' },
+        { url: 'value', valueString: 'not null' }
       ]
     };
   } else if (filter?.withError) {

--- a/test/DataRequirementHelpers.test.ts
+++ b/test/DataRequirementHelpers.test.ts
@@ -297,10 +297,11 @@ describe('DataRequirementHelpers', () => {
       };
 
       const expectedDetailFilter: fhir4.Extension = {
-        url: 'http://example.com/dr-value',
+        url: 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-valueFilter',
         extension: [
-          { url: 'dr-value-attribute', valueString: 'attr-1' },
-          { url: 'dr-value-filter', valueString: 'not null' }
+          { url: 'path', valueString: 'attr-1' },
+          { url: 'comparator', valueCode: 'eq' },
+          { url: 'value', valueString: 'not null' }
         ]
       };
 

--- a/test/GapsInCareHelpers.test.ts
+++ b/test/GapsInCareHelpers.test.ts
@@ -1008,14 +1008,18 @@ describe('Guidance Response', () => {
         ],
         extension: [
           {
-            url: 'http://example.com/dr-value',
+            url: 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-valueFilter',
             extension: [
               {
-                url: 'dr-value-attribute',
+                url: 'path',
                 valueString: 'value'
               },
               {
-                url: 'dr-value-filter',
+                url: 'comparator',
+                valueCode: 'eq'
+              },
+              {
+                url: 'value',
                 valueString: 'not null'
               }
             ]


### PR DESCRIPTION
# Summary
This PR switches the [example.com](http://example.com/) url to the official URL for the CQFM valueFilter extension and updates the attributes of the valueFilter extension slices, further aligning our care gaps implementation with the [spec](http://build.fhir.org/ig/HL7/cqf-measures/StructureDefinition-cqfm-valueFilter.html).

## New behavior
No major behavior changes aside from updates to the valueFilter extension object.

## Code changes
Updated url in `generateDetailedValueFilter()` to use the URL `http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-valueFilter`, as proposed in [the CQFM Value Filter extension page](http://build.fhir.org/ig/HL7/cqf-measures/StructureDefinition-cqfm-valueFilter.html). 

Changes were also made to the extension slices to align with the spec. The `comparator` slice was added, as it is required by the spec. The extension also now includes the `path` and `value` slices (previously labeled as `dr-value-attribute` and `dr-value-filter`).

A handful of unit tests were updated to reflect these changes.

# Testing guidance
Run all unit tests and ensure that they pass. Review the spec and check that the appropriate slices have been added, and that all `value[x]` instances are of the correct type.
