### PR TITLE
Updates to accommodate Global.Latest

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -103,7 +103,7 @@ async function calc(
     result = calculateDataRequirements(measureBundle, calcOptions);
   } else if (program.outputType === 'queryInfo') {
     // calculateQueryInfo doesn't make use of the calcOptions object at this point
-    result = calculateQueryInfo(measureBundle);
+    result = calculateQueryInfo(measureBundle, calcOptions);
   }
   if (!result) {
     throw new Error(`Could not obtain result based on outputType ${program.outputType}`);


### PR DESCRIPTION
# Summary
Updates to better handle the HbA1c measure (122), in particular identifying unsupported logic and handling Global.Latest well enough to give detailed gaps.
## New behavior
The queryInfo endpoint now accepts a measurement period, and the gaps endpoint can now calculate a detailed gap for the high HbA1c Laboratory Test that causes the patient to fall in the numerator (for a negative improvement measure).
## Code changes
- Added measurement period input for `calculateQueryInfo` endpoint
- `QueryFilterParser`
-- Added passthrough for "Latest" in that also allows for `MATGlobalCommonFunctionsFHIR4`
-- Added code for `interpretIn` to handle a parameter ref second operand
- Added unit test for `InterpretIn` that handles parameter ref second operand

# Testing guidance
run `npm run test`
Measure bundle and numerator patient can be pulled from here: https://github.com/cqframework/ecqm-content-r4-2021/tree/master/bundles/measure/DiabetesHemoglobinA1cHbA1cPoorControl9FHIR
The measure has a small issue that should be corrected for testing. Search the measure for `improvementNotation` and change the code to `decrease` because this should be a negative improvement measure.

Gaps has been updated to be able to now create a dateFilter detailed gap in the gaps report which indicates that a RecentHbA1c effective date for a high level was found during the measurement period. Sample gaps launch args:
```
"args": ["gaps", "--debug","-m", "${workspaceFolder}/test/fixtures/DiabetesHemoglobinA1cHbA1cPoorControl9FHIR-bundle.json", "-p", "${workspaceFolder}/test/fixtures/tests-numer-CMS122-Patient-bundle.json", "-s", "20190101", "-e", "20191231"]
```
Query info should be able to handle a measurement period now. The output can be used to see what results are still "unknown" in our interpretation (there are still some cases like `exists` that we don't handle for full coverage of this measure, but we seem to cover the critical ones). Sample query launch args:
```
"args": ["queryInfo", "--debug","-m", "${workspaceFolder}/test/fixtures/DiabetesHemoglobinA1cHbA1cPoorControl9FHIR-bundle.json", "-s", "20190101", "-e", "20191231"]
```
