### PR TITLE
add shouldCheckProfile flag to PatientSource/AsyncPatientSource classes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -401,17 +401,17 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.17.8",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.8.tgz",
-      "integrity": "sha512-dQpEpK0O9o6lj6oPu0gRDbbnk+4LeHlNcBpspf6Olzt3GIX4P1lWF1gS+pHLDFlaJvbR6q7jCfQ08zA4QJBnmA==",
+      "version": "7.17.9",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
+      "integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
     },
     "@babel/runtime-corejs3": {
-      "version": "7.17.8",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.17.8.tgz",
-      "integrity": "sha512-ZbYSUvoSF6dXZmMl/CYTMOvzIFnbGfv4W3SEHYgMvNsFTeLaF2gkGAF4K2ddmtSK4Emej+0aYcnSC6N5dPCXUQ==",
+      "version": "7.17.9",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.17.9.tgz",
+      "integrity": "sha512-WxYHHUWF2uZ7Hp1K+D1xQgbgkGUfA+5UPOegEXGt2Y5SMog/rYCVaifLZDbw8UkNXozEqqrZTy6bglL7xTaCOw==",
       "requires": {
         "core-js-pure": "^3.20.2",
         "regenerator-runtime": "^0.13.4"
@@ -1641,7 +1641,7 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "cql-exec-fhir": {
-      "version": "github:projecttacoma/cql-exec-fhir#95f951ebbf05eb0d7632746a42d8b43ae173400b",
+      "version": "github:projecttacoma/cql-exec-fhir#3d0f70d79993012af947022c41f6d35a2622c24e",
       "from": "github:projecttacoma/cql-exec-fhir",
       "requires": {
         "@babel/runtime": "^7.17.2",

--- a/src/types/CQLExecFHIR.d.ts
+++ b/src/types/CQLExecFHIR.d.ts
@@ -16,7 +16,7 @@ declare module 'cql-exec-fhir' {
     currentPatient(): Patient | undefined;
     nextPatient(): Patient | undefined;
     reset(): void;
-    static FHIRv401(): PatientSource;
+    static FHIRv401(shouldCheckProfile?: boolean): PatientSource;
   }
   export class AsyncPatientSource {
     constructor(serverInfo: string);
@@ -24,7 +24,7 @@ declare module 'cql-exec-fhir' {
     currentPatient(): AsyncPatient | undefined;
     nextPatient(): AsyncPatient | undefined;
     reset: void;
-    static FHIRv401(serverInfo: string): AsyncPatientSource;
+    static FHIRv401(serverInfo: string, shouldCheckProfile?: boolean): AsyncPatientSource;
   }
   export class FHIRWrapper {
     constructor(filePathOrXML: string);


### PR DESCRIPTION
# Summary
Updates the types for `PatientSource` and `AsyncPatientSource` classes in `CQLExecFHIR.d.ts`.

## New behavior
The new `shouldCheckProfile` boolean flag for `meta.profile` validation in cql-exec-fhir caused a breaking change in fqm-execution (build would fail because of the additional input to `AsyncPatientSource.FHIRv401()` and `PatientSource.FHIRv401()`). Now, the user will be able to test meta.profile validation in fqm-execution without any build errors.

## Code changes
Updated `CQLExecFHIR.d.ts` to account for the `shouldCheckProfile` boolean flag.

# Testing guidance
Follow the guidance laid out in the [meta.profile validation PR](https://github.com/projecttacoma/cql-exec-fhir/pull/4) for testing the meta.profile validation changes in fqm-execution. Test with the boolean flag set to `true`.
