### PR TITLE
Add -o/--out-file flag to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Options:
   --vs-api-key <key>                          API key, to authenticate against the valueset service to be used for resolving missing valuesets.
   --cache-valuesets                           Whether or not to cache ValueSets retrieved from the ValueSet service (default: false)
   --profile-validation                        To "trust" the content of meta.profile as a source of truth for what profiles the data that cql-exec-fhir grabs validates against
-  -o, --output-file <file-path>               Path to a file that fqm-execution will write the calculation results to
+  -o, --output-file [file-path]               Path to a file that fqm-execution will write the calculation results to (default: output.json)
   -h, --help                                  Display help for command.
 ```
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,8 @@ Options:
   -e, --measurement-period-end <date>         End date for the measurement period, in YYYY-MM-DD format (defaults to the end date defined in the Measure, or 2019-12-31 if not set there).
   --vs-api-key <key>                          API key, to authenticate against the valueset service to be used for resolving missing valuesets.
   --cache-valuesets                           Whether or not to cache ValueSets retrieved from the ValueSet service (default: false)
-  --profile-validation                         To "trust" the content of meta.profile as a source of truth for what profiles the data that cql-exec-fhir grabs validates against|
+  --profile-validation                        To "trust" the content of meta.profile as a source of truth for what profiles the data that cql-exec-fhir grabs validates against
+  -o, --output-file <file-path>               Path to a file that fqm-execution will write the calculation results to
   -h, --help                                  Display help for command.
 ```
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -79,8 +79,7 @@ program
   )
   .option(
     '-o, --out-file [file-path]',
-    'Path to a file that fqm-execution will write the calculation results to (default: output.json)',
-    'output.json'
+    'Path to a file that fqm-execution will write the calculation results to (default: output.json)'
   )
   .parse(process.argv);
 
@@ -277,8 +276,14 @@ populatePatientBundles().then(async patientBundles => {
     }
 
     if (program.outFile) {
-      writeToFile(program.outFile, JSON.stringify(result?.results, null, 2));
+      if (program.outFile === true) {
+        // use default output.json since no file path was provided
+        writeToFile('output.json', JSON.stringify(result?.results, null, 2));
+      } else {
+        writeToFile(program.outFile, JSON.stringify(result?.results, null, 2));
+      }
     } else {
+      // log results to stdout instead of file
       console.log(JSON.stringify(result?.results, null, 2));
     }
   } catch (error) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -275,15 +275,15 @@ populatePatientBundles().then(async patientBundles => {
       });
     }
 
-    if (program.outFile) {
-      if (program.outFile === true) {
-        // use default output.json since no file path was provided
-        writeToFile('output.json', JSON.stringify(result?.results, null, 2));
-      } else {
-        writeToFile(program.outFile, JSON.stringify(result?.results, null, 2));
-      }
+    // --out-file flag specified but no file path provided
+    if (program.outFile === true) {
+      // use output.json (default file path) since no file path was provided
+      writeToFile('output.json', JSON.stringify(result?.results, null, 2));
+      // --out-file flag specified with a file path
+    } else if (program.outFile) {
+      writeToFile(program.outFile, JSON.stringify(result?.results, null, 2));
+      // log results to stdout instead of file path (--out-file flag not specified)
     } else {
-      // log results to stdout instead of file
       console.log(JSON.stringify(result?.results, null, 2));
     }
   } catch (error) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -77,6 +77,7 @@ program
     'To "trust" the content of meta.profile as a source of truth for what profiles the data that cql-exec-fhir grabs validates against.',
     false
   )
+  .option('-o, --out-file <file-path>', ' Path to a file that fqm-execution will write the calculation results to')
   .parse(process.argv);
 
 function parseBundle(filePath: string): fhir4.Bundle {
@@ -90,6 +91,18 @@ function getCachedValueSets(cacheDir: string): fhir4.ValueSet[] {
   }
 
   return [];
+}
+
+function writeToFile(filePath: string, results: string) {
+  if (!filePath) {
+    console.error(
+      'Must provide a path to a file for fqm-execution to write the caculation results to when the -o/--out-file flag is specified'
+    );
+    program.help();
+  }
+  fs.writeFile(filePath, results, err => {
+    if (err) throw err;
+  });
 }
 
 async function calc(
@@ -264,7 +277,11 @@ populatePatientBundles().then(async patientBundles => {
       });
     }
 
-    console.log(JSON.stringify(result?.results, null, 2));
+    if (program.outFile) {
+      writeToFile(program.outFile, JSON.stringify(result?.results, null, 2));
+    } else {
+      console.log(JSON.stringify(result?.results, null, 2));
+    }
   } catch (error) {
     if (error instanceof Error) {
       console.error(error.message);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -77,7 +77,11 @@ program
     'To "trust" the content of meta.profile as a source of truth for what profiles the data that cql-exec-fhir grabs validates against.',
     false
   )
-  .option('-o, --out-file <file-path>', ' Path to a file that fqm-execution will write the calculation results to')
+  .option(
+    '-o, --out-file [file-path]',
+    ' Path to a file that fqm-execution will write the calculation results to',
+    'output.json'
+  )
   .parse(process.argv);
 
 function parseBundle(filePath: string): fhir4.Bundle {
@@ -94,12 +98,6 @@ function getCachedValueSets(cacheDir: string): fhir4.ValueSet[] {
 }
 
 function writeToFile(filePath: string, results: string) {
-  if (!filePath) {
-    console.error(
-      'Must provide a path to a file for fqm-execution to write the caculation results to when the -o/--out-file flag is specified'
-    );
-    program.help();
-  }
   fs.writeFile(filePath, results, err => {
     if (err) throw err;
   });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -79,7 +79,7 @@ program
   )
   .option(
     '-o, --out-file [file-path]',
-    ' Path to a file that fqm-execution will write the calculation results to',
+    'Path to a file that fqm-execution will write the calculation results to (default: output.json)',
     'output.json'
   )
   .parse(process.argv);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -103,6 +103,7 @@ function writeToFile(filePath: string, results: string) {
   fs.writeFile(filePath, results, err => {
     if (err) throw err;
   });
+  console.log(`Calculation results written to file path: ${filePath}`);
 }
 
 async function calc(


### PR DESCRIPTION
# Summary
Adds new `-o/--out-file` option to the fqm-execution CLI.

## New behavior
Now, when a user specifies `-o/--out-file` with a file path, fqm-execution will write the contents of the calculation results to that file instead of console.logging it to stdout. When this happens, a message will be logged to the user with the name of the file path.

If the user specifies the `-o/--out-file` flag but does not specify a file path, the CLI will default to using `output.json` as the file path.

If the user does not use this flag, the results will instead be console.logged to stdout.

## Code changes
Changes were made to the CLI to add the `-o/--out-file` flag and to add a function `writeToFile()` that takes in the file path and a results string and writes the results to the file. The `writeToFile()` function is called after the results have been calculated. If the flag was not supplied, then the results will be logged to stdout like before.

Changes were made to the README to reflect these changes.

# Testing guidance
Run `npm run build`, then try the following:
* Run a command using `-o/--out-file` with a file path —> check that the file was created and that the appropriate results are in the file
* Run a command using `-o/--out-file` without a file path —> the results should be written to `output.json`
* Run a command without this flag —> the output should be logged to the console
* Run a command using `-o/--out-file` and also add a few console.log statements that will be hit during calculation (can add a few in `calculate()` in `src/Calculator.ts` —> the calculation results should appear in the newly created file, and the console.log statements should be logged to the console and they should not be present in the new file