### PR TITLE
Value compare reason detail

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3849,9 +3849,9 @@
       "dev": true
     },
     "moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
+      "version": "2.29.3",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.3.tgz",
+      "integrity": "sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw=="
     },
     "ms": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "cql-execution": "github:projecttacoma/cql-execution",
     "handlebars": "^4.7.7",
     "lodash": "^4.17.21",
-    "moment": "^2.29.0",
+    "moment": "^2.29.3",
     "uuid": "^8.3.1"
   },
   "devDependencies": {

--- a/src/gaps/GapsReportBuilder.ts
+++ b/src/gaps/GapsReportBuilder.ts
@@ -20,9 +20,11 @@ import {
   DuringFilter,
   AnyFilter,
   NotNullFilter,
-  AttributeFilter
+  AttributeFilter,
+  ValueFilter
 } from '../types/QueryFilterTypes';
 import { GracefulError, isOfTypeGracefulError } from '../types/errors/GracefulError';
+import { compareValues } from '../helpers/ValueComparisonHelpers';
 
 /**
  * Iterate through base queries and add clause results for parent query and retrieve
@@ -363,32 +365,91 @@ export function calculateReasonDetail(
   detailedResult?: DetailedPopulationGroupResult
 ): { results: GapsDataTypeQuery[]; withErrors: GracefulError[] } {
   const withErrors: GracefulError[] = [];
+  const isPositiveImprovement = improvementNotation === ImprovementNotation.POSITIVE;
   const results = retrieves.map(r => {
-    let reasonDetail: ReasonDetail;
-    // If this is a positive improvement notation measure then we can look for reasons why the query wasn't satisfied
-    if (improvementNotation === ImprovementNotation.POSITIVE) {
-      // Create the initial reasonDetail information. There will be detail if the retrieve has a result but the query
-      // that filters on the retrieve does not have any results.
-      reasonDetail = {
-        hasReasonDetail: r.retrieveHasResult === true && r.parentQueryHasResult === false,
-        reasons: []
-      };
+    const reasonDetail: ReasonDetail = {
+      hasReasonDetail: false,
+      reasons: []
+    };
 
-      // If there are results for this clause and we have queryInfo then we can look at each of the
-      // resources from the retrieve results and record reasons for each filter they did not satisfy
-      if (reasonDetail.hasReasonDetail && r.queryInfo && detailedResult?.clauseResults) {
+    // If this is a positive improvement notation measure then we can look for reasons why the query wasn't satisfied
+    let shouldCalculateReasonDetail = false;
+    if (r.queryInfo?.fromExternalClause === true) {
+      // Clause doing the comparison of values
+      const valueClauseResult = detailedResult?.clauseResults?.find(
+        cr => cr.libraryName === r.retrieveLibraryName && cr.localId === r.valueComparisonLocalId
+      );
+
+      // reasonDetail occurs in this cause if the clause doing the comparison of some value
+      // has a truthy result for negative imporve, falsy for pos,
+      shouldCalculateReasonDetail = isPositiveImprovement
+        ? valueClauseResult?.final === FinalResult.FALSE
+        : valueClauseResult?.final === FinalResult.TRUE;
+    } else {
+      // Else, clause has come from the where part of a query
+      // compute reasonDetail if the overall query was truthy for negative improve, falsy for pos
+      shouldCalculateReasonDetail = shouldCalculateReasonDetail = isPositiveImprovement
+        ? r.parentQueryHasResult === false
+        : r.parentQueryHasResult === true;
+    }
+
+    // If we detect more going on, set the boolean to true
+    // NOTE: this may still result in a basic reason code, but it allows the engine to recognize
+    // that more information was processed
+    reasonDetail.hasReasonDetail = shouldCalculateReasonDetail;
+
+    if (shouldCalculateReasonDetail === true) {
+      if (r.queryInfo && detailedResult?.clauseResults) {
         const flattenedFilters = flattenFilters(r.queryInfo.filter);
         const resources = detailedResult.clauseResults?.find(
           cr => cr.libraryName === r.retrieveLibraryName && cr.localId === r.retrieveLocalId
         );
 
         if (resources) {
-          // loop through resources from the results
+          // Compute reason detail for every filter present on the found raw data from a retrieve
           resources.raw.forEach((resource: any) => {
-            // loop through each filter
             flattenedFilters.forEach(f => {
-              // Separate interval handling for 'during' filters
-              if (f.type === 'during') {
+              // ValueFilters are handled for both positive and negative improvement measures
+              if (f.type === 'value') {
+                const valueFilter = f as ValueFilter;
+                const reason: ReasonDetailData = <ReasonDetailData>{
+                  path: valueFilter.attribute
+                };
+
+                // TODO: might need to check if we get an array or a singleton
+                // a query could return either
+                const attrPath = valueFilter.attribute?.split('.');
+
+                // Access desired property of FHIRObject
+                let desiredAttr = resource;
+                attrPath?.forEach(key => {
+                  if (desiredAttr) {
+                    desiredAttr = desiredAttr[key];
+                  }
+                });
+
+                let comparisonResult: boolean | null = null;
+                if (valueFilter.valueQuantity?.value) {
+                  const quantity = desiredAttr.value;
+                  const actualValue = quantity.value as number;
+                  const requiredValue = valueFilter.valueQuantity.value;
+
+                  comparisonResult = compareValues(actualValue, requiredValue, valueFilter.comparator);
+                } else if (valueFilter.valueInteger) {
+                  comparisonResult = compareValues(
+                    desiredAttr.value as number,
+                    valueFilter.valueInteger,
+                    valueFilter.comparator
+                  );
+                }
+
+                // Resource caused gap
+                if (comparisonResult === true) {
+                  reason.reference = `${resource._json.resourceType}/${resource._json.id}`;
+                  reason.code = CareGapReasonCode.VALUEOUTOFRANGE;
+                  reasonDetail.reasons.push(reason);
+                }
+              } else if (isPositiveImprovement && f.type === 'during') {
                 const duringFilter = f as DuringFilter;
 
                 if (duringFilter.valuePeriod.interval) {
@@ -432,7 +493,7 @@ export function calculateReasonDetail(
                     });
                   }
                 }
-              } else if (f.type === 'notnull') {
+              } else if (isPositiveImprovement && f.type === 'notnull') {
                 const notNullFilter = f as NotNullFilter;
                 const attrPath = notNullFilter.attribute.split('.');
 
@@ -456,7 +517,7 @@ export function calculateReasonDetail(
                     reference: `${resource._json.resourceType}/${resource.id.value}`
                   });
                 }
-              } else {
+              } else if (isPositiveImprovement) {
                 // TODO: This logic is not perfect, and can be corrupted by multiple resources spanning truthy values for all filters
                 // For non-during filters, look up clause result by localId
                 // Ideally we can look to modify cql-execution to help us with this flaw
@@ -488,18 +549,15 @@ export function calculateReasonDetail(
           });
         }
       }
-
-      // If no specific reason details found, default is NotFound
-      if (reasonDetail.hasReasonDetail && reasonDetail.reasons.length === 0) {
-        reasonDetail.reasons = [{ code: CareGapReasonCode.NOTFOUND }];
-      }
-    } else {
-      // TODO: Handle negative improvement cases, similar to above but it will be a bit more complicated.
-      reasonDetail = {
-        hasReasonDetail: false,
-        reasons: []
-      };
     }
+
+    // If no specific reason details found, default is NotFound or Present based on ImprovementNotation
+    if (reasonDetail.reasons.length === 0) {
+      reasonDetail.reasons = isPositiveImprovement
+        ? [{ code: CareGapReasonCode.NOTFOUND }]
+        : [{ code: CareGapReasonCode.PRESENT }];
+    }
+
     // add the reason detail we calculated to the query info and retrieve and return it
     return { ...r, reasonDetail };
   });

--- a/src/gaps/GapsReportBuilder.ts
+++ b/src/gaps/GapsReportBuilder.ts
@@ -444,7 +444,7 @@ export function calculateReasonDetail(
                 }
 
                 // Resource caused gap
-                if (comparisonResult === true) {
+                if (isPositiveImprovement ? comparisonResult === false : comparisonResult === true) {
                   reason.reference = `${resource._json.resourceType}/${resource._json.id}`;
                   reason.code = CareGapReasonCode.VALUEOUTOFRANGE;
                   reasonDetail.reasons.push(reason);

--- a/src/gaps/GapsReportBuilder.ts
+++ b/src/gaps/GapsReportBuilder.ts
@@ -250,6 +250,17 @@ export function generateGuidanceResponses(
     };
     return guidanceResponse;
   });
+
+  // Prefer GRs to be sorted by ones with more specific reasonCodes other than PRESENT or MISSING
+  guidanceResponses.sort((gr1, gr2) => {
+    if (hasDetailedReasonCode(gr1)) {
+      return -1;
+    } else if (hasDetailedReasonCode(gr2)) {
+      return 1;
+    }
+    return 0;
+  });
+
   return { guidanceResponses, withErrors };
 }
 
@@ -618,4 +629,12 @@ export function addFiltersToDataRequirement(
       }
     });
   }
+}
+
+export function hasDetailedReasonCode(gr: fhir4.GuidanceResponse) {
+  return (
+    gr.reasonCode?.some(c => {
+      return c.coding?.[0]?.code !== CareGapReasonCode.NOTFOUND && c.coding?.[0]?.code !== CareGapReasonCode.PRESENT;
+    }) || false
+  );
 }

--- a/src/gaps/QueryFilterParser.ts
+++ b/src/gaps/QueryFilterParser.ts
@@ -115,6 +115,8 @@ export async function parseQueryInfo(
         } else {
           queryInfo.filter = comparisonInfo;
         }
+
+        queryInfo.fromExternalClause = true;
       }
     }
     // If this query's source is a reference to an expression that is a query then we should parse it and include

--- a/src/helpers/ValueComparisonHelpers.ts
+++ b/src/helpers/ValueComparisonHelpers.ts
@@ -1,0 +1,21 @@
+import { ValueFilterComparator } from '../types/QueryFilterTypes';
+
+/**
+ * Computes truthiness of value comparisons obtained from value filter
+ */
+export function compareValues(actualValue: number, desiredValue: number, comparator: ValueFilterComparator) {
+  switch (comparator) {
+    case 'ge':
+      return actualValue >= desiredValue;
+    case 'gt':
+      return actualValue > desiredValue;
+    case 'le':
+      return actualValue <= desiredValue;
+    case 'lt':
+      return actualValue < desiredValue;
+    case 'eq':
+      return actualValue == desiredValue;
+    default:
+      throw new Error(`Unsupported comparator "${comparator}" when comparing values`);
+  }
+}

--- a/src/helpers/ValueComparisonHelpers.ts
+++ b/src/helpers/ValueComparisonHelpers.ts
@@ -14,7 +14,7 @@ export function compareValues(actualValue: number, desiredValue: number, compara
     case 'lt':
       return actualValue < desiredValue;
     case 'eq':
-      return actualValue == desiredValue;
+      return actualValue === desiredValue;
     default:
       throw new Error(`Unsupported comparator "${comparator}" when comparing values`);
   }

--- a/src/types/QueryFilterTypes.ts
+++ b/src/types/QueryFilterTypes.ts
@@ -24,6 +24,7 @@ export interface QueryInfo {
   filter: AnyFilter;
   libraryName?: string;
   withError?: GracefulError;
+  fromExternalClause?: boolean;
 }
 
 /**
@@ -144,7 +145,7 @@ export interface ValueFilter extends Filter {
   type: 'value';
   attribute?: string;
   alias?: string;
-  comparator?: ValueFilterComparator;
+  comparator: ValueFilterComparator;
   valueBoolean?: boolean;
   valueString?: string;
   valueInteger?: number;

--- a/test/GapsInCareHelpers.test.ts
+++ b/test/GapsInCareHelpers.test.ts
@@ -579,7 +579,43 @@ describe('Find Reason Detail', () => {
       ]);
     });
 
-    test('should report ValueOutOfRange for positive improvement high value', () => {
+    test('should report ValueOutOfRange for positive improvement low value', () => {
+      const filter: ValueFilter = {
+        type: 'value',
+        attribute: 'value',
+        alias: 'O',
+        comparator: 'gt',
+        valueQuantity: {
+          value: 1.0,
+          unit: '%'
+        },
+        localId: 'obs-with-low-value'
+      };
+
+      const q: GapsDataTypeQuery = {
+        ...{ ...baseObservationQuery, retrieveLocalId: 'obs-with-low-value', parentQueryHasResult: false },
+        queryInfo: {
+          sources: [
+            {
+              alias: 'O',
+              resourceType: 'Observation',
+              retrieveLocalId: 'true-clause'
+            }
+          ],
+          filter
+        }
+      };
+
+      const [r] = calculateReasonDetail([q], ImprovementNotation.POSITIVE, dr).results;
+
+      expect(r.reasonDetail).toBeDefined();
+      expect(r.reasonDetail?.hasReasonDetail).toBe(true);
+      expect(r.reasonDetail?.reasons).toEqual([
+        { code: CareGapReasonCode.VALUEOUTOFRANGE, path: 'value', reference: 'Observation/obs-with-low-value' }
+      ]);
+    });
+
+    test('should report NotFound for positive improvement high value', () => {
       const filter: ValueFilter = {
         type: 'value',
         attribute: 'value',
@@ -610,45 +646,15 @@ describe('Find Reason Detail', () => {
 
       expect(r.reasonDetail).toBeDefined();
       expect(r.reasonDetail?.hasReasonDetail).toBe(true);
-      expect(r.reasonDetail?.reasons).toEqual([
-        { code: CareGapReasonCode.VALUEOUTOFRANGE, path: 'value', reference: 'Observation/obs-with-high-value' }
-      ]);
-    });
 
-    test('should report ValueOutOfRange for positive improvement low value', () => {
-      const filter: ValueFilter = {
-        type: 'value',
-        attribute: 'value',
-        alias: 'O',
-        comparator: 'lt',
-        valueQuantity: {
-          value: 5.0,
-          unit: '%'
-        },
-        localId: 'obs-with-low-value'
-      };
-
-      const q: GapsDataTypeQuery = {
-        ...{ ...baseObservationQuery, retrieveLocalId: 'obs-with-low-value', parentQueryHasResult: false },
-        queryInfo: {
-          sources: [
-            {
-              alias: 'O',
-              resourceType: 'Observation',
-              retrieveLocalId: 'true-clause'
-            }
-          ],
-          filter
-        }
-      };
-
-      const [r] = calculateReasonDetail([q], ImprovementNotation.POSITIVE, dr).results;
-
-      expect(r.reasonDetail).toBeDefined();
-      expect(r.reasonDetail?.hasReasonDetail).toBe(true);
-      expect(r.reasonDetail?.reasons).toEqual([
-        { code: CareGapReasonCode.VALUEOUTOFRANGE, path: 'value', reference: 'Observation/obs-with-low-value' }
-      ]);
+      // There shouldn't be any out of range values computed by reasonDetail since the obs-with-high-value satisfies the requirements
+      expect(r.reasonDetail?.reasons).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: CareGapReasonCode.VALUEOUTOFRANGE
+          })
+        ])
+      );
     });
 
     test('should report ValueOutOfRange for negative improvement low value', () => {
@@ -697,13 +703,13 @@ describe('Find Reason Detail', () => {
           value: 1.0,
           unit: '%'
         },
-        localId: 'obs-with-high-value'
+        localId: 'obs-with-low-value'
       };
 
       const q: GapsDataTypeQuery = {
         ...{
           ...baseObservationQuery,
-          retrieveLocalId: 'obs-with-high-value',
+          retrieveLocalId: 'obs-with-low-value',
           valueComparisonLocalId: 'false-clause',
           parentQueryHasResult: false
         },
@@ -725,7 +731,7 @@ describe('Find Reason Detail', () => {
       expect(r.reasonDetail).toBeDefined();
       expect(r.reasonDetail?.hasReasonDetail).toBe(true);
       expect(r.reasonDetail?.reasons).toEqual([
-        { code: CareGapReasonCode.VALUEOUTOFRANGE, path: 'value', reference: 'Observation/obs-with-high-value' }
+        { code: CareGapReasonCode.VALUEOUTOFRANGE, path: 'value', reference: 'Observation/obs-with-low-value' }
       ]);
     });
 

--- a/test/GapsInCareHelpers.test.ts
+++ b/test/GapsInCareHelpers.test.ts
@@ -7,7 +7,8 @@ import {
   calculateReasonDetail,
   groupGapQueries,
   generateGuidanceResponses,
-  generateReasonCoding
+  generateReasonCoding,
+  hasDetailedReasonCode
 } from '../src/gaps/GapsReportBuilder';
 import {
   DataTypeQuery,
@@ -1525,5 +1526,110 @@ describe('Guidance Response ReasonCode Coding', () => {
       ]
     };
     expect(generateReasonCoding(reasonDetail)).toEqual(expectedCoding);
+  });
+
+  describe('hasDetailedReasonCode', () => {
+    test('should return false for empty reasonCode', () => {
+      const gr: fhir4.GuidanceResponse = {
+        resourceType: 'GuidanceResponse',
+        status: 'data-required',
+        reasonCode: []
+      };
+
+      expect(hasDetailedReasonCode(gr)).toBe(false);
+    });
+
+    test('should return false for no reasonCode', () => {
+      const gr: fhir4.GuidanceResponse = {
+        resourceType: 'GuidanceResponse',
+        status: 'data-required'
+      };
+
+      expect(hasDetailedReasonCode(gr)).toBe(false);
+    });
+
+    test('should return true for GuidanceResponse with ValueOutOfRange', () => {
+      const gr: fhir4.GuidanceResponse = {
+        resourceType: 'GuidanceResponse',
+        status: 'data-required',
+        reasonCode: [
+          {
+            coding: [
+              {
+                system: 'CareGapReasonCodeSystem',
+                code: CareGapReasonCode.VALUEOUTOFRANGE
+              }
+            ]
+          }
+        ]
+      };
+
+      expect(hasDetailedReasonCode(gr)).toBe(true);
+    });
+
+    test('should return false for GuidanceResponse with NotFound', () => {
+      const gr: fhir4.GuidanceResponse = {
+        resourceType: 'GuidanceResponse',
+        status: 'data-required',
+        reasonCode: [
+          {
+            coding: [
+              {
+                system: 'CareGapReasonCodeSystem',
+                code: CareGapReasonCode.NOTFOUND
+              }
+            ]
+          }
+        ]
+      };
+
+      expect(hasDetailedReasonCode(gr)).toBe(false);
+    });
+
+    test('should return false for GuidanceResponse with Present', () => {
+      const gr: fhir4.GuidanceResponse = {
+        resourceType: 'GuidanceResponse',
+        status: 'data-required',
+        reasonCode: [
+          {
+            coding: [
+              {
+                system: 'CareGapReasonCodeSystem',
+                code: CareGapReasonCode.PRESENT
+              }
+            ]
+          }
+        ]
+      };
+
+      expect(hasDetailedReasonCode(gr)).toBe(false);
+    });
+
+    test('should return true for GuidanceResponse with ValueOutOfRange and Present', () => {
+      const gr: fhir4.GuidanceResponse = {
+        resourceType: 'GuidanceResponse',
+        status: 'data-required',
+        reasonCode: [
+          {
+            coding: [
+              {
+                system: 'CareGapReasonCodeSystem',
+                code: CareGapReasonCode.VALUEOUTOFRANGE
+              }
+            ]
+          },
+          {
+            coding: [
+              {
+                system: 'CareGapReasonCodeSystem',
+                code: CareGapReasonCode.PRESENT
+              }
+            ]
+          }
+        ]
+      };
+
+      expect(hasDetailedReasonCode(gr)).toBe(true);
+    });
   });
 });

--- a/test/GapsInCareHelpers.test.ts
+++ b/test/GapsInCareHelpers.test.ts
@@ -390,6 +390,110 @@ describe('Generate DetectedIssue Resource', () => {
     // above query should be present since queries with results are gaps
     expect(resource[0].evidence).toHaveLength(1);
   });
+
+  test('should filter duplicate dataRequirements and reasonCodes', () => {
+    // Two ORed queries will generate identical data requirements
+    const queries: GapsDataTypeQuery[] = [
+      {
+        dataType: 'Procedure',
+        valueSet: 'http://example.com/test-vs',
+        retrieveHasResult: false,
+        parentQueryHasResult: false,
+        retrieveLibraryName: 'SimpleDep',
+        expressionStack: [
+          {
+            localId: '29',
+            libraryName: 'SimpleQueries',
+            type: 'Or'
+          },
+          {
+            localId: '4',
+            libraryName: 'SimpleDep',
+            type: 'Retrieve'
+          }
+        ]
+      },
+      {
+        dataType: 'Procedure',
+        valueSet: 'http://example.com/test-vs',
+        retrieveHasResult: false,
+        parentQueryHasResult: false,
+        retrieveLibraryName: 'SimpleDep',
+        expressionStack: [
+          {
+            localId: '29',
+            libraryName: 'SimpleQueries',
+            type: 'Or'
+          },
+          {
+            localId: '5',
+            libraryName: 'SimpleDep',
+            type: 'Retrieve'
+          }
+        ]
+      }
+    ];
+    const resource = generateDetectedIssueResources(
+      queries,
+      SIMPLE_MEASURE_REPORT,
+      ImprovementNotation.POSITIVE
+    ).detectedIssues;
+
+    expect(resource[0]).toBeDefined();
+    expect(resource[0].evidence).toHaveLength(1);
+  });
+
+  test('should not filter GuidanceResponses when dataRequirements differ', () => {
+    // Two ORed queries will generate identical data requirements
+    const queries: GapsDataTypeQuery[] = [
+      {
+        dataType: 'Procedure',
+        valueSet: 'http://example.com/test-vs',
+        retrieveHasResult: false,
+        parentQueryHasResult: false,
+        retrieveLibraryName: 'SimpleDep',
+        expressionStack: [
+          {
+            localId: '29',
+            libraryName: 'SimpleQueries',
+            type: 'Or'
+          },
+          {
+            localId: '4',
+            libraryName: 'SimpleDep',
+            type: 'Retrieve'
+          }
+        ]
+      },
+      {
+        dataType: 'Procedure',
+        valueSet: 'http://example.com/test-vs-2',
+        retrieveHasResult: false,
+        parentQueryHasResult: false,
+        retrieveLibraryName: 'SimpleDep',
+        expressionStack: [
+          {
+            localId: '29',
+            libraryName: 'SimpleQueries',
+            type: 'Or'
+          },
+          {
+            localId: '5',
+            libraryName: 'SimpleDep',
+            type: 'Retrieve'
+          }
+        ]
+      }
+    ];
+    const resource = generateDetectedIssueResources(
+      queries,
+      SIMPLE_MEASURE_REPORT,
+      ImprovementNotation.POSITIVE
+    ).detectedIssues;
+
+    expect(resource[0]).toBeDefined();
+    expect(resource[0].evidence).toHaveLength(2);
+  });
 });
 
 describe('Find grouped queries', () => {

--- a/test/helpers/ValueComparisonHelpers.test.ts
+++ b/test/helpers/ValueComparisonHelpers.test.ts
@@ -1,0 +1,39 @@
+import { compareValues } from '../../src/helpers/ValueComparisonHelpers';
+
+describe('ValueComparisonHelpers', () => {
+  describe('compareValues', () => {
+    it('should return true for "ge" and "gt" values', () => {
+      expect(compareValues(2.0, 1, 'ge')).toBe(true);
+      expect(compareValues(2.0, 1, 'gt')).toBe(true);
+      expect(compareValues(2.0, 2.0, 'ge')).toBe(true);
+    });
+
+    it('should return false for non "ge" and "gt" values', () => {
+      expect(compareValues(1, 2.0, 'ge')).toBe(false);
+      expect(compareValues(1, 2.0, 'gt')).toBe(false);
+    });
+
+    it('should return true for "le" and "lt" values', () => {
+      expect(compareValues(1, 2.0, 'le')).toBe(true);
+      expect(compareValues(2.0, 2.0, 'le')).toBe(true);
+      expect(compareValues(1, 2.0, 'lt')).toBe(true);
+    });
+
+    it('should return false for non "le" and "lt" values', () => {
+      expect(compareValues(2.0, 1, 'le')).toBe(false);
+      expect(compareValues(2.0, 1, 'le')).toBe(false);
+    });
+
+    it('should return true for "eq" values', () => {
+      expect(compareValues(2.0, 2.0, 'eq')).toBe(true);
+    });
+
+    it('should return false for non "eq" values', () => {
+      expect(compareValues(2.0, 1, 'eq')).toBe(false);
+    });
+
+    it('should throw error for unsupported comparator', () => {
+      expect(() => compareValues(2.0, 1, 'sa')).toThrow('Unsupported comparator "sa" when comparing values');
+    });
+  });
+});

--- a/test/queryFilters/parseQueryInfo.test.ts
+++ b/test/queryFilters/parseQueryInfo.test.ts
@@ -410,6 +410,7 @@ const EXPECTED_INTERNAL_VALUE_COMPARISON_QUERY: QueryInfo = {
 
 const EXPECTED_EXTERNAL_VALUE_COMPARISON_QUERY: QueryInfo = {
   localId: '13',
+  fromExternalClause: true,
   sources: [
     {
       sourceLocalId: '5',


### PR DESCRIPTION
~Putting up the code diff for preliminary review if anyone wants to look.~

~Will stay in draft until #121 is merged, and then I will update the base branch~

---

# Summary

This PR adds the logic for reporting value-related reasonDetail on applicable measures for gaps in care. It does this by adding logic in reason detail calculation that actually checks the values present on the data found by a retrieve and seeing if it adhered to the range specified by a clause in the ELM represented as a `ValueFilter` from the query filter parser.

# New Behavior

For value filters that come back as a result of #121, any associated retrieves will now have the value filter comparison done. The change in behavior will result in `ValueOutOfRange` reason codes being present where applicable on both positive and negative improvement measures.

An additional piece of new behavior is sorting of the guidance response results, preferring ones that have reasonCodes other than `NotFound` and `Present`, mostly just for readability to the end user (it's better to not hide the guidance responses at the bottom if they're the most detailed ones)

# Code Changes

* Update `GapsReportBuilder` to have handling for value filters
  * Refactored function a bit to handle both positive and negative improvement without duplicating too much code (likely more work that can be done here)
* Add property to queryInfo to indicate if it came from an external clause or directly within a `where`
* Add helper for doing actual value comparison based on camparator
* Add and update tests

# Testing Guidance

A good test case for this is the diabetes measure with a numerator patient (ensure the improvement notation is properly set to `decrease` in the measure bundle, let me know if you need help with this). The resultant gaps bundle will now have value out of range as a reasonCode