### PR TITLE
Added new cli flag to support meta.profile validation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ The options that we support for calculation are as follows:
 | calculateHTML | boolean | yes | Include HTML structure for highlighting. Defaults to false. |
 | vsAPIKey | string | yes | API key, to be used to access a valueset API for downloading any missing valuesets |
 | useValueSetCaching | boolean | yes | Whether to cache valuesets obtained by an API on the filesystem |
+| profileValidation | boolean | yes |  To "trust" the content of meta.profile as a source of truth for what profiles the data that cql-exec-fhir grabs validates against|
 
 ### CLI
 
@@ -122,6 +123,7 @@ Options:
   -e, --measurement-period-end <date>         End date for the measurement period, in YYYY-MM-DD format (defaults to the end date defined in the Measure, or 2019-12-31 if not set there).
   --vs-api-key <key>                          API key, to authenticate against the valueset service to be used for resolving missing valuesets.
   --cache-valuesets                           Whether or not to cache ValueSets retrieved from the ValueSet service (default: false)
+  --profile-validation                         To "trust" the content of meta.profile as a source of truth for what profiles the data that cql-exec-fhir grabs validates against|
   -h, --help                                  Display help for command.
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1641,7 +1641,7 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "cql-exec-fhir": {
-      "version": "github:projecttacoma/cql-exec-fhir#3d0f70d79993012af947022c41f6d35a2622c24e",
+      "version": "github:projecttacoma/cql-exec-fhir#e53a6641197b56a220077b5d38c13b1398eadefd",
       "from": "github:projecttacoma/cql-exec-fhir",
       "requires": {
         "@babel/runtime": "^7.17.2",
@@ -1661,7 +1661,7 @@
       }
     },
     "cql-execution": {
-      "version": "github:projecttacoma/cql-execution#fc2ead15e584fee0131afe5893d768f5ff7a6bbb",
+      "version": "github:projecttacoma/cql-execution#36346a0fe1526abf48bfe8bdb37fe9e8164292bb",
       "from": "github:projecttacoma/cql-execution",
       "requires": {
         "@lhncbc/ucum-lhc": "^4.1.3",

--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -633,7 +633,7 @@ function resolvePatientSource(patientBundles: fhir4.Bundle[], options: Calculati
     if (patientBundles.filter(pb => pb.entry?.length).length === 0) {
       throw new UnexpectedResource('No entries found in passed patient bundles');
     }
-    const patientSource = PatientSource.FHIRv401();
+    const patientSource = PatientSource.FHIRv401(options.trustMetaProfile);
     patientSource.loadBundles(patientBundles);
     return patientSource;
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -68,6 +68,7 @@ program
     '--fhir-server-url <server-url>',
     'Loads bundles into an AsyncPatientSource which queries the passed in FHIR server URL for patient data. Note: --as-patient-source and --patient-ids are required when --fhir-server-url is provided.'
   )
+  .option('--profile-validation', 'To "trust" the content of meta.profile as a source of truth for what profiles the data that cql-exec-fhir grabs validates against.', false)
   .parse(process.argv);
 
 function parseBundle(filePath: string): fhir4.Bundle {
@@ -136,6 +137,7 @@ if (program.cacheValuesets && !program.vsApiKey) {
   program.help();
 }
 
+
 const cacheDirectory = 'cache/terminology';
 
 const calcOptions: CalculationOptions = {
@@ -163,16 +165,18 @@ if (program.asPatientSource) {
         'Must provide an array of patient ids with --patient-ids flag for calculation using AsyncPatientSource'
       );
     }
-    patientSource = AsyncPatientSource.FHIRv401(program.fhirServerUrl);
+    patientSource = AsyncPatientSource.FHIRv401(program.fhirServerUrl, program.profileValidation);
     patientSource.loadPatientIds(program.patientIds);
   } else {
-    patientSource = PatientSource.FHIRv401();
+    patientSource = PatientSource.FHIRv401(program.profileValidation);
     patientSource.loadBundles(patientBundles);
   }
   calcOptions.patientSource = patientSource;
   patientBundles = [];
 }
-
+if(program.profileValidation){
+  calcOptions.trustMetaProfile= program.profileValidation;
+}
 // Calculation is now async, so we have to do a callback here
 calc(
   measureBundle,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -147,7 +147,8 @@ const calcOptions: CalculationOptions = {
   enableDebugOutput: program.debug,
   vsAPIKey: program.vsApiKey,
   useValueSetCaching: program.cacheValuesets,
-  verboseCalculationResults: !program.slim
+  verboseCalculationResults: !program.slim,
+  trustMetaProfile: program.profileValidation
 };
 
 // Override the measurement period start/end in the options only if the user specified them
@@ -176,9 +177,6 @@ if (program.asPatientSource) {
   }
   calcOptions.patientSource = patientSource;
   patientBundles = [];
-}
-if (program.profileValidation) {
-  calcOptions.trustMetaProfile = program.profileValidation;
 }
 // Calculation is now async, so we have to do a callback here
 calc(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -68,7 +68,11 @@ program
     '--fhir-server-url <server-url>',
     'Loads bundles into an AsyncPatientSource which queries the passed in FHIR server URL for patient data. Note: --as-patient-source and --patient-ids are required when --fhir-server-url is provided.'
   )
-  .option('--profile-validation', 'To "trust" the content of meta.profile as a source of truth for what profiles the data that cql-exec-fhir grabs validates against.', false)
+  .option(
+    '--profile-validation',
+    'To "trust" the content of meta.profile as a source of truth for what profiles the data that cql-exec-fhir grabs validates against.',
+    false
+  )
   .parse(process.argv);
 
 function parseBundle(filePath: string): fhir4.Bundle {
@@ -137,7 +141,6 @@ if (program.cacheValuesets && !program.vsApiKey) {
   program.help();
 }
 
-
 const cacheDirectory = 'cache/terminology';
 
 const calcOptions: CalculationOptions = {
@@ -174,8 +177,8 @@ if (program.asPatientSource) {
   calcOptions.patientSource = patientSource;
   patientBundles = [];
 }
-if(program.profileValidation){
-  calcOptions.trustMetaProfile= program.profileValidation;
+if (program.profileValidation) {
+  calcOptions.trustMetaProfile = program.profileValidation;
 }
 // Calculation is now async, so we have to do a callback here
 calc(

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -38,7 +38,7 @@ export interface CalculationOptions {
   useValueSetCaching?: boolean;
   /** If false, detailed results will only contain information necessary to interpreting simple population results */
   verboseCalculationResults?: boolean;
-  /** if true the he content of meta.profile as a source of truth for what profiles the data that cql-exec-fhir grabs validates against */
+  /** if true trust the content of meta.profile as a source of truth for what profiles the data that cql-exec-fhir grabs validates against */
   trustMetaProfile?: boolean;
 }
 
@@ -169,7 +169,7 @@ export interface StatementResult {
   localId?: string;
   /** Final, processed result of raw calculation */
   final: FinalResult;
-  /** The relevance of this statement for the poulation group */
+  /** The relevance of this statement for the population group */
   relevance: Relevance;
   /** Raw result from the engine */
   raw?: any;
@@ -178,7 +178,7 @@ export interface StatementResult {
 }
 
 /**
- * Result for a particular stratifer for a patient or episode.
+ * Result for a particular stratifier for a patient or episode.
  */
 export interface StratifierResult {
   /**
@@ -234,7 +234,7 @@ export interface DataTypeQuery {
   retrieveLocalId?: string;
   /** localId in ELM for the query statement */
   queryLocalId?: string;
-  /** name of the library where the statment can be looked up */
+  /** name of the library where the statement can be looked up */
   retrieveLibraryName?: string;
   /** name of library where the outermost query is */
   queryLibraryName?: string;

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -38,6 +38,8 @@ export interface CalculationOptions {
   useValueSetCaching?: boolean;
   /** If false, detailed results will only contain information necessary to interpreting simple population results */
   verboseCalculationResults?: boolean;
+  /** if true the he content of meta.profile as a source of truth for what profiles the data that cql-exec-fhir grabs validates against */
+  trustMetaProfile?: boolean;
 }
 
 /**


### PR DESCRIPTION
# Summary
Added a new  CLI flag that says whether or not to "trust" the content of meta.profile as a source of truth for what profiles the data that cql-exec-fhir grabs validates against.
The flag is  stored in the CalculationOptions, and passed along to construction of a cql-exec-fhir patient source. It  defaults to false and is optional.

## New behavior
The default behavior is unchanged, if the user chooses to pass the flag `--profile-validation` to the cli or via launch.json fqm-execution will use meta.profile as the source of truth for what profiles the data that cql-exec-fhir grabs validates against.
## Code changes
`Readme.md` - added documentation for the flag
`src/types/Calculator.ts` - added  `trustMetaProfile` flag to track if the calculation was supposed to use the meta.profile as the source of truth. 
`src/cli.ts` - added new cli flag to track signal if we should use the meta.profile, this flag defaults to false  and is optional as a result. Modified calls to `PatientSource` constructor to now accept this flag, updated the creation of `calcOptions` object to store this flag as well. 
# Testing guidance
Run all tests, and make sure unit tests still pass. 
 I used the modified bundles that Nat had previously used for testing [this pr](https://github.com/projecttacoma/cql-exec-fhir/pull/4) as well as using the qi-core bundles referenced  [here](https://github.com/projecttacoma/cql-exec-fhir/pull/4)

Testing:
Run a reports calculation on EXM130 using the altered numerator patient bundle with the `--as-patient-source` and the `--profile-validation`  flag. You should see the patient calculate into the numerator
Now, change the meta.profile of Procedure numer-EXM130-1 in any way you like (I just added a 1 to the end)
Rerun the same report and the patient should evaluate into the denominator, as the necessary procedure is no longer evaluated

Testing an async patient source:
 You should upload the qi core measure and patient bundle to a running deqm-test-server
Then use http://localhost:3000/4_0_1 as the --fhir-server-url CLI option, and set the --profile-validation`  flag as well
And the ID of the patient resource in the qi core numerator patient for the --patient-ids CLI option
Thttps://github.com/projecttacoma/fqm-execution/pull/112 are further details about testing with async patient sources in this pr here