### PR TITLE
Basic results interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ const queryInfo = Calculator.calculateQueryInfo(measureBundle); // Get detailed 
 The options that we support for calculation are as follows:
 | option | type | optional? | description |
 | :--------------------- | :-----: | :-------: | :--------------------------------------------------------------------------------- |
+| verboseCalculationResults | boolean | yes | Use the detailed results interfaces for calculation. Defaults to true. |
 | enableDebugOutput | boolean | yes | Enable debug output from function calls. Defaults to false. |
 | includeClauseResults | boolean | yes | Option to include clause results. Defaults to false. |
 | includePrettyResults | boolean | yes | Option to include pretty results on statement results. Defaults to false. |
@@ -109,6 +110,7 @@ Commands:
 
 Options:
   --debug                                     Enable debug output (default: false).
+  --slim                                      Use slimmed-down calculation results interfaces (default: false)
   --report-type <report-type>                 Type of report, "individual", "summary", "subject-list".
   -m, --measure-bundle <measure-bundle>       Path to measure bundle.
   -p, --patient-bundles <patient-bundles...>  Paths to patient bundles. Required unless --patient-ids is provided or output type is dataRequirements. Note: cannot be used with --patient-ids.

--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -54,6 +54,9 @@ export async function calculate<T extends CalculationOptions>(
   options: T,
   valueSetCache: fhir4.ValueSet[] = []
 ): Promise<CalculationOutput<T>> {
+  // Ensure verboseCalculationResults defaults to true when not provided in options
+  options.verboseCalculationResults = options.verboseCalculationResults ?? true;
+
   const debugObject: DebugOutput | undefined = options.enableDebugOutput ? <DebugOutput>{} : undefined;
 
   // Get the PatientSource to use for calculation.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -36,6 +36,7 @@ program.command('queryInfo').action(() => {
 
 program
   .option('--debug', 'Enable debug output.', false)
+  .option('--slim', 'Use slimmed-down calculation results interfaces', false)
   .option('--report-type <report-type>', 'Type of report, "individual", "summary", "subject-list".')
   .requiredOption('-m, --measure-bundle <measure-bundle>', 'Path to measure bundle.')
   .option(
@@ -141,7 +142,7 @@ const calcOptions: CalculationOptions = {
   enableDebugOutput: program.debug,
   vsAPIKey: program.vsApiKey,
   useValueSetCaching: program.cacheValuesets,
-  verboseCalculationResults: !program.disableVerboseCalculation
+  verboseCalculationResults: !program.slim
 };
 
 // Override the measurement period start/end in the options only if the user specified them

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -140,7 +140,8 @@ const cacheDirectory = 'cache/terminology';
 const calcOptions: CalculationOptions = {
   enableDebugOutput: program.debug,
   vsAPIKey: program.vsApiKey,
-  useValueSetCaching: program.cacheValuesets
+  useValueSetCaching: program.cacheValuesets,
+  verboseCalculationResults: !program.disableVerboseCalculation
 };
 
 // Override the measurement period start/end in the options only if the user specified them

--- a/src/helpers/DetailedResultsHelpers.ts
+++ b/src/helpers/DetailedResultsHelpers.ts
@@ -1,0 +1,47 @@
+import {
+  ExecutionResult,
+  DetailedPopulationGroupResult,
+  SimplePopulationGroupResult,
+  PopulationGroupResult
+} from '../types/Calculator';
+
+export function pruneDetailedResults(
+  executionResults: ExecutionResult<DetailedPopulationGroupResult>[]
+): ExecutionResult<SimplePopulationGroupResult>[] {
+  const prunedExecutionResults: ExecutionResult<SimplePopulationGroupResult>[] = [];
+  executionResults.forEach(er => {
+    if (er.detailedResults) {
+      const prunedDetailedResults: SimplePopulationGroupResult[] = er.detailedResults.map(dr => {
+        return {
+          groupId: dr.groupId,
+          ...(dr.populationResults ? { populationResults: dr.populationResults } : {}),
+          ...(dr.episodeResults ? { episodeResults: dr.episodeResults } : {}),
+          ...(dr.stratifierResults ? { stratifierResults: dr.stratifierResults } : {})
+        };
+      });
+
+      const newEr: ExecutionResult<SimplePopulationGroupResult> = {
+        ...er,
+        detailedResults: prunedDetailedResults
+      };
+
+      prunedExecutionResults.push(newEr);
+    } else {
+      // If detailed results don't exist, there's nothing to prune.
+      // we can pass through a casted version of `er`
+      prunedExecutionResults.push(er as ExecutionResult<SimplePopulationGroupResult>);
+    }
+  });
+
+  return prunedExecutionResults;
+}
+
+export function isDetailedResult(result: PopulationGroupResult): result is DetailedPopulationGroupResult {
+  const candidate = result as DetailedPopulationGroupResult;
+  return (
+    candidate.html != null ||
+    candidate.populationRelevance != null ||
+    candidate.clauseResults != null ||
+    candidate.statementResults != null
+  );
+}

--- a/src/helpers/DetailedResultsHelpers.ts
+++ b/src/helpers/DetailedResultsHelpers.ts
@@ -10,6 +10,10 @@ export function pruneDetailedResults(
 ): ExecutionResult<SimplePopulationGroupResult>[] {
   const prunedExecutionResults: ExecutionResult<SimplePopulationGroupResult>[] = [];
   executionResults.forEach(er => {
+    if (er.evaluatedResource) {
+      delete er.evaluatedResource;
+    }
+
     if (er.detailedResults) {
       const prunedDetailedResults: SimplePopulationGroupResult[] = er.detailedResults.map(dr => {
         return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * as Calculator from './calculation/Calculator';
+export { default as MeasureReportBuilder } from './calculation/MeasureReportBuilder';
 export * as ELMHelpers from './helpers/elm/ELMHelpers';
 export * as ELMDependencyHelpers from './helpers/elm/ELMDependencyHelpers';
 export * as MeasureBundleHelpers from './helpers/MeasureBundleHelpers';

--- a/test/MeasureReportBuilder.addSDE.test.ts
+++ b/test/MeasureReportBuilder.addSDE.test.ts
@@ -3,7 +3,7 @@
 import { PatientSource } from 'cql-exec-fhir';
 import MeasureReportBuilder from '../src/calculation/MeasureReportBuilder';
 import { getJSONFixture } from './helpers/testHelpers';
-import { ExecutionResult } from '../src/types/Calculator';
+import { ExecutionResult, DetailedPopulationGroupResult } from '../src/types/Calculator';
 import { PopulationType } from '../src/types/Enums';
 
 const patient1 = getJSONFixture(
@@ -25,7 +25,7 @@ const simpleMeasureBundle: fhir4.Bundle = {
   ]
 };
 
-const executionResultsTemplate: ExecutionResult[] = [
+const executionResultsTemplate: ExecutionResult<DetailedPopulationGroupResult>[] = [
   {
     patientId: patient1Id,
     detailedResults: [
@@ -69,7 +69,7 @@ const executionResultsTemplate: ExecutionResult[] = [
 
 describe('MeasureReportBuilder Class', () => {
   let builder: MeasureReportBuilder;
-  let executionResult: ExecutionResult;
+  let executionResult: ExecutionResult<DetailedPopulationGroupResult>;
   beforeEach(() => {
     builder = new MeasureReportBuilder(simpleMeasureBundle, {
       reportType: 'individual',

--- a/test/MeasureReportBuilder.addSDE.test.ts
+++ b/test/MeasureReportBuilder.addSDE.test.ts
@@ -68,7 +68,7 @@ const executionResultsTemplate: ExecutionResult<DetailedPopulationGroupResult>[]
 ];
 
 describe('MeasureReportBuilder Class', () => {
-  let builder: MeasureReportBuilder;
+  let builder: MeasureReportBuilder<DetailedPopulationGroupResult>;
   let executionResult: ExecutionResult<DetailedPopulationGroupResult>;
   beforeEach(() => {
     builder = new MeasureReportBuilder(simpleMeasureBundle, {

--- a/test/MeasureReportBuilder.test.ts
+++ b/test/MeasureReportBuilder.test.ts
@@ -3,7 +3,7 @@
 import { PatientSource } from 'cql-exec-fhir';
 import MeasureReportBuilder from '../src/calculation/MeasureReportBuilder';
 import { getJSONFixture } from './helpers/testHelpers';
-import { ExecutionResult, CalculationOptions } from '../src/types/Calculator';
+import { ExecutionResult, CalculationOptions, DetailedPopulationGroupResult } from '../src/types/Calculator';
 import { PopulationType } from '../src/types/Enums';
 
 const patient1 = getJSONFixture(
@@ -42,7 +42,7 @@ const cvMeasureBundle: fhir4.Bundle = {
   ]
 };
 
-const executionResults: ExecutionResult[] = [
+const executionResults: ExecutionResult<DetailedPopulationGroupResult>[] = [
   {
     patientId: patient1Id,
     detailedResults: [
@@ -84,7 +84,7 @@ const executionResults: ExecutionResult[] = [
   }
 ];
 
-const cvExecutionResults: ExecutionResult[] = [
+const cvExecutionResults: ExecutionResult<DetailedPopulationGroupResult>[] = [
   {
     patientId: patient2Id,
     detailedResults: [

--- a/test/helpers/DetailedResultsHelpers.test.ts
+++ b/test/helpers/DetailedResultsHelpers.test.ts
@@ -4,12 +4,25 @@ import {
   DetailedPopulationGroupResult,
   SimplePopulationGroupResult
 } from '../../src/types/Calculator';
+import { CQLPatient } from '../../src/types/CQLPatient';
 
 describe('pruneDetailedResults', () => {
   test('should not change result with no detailedResults', () => {
     const ers: ExecutionResult<DetailedPopulationGroupResult>[] = [
       {
         patientId: 'test-patient'
+      }
+    ];
+
+    expect(pruneDetailedResults(ers)).toEqual(ers);
+  });
+
+  test('should persist patientObject and supplementalData', () => {
+    const ers: ExecutionResult<DetailedPopulationGroupResult>[] = [
+      {
+        patientId: 'test-patient',
+        patientObject: {} as CQLPatient,
+        supplementalData: []
       }
     ];
 
@@ -55,6 +68,21 @@ describe('pruneDetailedResults', () => {
     expect(dr.populationResults).toEqual([]);
     expect(dr.stratifierResults).toEqual([]);
     expect(dr.episodeResults).toEqual([]);
+  });
+
+  test('should remove evaluatedResource', () => {
+    const ers: ExecutionResult<DetailedPopulationGroupResult>[] = [
+      {
+        patientId: 'test-patient',
+        evaluatedResource: []
+      }
+    ];
+
+    expect(pruneDetailedResults(ers)).toEqual([
+      {
+        patientId: 'test-patient'
+      }
+    ]);
   });
 });
 

--- a/test/helpers/DetailedResultsHelpers.test.ts
+++ b/test/helpers/DetailedResultsHelpers.test.ts
@@ -1,0 +1,126 @@
+import { pruneDetailedResults, isDetailedResult } from '../../src/helpers/DetailedResultsHelpers';
+import {
+  ExecutionResult,
+  DetailedPopulationGroupResult,
+  SimplePopulationGroupResult
+} from '../../src/types/Calculator';
+
+describe('pruneDetailedResults', () => {
+  test('should not change result with no detailedResults', () => {
+    const ers: ExecutionResult<DetailedPopulationGroupResult>[] = [
+      {
+        patientId: 'test-patient'
+      }
+    ];
+
+    expect(pruneDetailedResults(ers)).toEqual(ers);
+  });
+
+  test('should remove html/clauseResults/statementResults/populationRelevance', () => {
+    const ers: ExecutionResult<DetailedPopulationGroupResult>[] = [
+      {
+        patientId: 'test-patient',
+        detailedResults: [
+          {
+            groupId: 'group-0',
+            statementResults: [],
+            html: 'test',
+            populationRelevance: [],
+            clauseResults: [],
+            stratifierResults: [],
+            episodeResults: [],
+            populationResults: []
+          }
+        ]
+      }
+    ];
+
+    const pruned = pruneDetailedResults(ers);
+
+    expect(pruned).toHaveLength(1);
+    expect(pruned[0].detailedResults).toBeDefined();
+
+    // Cast to any to allow assertions on pruned properties
+    // Typescript will think they don't exist otherwise
+    (pruned[0].detailedResults as any[]).forEach(er => {
+      // These should be removed
+      expect(er.statementResults).toBeUndefined();
+      expect(er.clauseResults).toBeUndefined();
+      expect(er.html).toBeUndefined();
+      expect(er.populationRelevance).toBeUndefined();
+
+      // These should be persisted
+      expect(er.populationResults).toEqual([]);
+      expect(er.stratifierResults).toEqual([]);
+      expect(er.episodeResults).toEqual([]);
+    });
+  });
+});
+
+describe('isDetailedResult', () => {
+  test('should return true for anything that contains statementResults', () => {
+    const dr: DetailedPopulationGroupResult = {
+      groupId: 'group-0',
+      statementResults: []
+    };
+
+    expect(isDetailedResult(dr)).toBe(true);
+  });
+
+  test('should return true for anything that contains populationRelevance', () => {
+    const dr: DetailedPopulationGroupResult = {
+      groupId: 'group-0',
+      statementResults: [],
+      populationRelevance: []
+    };
+
+    expect(isDetailedResult(dr)).toBe(true);
+  });
+
+  test('should return true for anything that contains html', () => {
+    const dr: DetailedPopulationGroupResult = {
+      groupId: 'group-0',
+      statementResults: [],
+      html: 'test'
+    };
+
+    expect(isDetailedResult(dr)).toBe(true);
+  });
+
+  test('should return true for anything that contains clauseResults', () => {
+    const dr: DetailedPopulationGroupResult = {
+      groupId: 'group-0',
+      statementResults: [],
+      clauseResults: []
+    };
+
+    expect(isDetailedResult(dr)).toBe(true);
+  });
+
+  test('should return false for only populationResults', () => {
+    const sr: SimplePopulationGroupResult = {
+      groupId: 'group-0',
+      populationResults: []
+    };
+
+    expect(isDetailedResult(sr)).toBe(false);
+  });
+
+  test('should return false for only stratifierResults', () => {
+    const sr: SimplePopulationGroupResult = {
+      groupId: 'group-0',
+      stratifierResults: []
+    };
+
+    expect(isDetailedResult(sr)).toBe(false);
+  });
+
+  test('should return false for only episodeResults', () => {
+    const sr: SimplePopulationGroupResult = {
+      groupId: 'group-0',
+      episodeResults: []
+    };
+
+    expect(isDetailedResult(sr)).toBe(false);
+  });
+});

--- a/test/helpers/DetailedResultsHelpers.test.ts
+++ b/test/helpers/DetailedResultsHelpers.test.ts
@@ -42,18 +42,19 @@ describe('pruneDetailedResults', () => {
 
     // Cast to any to allow assertions on pruned properties
     // Typescript will think they don't exist otherwise
-    (pruned[0].detailedResults as any[]).forEach(er => {
-      // These should be removed
-      expect(er.statementResults).toBeUndefined();
-      expect(er.clauseResults).toBeUndefined();
-      expect(er.html).toBeUndefined();
-      expect(er.populationRelevance).toBeUndefined();
+    const [dr] = pruned[0].detailedResults as any;
+    expect(dr).toBeDefined();
 
-      // These should be persisted
-      expect(er.populationResults).toEqual([]);
-      expect(er.stratifierResults).toEqual([]);
-      expect(er.episodeResults).toEqual([]);
-    });
+    // These should be removed
+    expect(dr.statementResults).toBeUndefined();
+    expect(dr.clauseResults).toBeUndefined();
+    expect(dr.html).toBeUndefined();
+    expect(dr.populationRelevance).toBeUndefined();
+
+    // These should be persisted
+    expect(dr.populationResults).toEqual([]);
+    expect(dr.stratifierResults).toEqual([]);
+    expect(dr.episodeResults).toEqual([]);
   });
 });
 


### PR DESCRIPTION
# Summary

This PR introduces a new "slim" mode to detailed results calculation that does not include verbose reporting of clause results, statement results, relevance, and highlighted HTML. By default, it will use the verbose output unless the `verboseCalculationResults` calculation option is set to `false`

## New behavior

* For the CLI, when using the `--slim` options, it will strip off all the unnecessary info on a detailed result that doesn't contribute to interpreting the population
* For the `calculate` API function, when provided `verboseCalculationResults: false`, it will strip off the irrelevant information

## Code changes

* `calculate` strips off unneeded information when `verboseCalculationResults` is false
* `calculate` is now a generic on CalculationOptions
  * This allows the function to infer its own return type based on the value of `verboseCalculationResults`
* Update types to support returning of simple or detailed results
* Update MeasureReportBuilder to be generic on type of detailed result
  * Can optionally do `new MeasureReportBuilder<SimplePopulationGroupResult>(...);` or `new MeasureReportBuilder<DetailedPopulationGroupResult>(...);`
* Le unit tests

# Testing guidance

* Run cli with `--slim` flag on reports and detailed output types. For the former, it should not generate an HTML narrative. For the latter, it should only generate `populationResults`
* Try to mimic a call to the calculate function yourself in a different file with custom calculation options, e.g.:

``` Typescript

const b = <fhir4.Bundle>{};
calculate(b, [b], {
  verboseCalculationResults: false
}).then(({ results }) => {
  // results should be of type ExecutionResult<SimplePopulationGroupResult>[]
});

calculate(b, [b], {
  verboseCalculationResults: true
}).then(({ results }) => {
  // results should be of type ExecutionResult<DetailedPopulationGroupResult>[]
});

calculate(b, [b], {}).then(({ results }) => {
  // results should be of type ExecutionResult<DetailedPopulationGroupResult>[]
});
```

This is the magic of generics
