### PR TITLE
SDE bug fix

### DIFF
--- a/test/MeasureReportBuilder.addSDE.test.ts
+++ b/test/MeasureReportBuilder.addSDE.test.ts
@@ -189,7 +189,6 @@ describe('MeasureReportBuilder Class', () => {
       const report = builder.getReport();
 
       expect(report.contained as fhir4.FhirResource[]).toHaveLength(0);
-
     });
   });
 });

--- a/test/MeasureReportBuilder.addSDE.test.ts
+++ b/test/MeasureReportBuilder.addSDE.test.ts
@@ -177,5 +177,19 @@ describe('MeasureReportBuilder Class', () => {
         ]
       });
     });
+
+    test('Should create observation only if SDE and SDE raw results are defined', () => {
+      executionResult.supplementalData = [
+        {
+          name: 'sde-code',
+          rawResult: undefined
+        }
+      ];
+      builder.addPatientResults(executionResult);
+      const report = builder.getReport();
+
+      expect(report.contained as fhir4.FhirResource[]).toHaveLength(0);
+
+    });
   });
 });


### PR DESCRIPTION
# Summary
Fixes a bug in fqm-execution where SDE calculation breaks if the `rawResult` is undefined as a result of failing the `meta.profile` check when the `--profile-validation` flag is used in calculation.

## New behavior
Previously, when using the `--profile-validation` flag with a patient resource that fails the `meta.profile` check, an error would be thrown because the patient does not get retrieved from `cql-exec-fhir`, and thus the SDE results are undefined.

Now, instead of a TypeError being thrown when trying to work through the undefined SDEs, the MeasureReportBuilder will check if the SDE raw results are defined before proceeding. Thus, only SDEs with defined results will be added to the final measure report.

## Code changes
Changes were made to the `MeasureReportBuilder`, as this is where the error gets thrown (gets thrown from `addSDE` when the SDE results are undefined). Adds a conditional to check that the SDE results are defined - if not, then the observation will not be pushed onto the measure report.

Adds unit test for the case where the SDE results are undefined.

# Testing guidance
Run unit tests.

Replicate this scenario by testing the following command:
```
fqm-execution reports -m <path to CMS122 Diabetes measure bundle> -p <path to CMS122 Diabetes numerator patient> -s 2021-01-01 -e 2021-12-31 —profile-validation
```

Previously, you would run into the following error:
```
Cannot use 'in' operator to search for 'forEach' in undefined
TypeError: Cannot use 'in' operator to search for 'forEach' in undefined
…
```

Now, you should not run into any errors. Look at the resulting measure report. The SDE Payer should be included in the report (since it is an empty array but not undefined). There should be no other SDEs in the report. You can try testing without the `--profile-validation` flag and you will see that all the SDEs appear in the final report, as expected.