### PR TITLE
Moved @types/fhir to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -865,8 +865,7 @@
     "@types/fhir": {
       "version": "0.0.34",
       "resolved": "https://registry.npmjs.org/@types/fhir/-/fhir-0.0.34.tgz",
-      "integrity": "sha512-8pCGwxYMKbxHzFmekh4HnhLvolDB+Tj61LT6yFkL+ERSFtbUvEdvcxMip52pd0vW4PLUyUk1otRvZq07HKCSzQ==",
-      "dev": true
+      "integrity": "sha512-8pCGwxYMKbxHzFmekh4HnhLvolDB+Tj61LT6yFkL+ERSFtbUvEdvcxMip52pd0vW4PLUyUk1otRvZq07HKCSzQ=="
     },
     "@types/graceful-fs": {
       "version": "4.1.5",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build/*"
   ],
   "dependencies": {
+    "@types/fhir": "0.0.34",
     "atob": "^2.1.2",
     "axios": "^0.21.1",
     "commander": "^6.1.0",
@@ -19,8 +20,7 @@
     "handlebars": "^4.7.7",
     "lodash": "^4.17.21",
     "moment": "^2.29.0",
-    "uuid": "^8.3.1",
-    "@types/fhir": "0.0.34"
+    "uuid": "^8.3.1"
   },
   "devDependencies": {
     "@types/handlebars": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
     "handlebars": "^4.7.7",
     "lodash": "^4.17.21",
     "moment": "^2.29.0",
-    "uuid": "^8.3.1"
+    "uuid": "^8.3.1",
+    "@types/fhir": "0.0.34"
   },
   "devDependencies": {
-    "@types/fhir": "0.0.34",
     "@types/handlebars": "^4.1.0",
     "@types/jest": "^26.0.5",
     "@types/lodash": "^4.14.170",


### PR DESCRIPTION
# Summary
Moved @types/fhir to dependencies. This was done because we export some types that rely on types inside @types/fhir. Although it is not typical to include types files in dependencies, developers using our exported types could run into errors if @types/fhir is left as a dev dependency

## New behavior
None

## Code changes
- Moved @types/fhir to dependencies

# Testing guidance
- Run `npm test`
- Run any other calculations you'd like and ensure no output is changed
