### PR TITLE
assume default population to capture observations by population

### DIFF
--- a/src/execution/Execution.ts
+++ b/src/execution/Execution.ts
@@ -70,9 +70,25 @@ export async function execute(
         population => MeasureBundleHelpers.codeableConceptToPopulationType(population.code) === PopulationType.OBSERV
       )
       ?.forEach(obsrvPop => {
-        const msrPop = group.population?.find(
+        let msrPop = group.population?.find(
           population => MeasureBundleHelpers.codeableConceptToPopulationType(population.code) === PopulationType.MSRPOPL
         );
+        // special handling of ratio measure without specified populations for the observations
+        if (!msrPop) {
+          if (obsrvPop.criteria.expression === 'Denominator Observations') {
+            // denominator assumed population
+            msrPop = group.population?.find(
+              population =>
+                MeasureBundleHelpers.codeableConceptToPopulationType(population.code) === PopulationType.DENOM
+            );
+          } else if (obsrvPop.criteria.expression === 'Numerator Observations') {
+            // numerator assumed population
+            msrPop = group.population?.find(
+              population =>
+                MeasureBundleHelpers.codeableConceptToPopulationType(population.code) === PopulationType.NUMER
+            );
+          }
+        }
         if (msrPop?.criteria?.expression && obsrvPop.criteria?.expression) {
           const mainLib = elmJSONs.find(elm => elm.library.identifier.id === rootLibIdentifier.id);
           if (mainLib) {


### PR DESCRIPTION
# Summary
This PR makes a small update to make an intelligence assumption of what population is associated with an observation. Ideally in future versions of the measure specification (R5) we anticipate this to be specifiable through the measure data elements. For now, we use the criteria expression to determine whether the population is the denominator or numerator. This is meant to specifically address CMS871 and may only be partially transferable to other measures depending on their structure.

## New behavior
Observations are appropriately associated with their corresponding population.

## Code changes
In Execution, f an associated population is not found for an obsrvPop (observation population), the obsrvPop criteria expression is used to set the associated population to either denom or numer accordingly.

# Testing guidance
You can test this with CMS 871
Bundle directory: https://github.com/cqframework/ecqm-content-r4-2021/tree/master/bundles/measure/HospitalHarmHyperglycemiainHospitalizedPatientsFHIR
The numerator patient (and I think any other patient chosen from this folder) needs to be updated so that all of its datetimes use milliseconds (add `.0` to the end) to avoid an interval comparison problem. Feel free to reach out if you'd like me to just drop you my updated patient file.

VSCode launch: `
        "args": ["detailed","--debug","-m", "${workspaceFolder}/test/fixtures/connectathon/HospitalHarmHyperglycemiainHospitalizedPatientsFHIR-bundle.json", "-p", "${workspaceFolder}/test/fixtures/connectathon/tests-numer-EXM871-bundle.json", "-s", "20190101", "-e", "20191231", "-o", "test-output.json"]`

Result:
The new code should appropriately generate `obs_func_`  that gets added to the detailedResults for both the numerator and denominator observations.

Note that there are no unit tests for this change in functionality because this is a really tricky part of the code to add unit tests for. It may behoove us to add integration testing at some point, but that would probably make more sense once we have a fully functioning ratio measure (and there is still some tasking that needs to be completed for that).
