### PR TITLE
Group support for AsyncPatientSource - CLI updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Options:
   --patient-ids <ids...>                      A list of patient ids an AsyncPatientSource will use to query a fhir server for patient data. Note: cannot be used with --patient-bundles or --group-id; --as-patient-source and --fhir-server-url are required when --patient-ids is provided.
   --group-id <id>                             A group id an AsyncPatientSource will use to query a fhir server for patient data. Note: cannot be used with --patient-bundles or --patient-ids; --as-patient-source and --fhir-server-url are required when --group-id is provided.
   --as-patient-source                         Load bundles by creating cql-exec-fhir PatientSource to pass into library calls.
-  --fhir-server-url <url>                     Loads bundles into an AsyncPatientSource which queries the passed in FHIR server URL for patient data. Note: --as-patient-source and --patient-ids (or --group-id) are required when --fhir-server-url is provided.
+  --fhir-server-url <url>                     Loads bundles into an AsyncPatientSource which queries the passed in FHIR server URL for patient data. Note: --as-patient-source and either --patient-ids or --group-id are required when --fhir-server-url is provided.
   -s, --measurement-period-start <date>       Start date for the measurement period, in YYYY-MM-DD format (defaults to the start date defined in the Measure, or 2019-01-01 if not set.
                                               there)
   -e, --measurement-period-end <date>         End date for the measurement period, in YYYY-MM-DD format (defaults to the end date defined in the Measure, or 2019-12-31 if not set there).

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The options that we support for calculation are as follows:
 | calculateHTML | boolean | yes | Include HTML structure for highlighting. Defaults to false. |
 | vsAPIKey | string | yes | API key, to be used to access a valueset API for downloading any missing valuesets |
 | useValueSetCaching | boolean | yes | Whether to cache valuesets obtained by an API on the filesystem |
-| profileValidation | boolean | yes |  To "trust" the content of meta.profile as a source of truth for what profiles the data that cql-exec-fhir grabs validates against|
+| profileValidation | boolean | yes | To "trust" the content of meta.profile as a source of truth for what profiles the data that cql-exec-fhir grabs validates against|
 
 ### CLI
 
@@ -114,10 +114,11 @@ Options:
   --slim                                      Use slimmed-down calculation results interfaces (default: false)
   --report-type <report-type>                 Type of report, "individual", "summary", "subject-list".
   -m, --measure-bundle <measure-bundle>       Path to measure bundle.
-  -p, --patient-bundles <patient-bundles...>  Paths to patient bundles. Required unless --patient-ids is provided or output type is dataRequirements. Note: cannot be used with --patient-ids.
-  --patient-ids <ids...>                      A list of patient ids an AsyncPatientSource will use to query a fhir server for patient data. Note: cannot be used with --patient-bundles, --as-patient-source and --fhir-server-url are required when --patient-ids is provided.
+  -p, --patient-bundles <patient-bundles...>  Paths to patient bundles. Required unless --patient-ids or --group-id is provided or output type is dataRequirements. Note: cannot be used with --patient-ids or --group-id.
+  --patient-ids <ids...>                      A list of patient ids an AsyncPatientSource will use to query a fhir server for patient data. Note: cannot be used with --patient-bundles or --group-id; --as-patient-source and --fhir-server-url are required when --patient-ids is provided.
+  --group-id <id>                             A group id an AsyncPatientSource will use to query a fhir server for patient data. Note: cannot be used with --patient-bundles or --patient-ids; --as-patient-source and --fhir-server-url are required when --group-id is provided.
   --as-patient-source                         Load bundles by creating cql-exec-fhir PatientSource to pass into library calls.
-  --fhir-server-url <url>                     Loads bundles into an AsyncPatientSource which queries the passed in FHIR server URL for patient data. Note: --as-patient-source and --patient-ids are required when --fhir-server-url is provided.
+  --fhir-server-url <url>                     Loads bundles into an AsyncPatientSource which queries the passed in FHIR server URL for patient data. Note: --as-patient-source and --patient-ids (or --group-id) are required when --fhir-server-url is provided.
   -s, --measurement-period-start <date>       Start date for the measurement period, in YYYY-MM-DD format (defaults to the start date defined in the Measure, or 2019-01-01 if not set.
                                               there)
   -e, --measurement-period-end <date>         End date for the measurement period, in YYYY-MM-DD format (defaults to the end date defined in the Measure, or 2019-12-31 if not set there).

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -70,7 +70,7 @@ program
   .option('--cache-valuesets', 'Whether or not to cache ValueSets retrieved from the ValueSet service.', false)
   .option(
     '--fhir-server-url <server-url>',
-    'Loads bundles into an AsyncPatientSource which queries the passed in FHIR server URL for patient data. Note: --as-patient-source and --patient-ids (or --group-id) are required when --fhir-server-url is provided.'
+    'Loads bundles into an AsyncPatientSource which queries the passed in FHIR server URL for patient data. Note: --as-patient-source and either --patient-ids or --group-id are required when --fhir-server-url is provided.'
   )
   .option(
     '--profile-validation',

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -153,9 +153,11 @@ async function populatePatientBundles() {
           console.error(
             'Must provide an array of patient ids with --patient-ids flag or group id with --group-id flag for calculation using AsyncPatientSource'
           );
+          program.help();
         }
         if (program.patientIds && program.groupId) {
           console.error('Cannot provide both --patient-ids and --group-id flags.');
+          program.help();
         }
         patientSource = AsyncPatientSource.FHIRv401(program.fhirServerUrl, program.profileValidation);
         if (program.patientIds) {
@@ -200,7 +202,6 @@ if (program.measurementPeriodEnd) {
   calcOptions.measurementPeriodEnd = program.measurementPeriodEnd;
 }
 
-// Calculation is now async, so we have to do a callback here
 populatePatientBundles().then(async patientBundles => {
   try {
     const result = await calc(

--- a/src/types/CQLExecFHIR.d.ts
+++ b/src/types/CQLExecFHIR.d.ts
@@ -21,6 +21,7 @@ declare module 'cql-exec-fhir' {
   export class AsyncPatientSource {
     constructor(serverInfo: string);
     loadPatientIds(ids: string[]): void;
+    async loadGroupId(id: string): void;
     currentPatient(): AsyncPatient | undefined;
     nextPatient(): AsyncPatient | undefined;
     reset: void;


### PR DESCRIPTION
# Summary
Fqm-execution now supports calculation using cql-exec-fhir AsyncPatientSource when a group Id is specified rather than an explicit list of patient IDs.

## New behavior
Existing calculation functionality should remain unchanged. This PR adds the ability to pass in a FHIR server Url and Group Id for a FHIR Group resource that references patients on the server. For more information on the Group resource structure, see the [Resource Group spec](https://build.fhir.org/group.html).

Note: the new --group-id Cli option is mutually exclusive with the --patient-ids flag, as both accomplish the same goal of populating the list of patient Ids to use in the AsyncPatientSource class in cql-exec-fhir.

## Code changes
* README updates
* CLI updates for new --group-id flag
* Reworking of function calls in CLI to account for new `loadGroupId()` function from cql-exec-fhir

# Testing guidance
* Review and run unit tests with `npm run test`
* Review the README/CLI documentation
* Update package.json to point to the [`group-support` branch of `cql-exec-fhir`](https://github.com/projecttacoma/cql-exec-fhir/pull/7) instead of the main branch (or use npm link) - this will give us the new Group support functionality
* Navigate to deqm-test-server and reset the server with `npm run db:reset`, followed by `npm run connectathon-upload`
* Test with the EXM130 measure. POST the following test Group resource to deqm-test-server: 
```json
{ "resourceType": "Group", "id": "EXM130-patients", "type": "person", "actual": "true", "member": [ { "entity": { "reference": "Patient/denom-EXM130" } }, { "entity": { "reference": "Patient/numer-EXM130" } } ] }
```
* With deqm-test-server running, run `npm run build` in fqm-execution
* Test every command with the --group-id flag. For example, try
```
node build/cli.js reports -m "path/to/measure/bundle" --as-patient-source --fhir-server-url "http://localhost:3000/4_0_1/" --group-id EXM130-patients -s "2019-01-01" -e "2019-12-31” --debug > output.json
```
* While testing all the commands with the --group-id flag, also test them separately with the --patient-ids flag and compare the output. When testing, I replaced `--group-id EXM130-patients` with `--patient-ids denom-EXM130 numerator-EXM130` and saved the output in a new JSON file. Then, I compared the two files in VSCode - you should receive the same output when running the `--group-id` flag with `EXM130-patients` as when you run with `--patient-id` and the patient IDs that are referenced in the group.
* Test that other CLI logic works. For example, 
* test that if `--patient-bundles` is provided, the output is correct
* test that if `--patient-bundles` and `--group-id` are both provided,  an error is thrown
* test that an error is thrown from `cql-exec-fhir` if the specified group Id cannot be found on the server
* test that an error is thrown if both `--patient-id` and `--group-id` are provided
