### PR TITLE
Detailed obs

### DIFF
--- a/src/calculation/ClauseResultsBuilder.ts
+++ b/src/calculation/ClauseResultsBuilder.ts
@@ -596,6 +596,7 @@ export function buildPopulationRelevanceForAllEpisodes(
     populationGroup.population?.map(population => {
       return <PopulationResult>{
         populationType: MeasureBundleHelpers.codeableConceptToPopulationType(population.code),
+        criteriaExpression: population.criteria.expression || 'Unknown',
         result: false
       };
     }) || []; // Should not end up becoming an empty list.
@@ -635,6 +636,7 @@ export function buildPopulationRelevanceMap(results: PopulationResult[]): Popula
   const relevantResults: PopulationResult[] = results.map(result => {
     return {
       populationType: result.populationType,
+      criteriaExpression: result.criteriaExpression,
       result: true
     };
   });
@@ -772,6 +774,7 @@ export function setResult(populationType: PopulationType, newResult: boolean, re
 // create a result for the given population type and result or update the existing value to true if newResult is true
 export function createOrSetResult(
   populationType: PopulationType,
+  criteriaExpression: string,
   newResult: boolean,
   results: PopulationResult[]
 ): void {
@@ -783,6 +786,7 @@ export function createOrSetResult(
   } else {
     results.push({
       populationType,
+      criteriaExpression,
       result: newResult
     });
   }

--- a/src/calculation/ClauseResultsBuilder.ts
+++ b/src/calculation/ClauseResultsBuilder.ts
@@ -596,7 +596,7 @@ export function buildPopulationRelevanceForAllEpisodes(
     populationGroup.population?.map(population => {
       return <PopulationResult>{
         populationType: MeasureBundleHelpers.codeableConceptToPopulationType(population.code),
-        criteriaExpression: population.criteria.expression || 'Unknown',
+        criteriaExpression: population.criteria.expression,
         result: false
       };
     }) || []; // Should not end up becoming an empty list.
@@ -774,7 +774,7 @@ export function setResult(populationType: PopulationType, newResult: boolean, re
 // create a result for the given population type and result or update the existing value to true if newResult is true
 export function createOrSetResult(
   populationType: PopulationType,
-  criteriaExpression: string,
+  criteriaExpression: string | undefined,
   newResult: boolean,
   results: PopulationResult[]
 ): void {

--- a/src/calculation/DetailedResultsBuilder.ts
+++ b/src/calculation/DetailedResultsBuilder.ts
@@ -1,5 +1,6 @@
 import { DetailedPopulationGroupResult, EpisodeResults, PopulationResult, StratifierResult } from '../types/Calculator';
 import * as MeasureBundleHelpers from '../helpers/MeasureBundleHelpers';
+import * as DetailedResultsHelpers from '../helpers/DetailedResultsHelpers';
 import { getResult, hasResult, setResult, createOrSetResult } from './ClauseResultsBuilder';
 import { ELM, ELMStatement } from '../types/ELMTypes';
 import { PopulationType } from '../types/Enums';
@@ -248,9 +249,7 @@ export function createEpisodePopulationValues(
       // handle observation population
       if (populationType === PopulationType.OBSERV) {
         // find the MSRPOPL for this population because we need to know its name
-        const msrPopl = populationGroup.population?.find(
-          pop => MeasureBundleHelpers.codeableConceptToPopulationType(pop.code) === PopulationType.MSRPOPL
-        );
+        const msrPopl = DetailedResultsHelpers.findObsMsrPopl(populationGroup, population);
         if (msrPopl?.criteria.expression) {
           const episodesRawResults = patientResults[`obs_func_${cqlPopulation}_${msrPopl?.criteria.expression}`];
           // loop through observation results and create observations
@@ -267,20 +266,23 @@ export function createEpisodePopulationValues(
                 };
                 episodeResultsSet.push(episodeResult);
               }
-              // if there already is a result for observation, add to the list
-              if (hasResult(PopulationType.OBSERV, episodeResult.populationResults)) {
-                const observResult = <PopulationResult>(
-                  episodeResult.populationResults.find(popResult => popResult.populationType === PopulationType.OBSERV)
-                );
+
+              // check if there is already an observation result with this cqlPopulation
+              const observResult = episodeResult.populationResults.find(
+                result => result.populationType == populationType && result.criteriaExpression == cqlPopulation
+              );
+              if (observResult !== undefined) {
+                // push obs onto an existing populationResult
                 if (!observResult.observations) {
                   observResult.observations = [];
                 }
                 observResult.observations.push(observation);
                 observResult.result = true;
               } else {
+                // create new populationResult with obs
                 episodeResult.populationResults.push({
                   populationType: PopulationType.OBSERV,
-                  criteriaExpression: population.criteria.expression || 'Unknown',
+                  criteriaExpression: cqlPopulation,
                   result: true,
                   observations: [observation]
                 });

--- a/src/calculation/DetailedResultsBuilder.ts
+++ b/src/calculation/DetailedResultsBuilder.ts
@@ -183,7 +183,7 @@ export function createPatientPopulationValues(
       const result = isStatementValueTruthy(value);
       const newPopulationResult: PopulationResult = {
         populationType: populationType,
-        criteriaExpression: population.criteria.expression || 'Unknown',
+        criteriaExpression: population.criteria.expression,
         result: result
       };
       populationResults.push(newPopulationResult);
@@ -372,7 +372,7 @@ function createOrSetValueOfEpisodes(
           populationGroup.population?.forEach(population => {
             newEpisodeResults.populationResults.push({
               populationType: <PopulationType>MeasureBundleHelpers.codeableConceptToPopulationType(population.code),
-              criteriaExpression: population.criteria.expression || 'Unknown',
+              criteriaExpression: population.criteria.expression,
               result: false
             });
           });

--- a/src/calculation/DetailedResultsBuilder.ts
+++ b/src/calculation/DetailedResultsBuilder.ts
@@ -49,7 +49,12 @@ export function createPopulationValues(
       // create patient level population and stratifier results based on episodes
       episodeResults.forEach(episodeResult => {
         episodeResult.populationResults.forEach(popResult => {
-          createOrSetResult(popResult.populationType, popResult.result, populationResults);
+          createOrSetResult(
+            popResult.populationType,
+            popResult.criteriaExpression,
+            popResult.result,
+            populationResults
+          );
         });
 
         episodeResult.stratifierResults?.forEach(strat => {
@@ -177,6 +182,7 @@ export function createPatientPopulationValues(
       const result = isStatementValueTruthy(value);
       const newPopulationResult: PopulationResult = {
         populationType: populationType,
+        criteriaExpression: population.criteria.expression || 'Unknown',
         result: result
       };
       populationResults.push(newPopulationResult);
@@ -274,6 +280,7 @@ export function createEpisodePopulationValues(
               } else {
                 episodeResult.populationResults.push({
                   populationType: PopulationType.OBSERV,
+                  criteriaExpression: population.criteria.expression || 'Unknown',
                   result: true,
                   observations: [observation]
                 });
@@ -363,6 +370,7 @@ function createOrSetValueOfEpisodes(
           populationGroup.population?.forEach(population => {
             newEpisodeResults.populationResults.push({
               populationType: <PopulationType>MeasureBundleHelpers.codeableConceptToPopulationType(population.code),
+              criteriaExpression: population.criteria.expression || 'Unknown',
               result: false
             });
           });

--- a/src/execution/Execution.ts
+++ b/src/execution/Execution.ts
@@ -3,6 +3,7 @@ import { CalculationOptions, RawExecutionData, DebugOutput } from '../types/Calc
 import { DataProvider, CodeService, DateTime, Interval, Repository, Executor } from 'cql-execution';
 import { parseTimeStringAsUTC, valueSetsForCodeService, getMissingDependentValuesets } from './ValueSetHelper';
 import * as MeasureBundleHelpers from '../helpers/MeasureBundleHelpers';
+import * as DetailedResultsHelpers from '../helpers/DetailedResultsHelpers';
 import { PopulationType } from '../types/Enums';
 import { generateELMJSONFunction } from '../calculation/DetailedResultsBuilder';
 import { ValueSetResolver } from './ValueSetResolver';
@@ -70,25 +71,7 @@ export async function execute(
         population => MeasureBundleHelpers.codeableConceptToPopulationType(population.code) === PopulationType.OBSERV
       )
       ?.forEach(obsrvPop => {
-        let msrPop = group.population?.find(
-          population => MeasureBundleHelpers.codeableConceptToPopulationType(population.code) === PopulationType.MSRPOPL
-        );
-        // special handling of ratio measure without specified populations for the observations
-        if (!msrPop) {
-          if (obsrvPop.criteria.expression === 'Denominator Observations') {
-            // denominator assumed population
-            msrPop = group.population?.find(
-              population =>
-                MeasureBundleHelpers.codeableConceptToPopulationType(population.code) === PopulationType.DENOM
-            );
-          } else if (obsrvPop.criteria.expression === 'Numerator Observations') {
-            // numerator assumed population
-            msrPop = group.population?.find(
-              population =>
-                MeasureBundleHelpers.codeableConceptToPopulationType(population.code) === PopulationType.NUMER
-            );
-          }
-        }
+        const msrPop = DetailedResultsHelpers.findObsMsrPopl(group, obsrvPop);
         if (msrPop?.criteria?.expression && obsrvPop.criteria?.expression) {
           const mainLib = elmJSONs.find(elm => elm.library.identifier.id === rootLibIdentifier.id);
           if (mainLib) {

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -5,8 +5,6 @@ import { CQLPatient } from './CQLPatient';
 import { ELM } from './ELMTypes';
 import { QueryInfo } from './QueryFilterTypes';
 import { GracefulError } from './errors/GracefulError';
-import { RightCurriedFunction4 } from 'lodash';
-import { FHIRObject } from 'cql-exec-fhir';
 
 /**
  * Options for calculation.

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -198,7 +198,7 @@ export interface PopulationResult {
   /** Type of population matching http://hl7.org/fhir/ValueSet/measure-population */
   populationType: PopulationType;
   /** The population criteria expression, which may be used to further identify the population (i.e. a cql identifier) */
-  criteriaExpression: string;
+  criteriaExpression: string | undefined;
   /** True if this patient or episode calculates with membership in this population. */
   result: boolean;
   /** Observations made for this population. */

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -5,6 +5,8 @@ import { CQLPatient } from './CQLPatient';
 import { ELM } from './ELMTypes';
 import { QueryInfo } from './QueryFilterTypes';
 import { GracefulError } from './errors/GracefulError';
+import { RightCurriedFunction4 } from 'lodash';
+import { FHIRObject } from 'cql-exec-fhir';
 
 /**
  * Options for calculation.
@@ -197,6 +199,8 @@ export interface StratifierResult {
 export interface PopulationResult {
   /** Type of population matching http://hl7.org/fhir/ValueSet/measure-population */
   populationType: PopulationType;
+  /** The population criteria expression, which may be used to further identify the population (i.e. a cql identifier) */
+  criteriaExpression: string;
   /** True if this patient or episode calculates with membership in this population. */
   result: boolean;
   /** Observations made for this population. */

--- a/test/ClauseResultsBuilder.test.ts
+++ b/test/ClauseResultsBuilder.test.ts
@@ -15,22 +15,27 @@ const mainLibraryId = exampleELM.library.identifier.id;
 const populationResults: PopulationResult[] = [
   {
     populationType: PopulationType.IPP,
+    criteriaExpression: 'Initial Population',
     result: true
   },
   {
     populationType: PopulationType.DENOM,
+    criteriaExpression: 'Denominator',
     result: true
   },
   {
     populationType: PopulationType.NUMER,
+    criteriaExpression: 'Numerator',
     result: true
   },
   {
     populationType: PopulationType.NUMEX,
+    criteriaExpression: 'Numerator Exclusion',
     result: false
   },
   {
     populationType: PopulationType.DENEX,
+    criteriaExpression: 'Denominator Exclusion',
     result: false
   }
 ];
@@ -210,27 +215,27 @@ describe('ResultsHelper', () => {
   describe('episodes', () => {
     test('should mark master results relevant if any episode is true', () => {
       const truePopulationResults: PopulationResult[] = [
-        { populationType: PopulationType.IPP, result: true },
-        { populationType: PopulationType.DENOM, result: true },
-        { populationType: PopulationType.DENEX, result: false },
-        { populationType: PopulationType.NUMER, result: true },
-        { populationType: PopulationType.NUMEX, result: false }
+        { populationType: PopulationType.IPP, criteriaExpression: 'Initial Population', result: true },
+        { populationType: PopulationType.DENOM, criteriaExpression: 'Denominator', result: true },
+        { populationType: PopulationType.DENEX, criteriaExpression: 'Denominator Exclusion', result: false },
+        { populationType: PopulationType.NUMER, criteriaExpression: 'Numerator', result: true },
+        { populationType: PopulationType.NUMEX, criteriaExpression: 'Numerator Exclusion', result: false }
       ];
 
       const falsePopulationResults: PopulationResult[] = [
-        { populationType: PopulationType.IPP, result: false },
-        { populationType: PopulationType.DENOM, result: false },
-        { populationType: PopulationType.DENEX, result: false },
-        { populationType: PopulationType.NUMER, result: false },
-        { populationType: PopulationType.NUMEX, result: false }
+        { populationType: PopulationType.IPP, criteriaExpression: 'Initial Population', result: false },
+        { populationType: PopulationType.DENOM, criteriaExpression: 'Denominator', result: false },
+        { populationType: PopulationType.DENEX, criteriaExpression: 'Denominator Exclusion', result: false },
+        { populationType: PopulationType.NUMER, criteriaExpression: 'Numerator', result: false },
+        { populationType: PopulationType.NUMEX, criteriaExpression: 'Numerator Exclusion', result: false }
       ];
 
       const expectedMasterResults: PopulationResult[] = [
-        { populationType: PopulationType.IPP, result: true },
-        { populationType: PopulationType.DENOM, result: true },
-        { populationType: PopulationType.DENEX, result: true },
-        { populationType: PopulationType.NUMER, result: true },
-        { populationType: PopulationType.NUMEX, result: true }
+        { populationType: PopulationType.IPP, criteriaExpression: 'Initial Population', result: true },
+        { populationType: PopulationType.DENOM, criteriaExpression: 'Denominator', result: true },
+        { populationType: PopulationType.DENEX, criteriaExpression: 'Denominator Exclusion', result: true },
+        { populationType: PopulationType.NUMER, criteriaExpression: 'Numerator', result: true },
+        { populationType: PopulationType.NUMEX, criteriaExpression: 'Numerator Exclusion', result: true }
       ];
 
       const results = ClauseResultsBuilder.buildPopulationRelevanceForAllEpisodes(simpleMeasure.group[0], [
@@ -284,20 +289,20 @@ describe('ResultsHelper', () => {
   describe('buildStatementRelevanceMap', () => {
     test('marks all false when IPP is false', () => {
       const populationResults: PopulationResult[] = [
-        { populationType: PopulationType.IPP, result: false },
-        { populationType: PopulationType.DENOM, result: false },
-        { populationType: PopulationType.DENEX, result: false },
-        { populationType: PopulationType.DENEXCEP, result: false },
-        { populationType: PopulationType.NUMER, result: false },
-        { populationType: PopulationType.NUMEX, result: false }
+        { populationType: PopulationType.IPP, criteriaExpression: 'Initial Population', result: false },
+        { populationType: PopulationType.DENOM, criteriaExpression: 'Denominator', result: false },
+        { populationType: PopulationType.DENEX, criteriaExpression: 'Denominator Exclusion', result: false },
+        { populationType: PopulationType.DENEXCEP, criteriaExpression: 'Denominator Exception', result: false },
+        { populationType: PopulationType.NUMER, criteriaExpression: 'Numerator', result: false },
+        { populationType: PopulationType.NUMEX, criteriaExpression: 'Numerator Exclusion', result: false }
       ];
       const expectedRelevanceMap: PopulationResult[] = [
-        { populationType: PopulationType.IPP, result: true },
-        { populationType: PopulationType.DENOM, result: false },
-        { populationType: PopulationType.DENEX, result: false },
-        { populationType: PopulationType.DENEXCEP, result: false },
-        { populationType: PopulationType.NUMER, result: false },
-        { populationType: PopulationType.NUMEX, result: false }
+        { populationType: PopulationType.IPP, criteriaExpression: 'Initial Population', result: true },
+        { populationType: PopulationType.DENOM, criteriaExpression: 'Denominator', result: false },
+        { populationType: PopulationType.DENEX, criteriaExpression: 'Denominator Exclusion', result: false },
+        { populationType: PopulationType.DENEXCEP, criteriaExpression: 'Denominator Exception', result: false },
+        { populationType: PopulationType.NUMER, criteriaExpression: 'Numerator', result: false },
+        { populationType: PopulationType.NUMEX, criteriaExpression: 'Numerator Exclusion', result: false }
       ];
 
       const relevanceMap = ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults);
@@ -306,20 +311,20 @@ describe('ResultsHelper', () => {
 
     test('marks DENEX, DENEXCP, NUMER, NUMEX all false when DENOM is false', () => {
       const populationResults: PopulationResult[] = [
-        { populationType: PopulationType.IPP, result: true },
-        { populationType: PopulationType.DENOM, result: false },
-        { populationType: PopulationType.DENEX, result: false },
-        { populationType: PopulationType.DENEXCEP, result: false },
-        { populationType: PopulationType.NUMER, result: false },
-        { populationType: PopulationType.NUMEX, result: false }
+        { populationType: PopulationType.IPP, criteriaExpression: 'Initial Population', result: true },
+        { populationType: PopulationType.DENOM, criteriaExpression: 'Denominator', result: false },
+        { populationType: PopulationType.DENEX, criteriaExpression: 'Denominator Exclusion', result: false },
+        { populationType: PopulationType.DENEXCEP, criteriaExpression: 'Denominator Exception', result: false },
+        { populationType: PopulationType.NUMER, criteriaExpression: 'Numerator', result: false },
+        { populationType: PopulationType.NUMEX, criteriaExpression: 'Numerator Exclusion', result: false }
       ];
       const expectedRelevanceMap: PopulationResult[] = [
-        { populationType: PopulationType.IPP, result: true },
-        { populationType: PopulationType.DENOM, result: true },
-        { populationType: PopulationType.DENEX, result: false },
-        { populationType: PopulationType.DENEXCEP, result: false },
-        { populationType: PopulationType.NUMER, result: false },
-        { populationType: PopulationType.NUMEX, result: false }
+        { populationType: PopulationType.IPP, criteriaExpression: 'Initial Population', result: true },
+        { populationType: PopulationType.DENOM, criteriaExpression: 'Denominator', result: true },
+        { populationType: PopulationType.DENEX, criteriaExpression: 'Denominator Exclusion', result: false },
+        { populationType: PopulationType.DENEXCEP, criteriaExpression: 'Denominator Exception', result: false },
+        { populationType: PopulationType.NUMER, criteriaExpression: 'Numerator', result: false },
+        { populationType: PopulationType.NUMEX, criteriaExpression: 'Numerator Exclusion', result: false }
       ];
 
       const relevanceMap = ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults);
@@ -328,20 +333,20 @@ describe('ResultsHelper', () => {
 
     test('marks DENEXCP, NUMER, NUMEX all false when DENEX is false', () => {
       const populationResults: PopulationResult[] = [
-        { populationType: PopulationType.IPP, result: true },
-        { populationType: PopulationType.DENOM, result: true },
-        { populationType: PopulationType.DENEX, result: true },
-        { populationType: PopulationType.DENEXCEP, result: false },
-        { populationType: PopulationType.NUMER, result: false },
-        { populationType: PopulationType.NUMEX, result: false }
+        { populationType: PopulationType.IPP, criteriaExpression: 'Initial Population', result: true },
+        { populationType: PopulationType.DENOM, criteriaExpression: 'Denominator', result: true },
+        { populationType: PopulationType.DENEX, criteriaExpression: 'Denominator Exclusion', result: true },
+        { populationType: PopulationType.DENEXCEP, criteriaExpression: 'Denominator Exception', result: false },
+        { populationType: PopulationType.NUMER, criteriaExpression: 'Numerator', result: false },
+        { populationType: PopulationType.NUMEX, criteriaExpression: 'Numerator Exclusion', result: false }
       ];
       const expectedRelevanceMap: PopulationResult[] = [
-        { populationType: PopulationType.IPP, result: true },
-        { populationType: PopulationType.DENOM, result: true },
-        { populationType: PopulationType.DENEX, result: true },
-        { populationType: PopulationType.DENEXCEP, result: false },
-        { populationType: PopulationType.NUMER, result: false },
-        { populationType: PopulationType.NUMEX, result: false }
+        { populationType: PopulationType.IPP, criteriaExpression: 'Initial Population', result: true },
+        { populationType: PopulationType.DENOM, criteriaExpression: 'Denominator', result: true },
+        { populationType: PopulationType.DENEX, criteriaExpression: 'Denominator Exclusion', result: true },
+        { populationType: PopulationType.DENEXCEP, criteriaExpression: 'Denominator Exception', result: false },
+        { populationType: PopulationType.NUMER, criteriaExpression: 'Numerator', result: false },
+        { populationType: PopulationType.NUMEX, criteriaExpression: 'Numerator Exclusion', result: false }
       ];
 
       const relevanceMap = ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults);
@@ -350,20 +355,20 @@ describe('ResultsHelper', () => {
 
     test('marks DENEXCP false when NUMER is true', () => {
       const populationResults: PopulationResult[] = [
-        { populationType: PopulationType.IPP, result: true },
-        { populationType: PopulationType.DENOM, result: true },
-        { populationType: PopulationType.DENEX, result: false },
-        { populationType: PopulationType.DENEXCEP, result: false },
-        { populationType: PopulationType.NUMER, result: true },
-        { populationType: PopulationType.NUMEX, result: false }
+        { populationType: PopulationType.IPP, criteriaExpression: 'Initial Population', result: true },
+        { populationType: PopulationType.DENOM, criteriaExpression: 'Denominator', result: true },
+        { populationType: PopulationType.DENEX, criteriaExpression: 'Denominator Exclusion', result: false },
+        { populationType: PopulationType.DENEXCEP, criteriaExpression: 'Denominator Exception', result: false },
+        { populationType: PopulationType.NUMER, criteriaExpression: 'Numerator', result: true },
+        { populationType: PopulationType.NUMEX, criteriaExpression: 'Numerator Exclusion', result: false }
       ];
       const expectedRelevanceMap: PopulationResult[] = [
-        { populationType: PopulationType.IPP, result: true },
-        { populationType: PopulationType.DENOM, result: true },
-        { populationType: PopulationType.DENEX, result: true },
-        { populationType: PopulationType.DENEXCEP, result: false },
-        { populationType: PopulationType.NUMER, result: true },
-        { populationType: PopulationType.NUMEX, result: true }
+        { populationType: PopulationType.IPP, criteriaExpression: 'Initial Population', result: true },
+        { populationType: PopulationType.DENOM, criteriaExpression: 'Denominator', result: true },
+        { populationType: PopulationType.DENEX, criteriaExpression: 'Denominator Exclusion', result: true },
+        { populationType: PopulationType.DENEXCEP, criteriaExpression: 'Denominator Exception', result: false },
+        { populationType: PopulationType.NUMER, criteriaExpression: 'Numerator', result: true },
+        { populationType: PopulationType.NUMEX, criteriaExpression: 'Numerator Exclusion', result: true }
       ];
 
       const relevanceMap = ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults);
@@ -372,20 +377,20 @@ describe('ResultsHelper', () => {
 
     test('marks NUMEX false when NUMER is false', () => {
       const populationResults: PopulationResult[] = [
-        { populationType: PopulationType.IPP, result: true },
-        { populationType: PopulationType.DENOM, result: true },
-        { populationType: PopulationType.DENEX, result: false },
-        { populationType: PopulationType.DENEXCEP, result: false },
-        { populationType: PopulationType.NUMER, result: false },
-        { populationType: PopulationType.NUMEX, result: false }
+        { populationType: PopulationType.IPP, criteriaExpression: 'Initial Population', result: true },
+        { populationType: PopulationType.DENOM, criteriaExpression: 'Denominator', result: true },
+        { populationType: PopulationType.DENEX, criteriaExpression: 'Denominator Exclusion', result: false },
+        { populationType: PopulationType.DENEXCEP, criteriaExpression: 'Denominator Exception', result: false },
+        { populationType: PopulationType.NUMER, criteriaExpression: 'Numerator', result: false },
+        { populationType: PopulationType.NUMEX, criteriaExpression: 'Numerator Exclusion', result: false }
       ];
       const expectedRelevanceMap: PopulationResult[] = [
-        { populationType: PopulationType.IPP, result: true },
-        { populationType: PopulationType.DENOM, result: true },
-        { populationType: PopulationType.DENEX, result: true },
-        { populationType: PopulationType.DENEXCEP, result: true },
-        { populationType: PopulationType.NUMER, result: true },
-        { populationType: PopulationType.NUMEX, result: false }
+        { populationType: PopulationType.IPP, criteriaExpression: 'Initial Population', result: true },
+        { populationType: PopulationType.DENOM, criteriaExpression: 'Denominator', result: true },
+        { populationType: PopulationType.DENEX, criteriaExpression: 'Denominator Exclusion', result: true },
+        { populationType: PopulationType.DENEXCEP, criteriaExpression: 'Denominator Exception', result: true },
+        { populationType: PopulationType.NUMER, criteriaExpression: 'Numerator', result: true },
+        { populationType: PopulationType.NUMEX, criteriaExpression: 'Numerator Exclusion', result: false }
       ];
 
       const relevanceMap = ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults);
@@ -394,14 +399,14 @@ describe('ResultsHelper', () => {
 
     test('marks OBSERV, MSRPOPLEX false when MSRPOPL is false', () => {
       const populationResults: PopulationResult[] = [
-        { populationType: PopulationType.MSRPOPL, result: false },
-        { populationType: PopulationType.OBSERV, result: false },
-        { populationType: PopulationType.MSRPOPLEX, result: false }
+        { populationType: PopulationType.MSRPOPL, criteriaExpression: 'Measure Population', result: false },
+        { populationType: PopulationType.OBSERV, criteriaExpression: 'MeasureObservation', result: false },
+        { populationType: PopulationType.MSRPOPLEX, criteriaExpression: 'Measure Population Exclusions', result: false }
       ];
       const expectedRelevanceMap: PopulationResult[] = [
-        { populationType: PopulationType.MSRPOPL, result: false },
-        { populationType: PopulationType.OBSERV, result: false },
-        { populationType: PopulationType.MSRPOPLEX, result: false }
+        { populationType: PopulationType.MSRPOPL, criteriaExpression: 'Measure Population', result: false },
+        { populationType: PopulationType.OBSERV, criteriaExpression: 'MeasureObservation', result: false },
+        { populationType: PopulationType.MSRPOPLEX, criteriaExpression: 'Measure Population Exclusions', result: false }
       ];
 
       const relevanceMap = ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults);
@@ -410,14 +415,14 @@ describe('ResultsHelper', () => {
 
     test('marks OBSERV false when MSRPOPLEX is true', () => {
       const populationResults: PopulationResult[] = [
-        { populationType: PopulationType.MSRPOPL, result: true },
-        { populationType: PopulationType.OBSERV, result: false },
-        { populationType: PopulationType.MSRPOPLEX, result: true }
+        { populationType: PopulationType.MSRPOPL, criteriaExpression: 'Measure Population', result: true },
+        { populationType: PopulationType.OBSERV, criteriaExpression: 'MeasureObservation', result: false },
+        { populationType: PopulationType.MSRPOPLEX, criteriaExpression: 'Measure Population Exclusions', result: true }
       ];
       const expectedRelevanceMap: PopulationResult[] = [
-        { populationType: PopulationType.MSRPOPL, result: false },
-        { populationType: PopulationType.OBSERV, result: false },
-        { populationType: PopulationType.MSRPOPLEX, result: false }
+        { populationType: PopulationType.MSRPOPL, criteriaExpression: 'Measure Population', result: false },
+        { populationType: PopulationType.OBSERV, criteriaExpression: 'MeasureObservation', result: false },
+        { populationType: PopulationType.MSRPOPLEX, criteriaExpression: 'Measure Population Exclusions', result: false }
       ];
 
       const relevanceMap = ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults);

--- a/test/DetailedResultsBuilder.test.ts
+++ b/test/DetailedResultsBuilder.test.ts
@@ -25,13 +25,12 @@ describe('DetailedResultsBuilder', () => {
         Numerator: true,
         'Numerator Exclusion': true
       };
-
       const expectedPopulationResults: PopulationResult[] = [
-        { populationType: PopulationType.IPP, result: true },
-        { populationType: PopulationType.DENOM, result: true },
-        { populationType: PopulationType.DENEX, result: false },
-        { populationType: PopulationType.NUMER, result: true },
-        { populationType: PopulationType.NUMEX, result: true }
+        { populationType: PopulationType.IPP, criteriaExpression: 'Initial Population', result: true },
+        { populationType: PopulationType.DENOM, criteriaExpression: 'Denominator', result: true },
+        { populationType: PopulationType.DENEX, criteriaExpression: 'Denominator Exclusion', result: false },
+        { populationType: PopulationType.NUMER, criteriaExpression: 'Numerator', result: true },
+        { populationType: PopulationType.NUMEX, criteriaExpression: 'Numerator Exclusion', result: true }
       ];
 
       const results = DetailedResultsBuilder.createPopulationValues(
@@ -55,11 +54,11 @@ describe('DetailedResultsBuilder', () => {
       };
 
       const expectedPopulationResults: PopulationResult[] = [
-        { populationType: PopulationType.IPP, result: true },
-        { populationType: PopulationType.DENOM, result: true },
-        { populationType: PopulationType.DENEX, result: false },
-        { populationType: PopulationType.NUMER, result: false },
-        { populationType: PopulationType.NUMEX, result: false }
+        { populationType: PopulationType.IPP, criteriaExpression: 'Initial Population', result: true },
+        { populationType: PopulationType.DENOM, criteriaExpression: 'Denominator', result: true },
+        { populationType: PopulationType.DENEX, criteriaExpression: 'Denominator Exclusion', result: false },
+        { populationType: PopulationType.NUMER, criteriaExpression: 'Numerator', result: false },
+        { populationType: PopulationType.NUMEX, criteriaExpression: 'Numerator Exclusion', result: false }
       ];
 
       const results = DetailedResultsBuilder.createPopulationValues(
@@ -83,11 +82,11 @@ describe('DetailedResultsBuilder', () => {
       };
 
       const expectedPopulationResults: PopulationResult[] = [
-        { populationType: PopulationType.IPP, result: true },
-        { populationType: PopulationType.DENOM, result: false },
-        { populationType: PopulationType.DENEX, result: false },
-        { populationType: PopulationType.NUMER, result: false },
-        { populationType: PopulationType.NUMEX, result: false }
+        { populationType: PopulationType.IPP, criteriaExpression: 'Initial Population', result: true },
+        { populationType: PopulationType.DENOM, criteriaExpression: 'Denominator', result: false },
+        { populationType: PopulationType.DENEX, criteriaExpression: 'Denominator Exclusion', result: false },
+        { populationType: PopulationType.NUMER, criteriaExpression: 'Numerator', result: false },
+        { populationType: PopulationType.NUMEX, criteriaExpression: 'Numerator Exclusion', result: false }
       ];
 
       const results = DetailedResultsBuilder.createPopulationValues(
@@ -111,11 +110,11 @@ describe('DetailedResultsBuilder', () => {
       };
 
       const expectedPopulationResults: PopulationResult[] = [
-        { populationType: PopulationType.IPP, result: true },
-        { populationType: PopulationType.DENOM, result: true },
-        { populationType: PopulationType.DENEX, result: true },
-        { populationType: PopulationType.NUMER, result: false },
-        { populationType: PopulationType.NUMEX, result: false }
+        { populationType: PopulationType.IPP, criteriaExpression: 'Initial Population', result: true },
+        { populationType: PopulationType.DENOM, criteriaExpression: 'Denominator', result: true },
+        { populationType: PopulationType.DENEX, criteriaExpression: 'Denominator Exclusion', result: true },
+        { populationType: PopulationType.NUMER, criteriaExpression: 'Numerator', result: false },
+        { populationType: PopulationType.NUMEX, criteriaExpression: 'Numerator Exclusion', result: false }
       ];
 
       const results = DetailedResultsBuilder.createPopulationValues(
@@ -139,11 +138,11 @@ describe('DetailedResultsBuilder', () => {
       };
 
       const expectedPopulationResults: PopulationResult[] = [
-        { populationType: PopulationType.IPP, result: true },
-        { populationType: PopulationType.DENOM, result: false },
-        { populationType: PopulationType.DENEX, result: false },
-        { populationType: PopulationType.NUMER, result: false },
-        { populationType: PopulationType.NUMEX, result: false }
+        { populationType: PopulationType.IPP, criteriaExpression: 'Initial Population', result: true },
+        { populationType: PopulationType.DENOM, criteriaExpression: 'Denominator', result: false },
+        { populationType: PopulationType.DENEX, criteriaExpression: 'Denominator Exclusion', result: false },
+        { populationType: PopulationType.NUMER, criteriaExpression: 'Numerator', result: false },
+        { populationType: PopulationType.NUMEX, criteriaExpression: 'Numerator Exclusion', result: false }
       ];
 
       const results = DetailedResultsBuilder.createPopulationValues(
@@ -166,10 +165,14 @@ describe('DetailedResultsBuilder', () => {
       };
 
       const expectedPopulationResults: PopulationResult[] = [
-        { populationType: PopulationType.IPP, result: true },
-        { populationType: PopulationType.MSRPOPL, result: false },
-        { populationType: PopulationType.MSRPOPLEX, result: false },
-        { populationType: PopulationType.OBSERV, result: false }
+        { populationType: PopulationType.IPP, criteriaExpression: 'Initial Population', result: true },
+        { populationType: PopulationType.MSRPOPL, criteriaExpression: 'Measure Population', result: false },
+        {
+          populationType: PopulationType.MSRPOPLEX,
+          criteriaExpression: 'Measure Population Exclusions',
+          result: false
+        },
+        { populationType: PopulationType.OBSERV, criteriaExpression: 'MeasureObservation', result: false }
       ];
 
       const results = DetailedResultsBuilder.createPopulationValues(cvMeasure, cvMeasureGroup, statementResults);
@@ -188,10 +191,10 @@ describe('DetailedResultsBuilder', () => {
       };
 
       const expectedPopulationResults: PopulationResult[] = [
-        { populationType: PopulationType.IPP, result: true },
-        { populationType: PopulationType.MSRPOPL, result: true },
-        { populationType: PopulationType.MSRPOPLEX, result: true },
-        { populationType: PopulationType.OBSERV, result: false }
+        { populationType: PopulationType.IPP, criteriaExpression: 'Initial Population', result: true },
+        { populationType: PopulationType.MSRPOPL, criteriaExpression: 'Measure Population', result: true },
+        { populationType: PopulationType.MSRPOPLEX, criteriaExpression: 'Measure Population Exclusions', result: true },
+        { populationType: PopulationType.OBSERV, criteriaExpression: 'MeasureObservation', result: false }
       ];
 
       const results = DetailedResultsBuilder.createPopulationValues(cvMeasure, cvMeasureGroup, statementResults);

--- a/test/MeasureReportBuilder.addSDE.test.ts
+++ b/test/MeasureReportBuilder.addSDE.test.ts
@@ -35,18 +35,22 @@ const executionResultsTemplate: ExecutionResult<DetailedPopulationGroupResult>[]
         populationResults: [
           {
             populationType: PopulationType.NUMER,
+            criteriaExpression: 'Numerator',
             result: false
           },
           {
             populationType: PopulationType.DENOM,
+            criteriaExpression: 'Denominator',
             result: true
           },
           {
             populationType: PopulationType.IPP,
+            criteriaExpression: 'Initial Population',
             result: true
           },
           {
             populationType: PopulationType.DENEX,
+            criteriaExpression: 'Denominator Exclusion',
             result: false
           }
         ],

--- a/test/MeasureReportBuilder.test.ts
+++ b/test/MeasureReportBuilder.test.ts
@@ -52,18 +52,22 @@ const executionResults: ExecutionResult<DetailedPopulationGroupResult>[] = [
         populationResults: [
           {
             populationType: PopulationType.NUMER,
+            criteriaExpression: 'Numerator',
             result: false
           },
           {
             populationType: PopulationType.DENOM,
+            criteriaExpression: 'Denominator',
             result: true
           },
           {
             populationType: PopulationType.IPP,
+            criteriaExpression: 'Initial Population',
             result: true
           },
           {
             populationType: PopulationType.DENEX,
+            criteriaExpression: 'Denominator Exclusion',
             result: false
           }
         ],
@@ -94,18 +98,22 @@ const cvExecutionResults: ExecutionResult<DetailedPopulationGroupResult>[] = [
         populationResults: [
           {
             populationType: PopulationType.MSRPOPL,
+            criteriaExpression: 'Measure Population',
             result: false
           },
           {
             populationType: PopulationType.MSRPOPLEX,
+            criteriaExpression: 'Measure Population Exclusions',
             result: true
           },
           {
             populationType: PopulationType.IPP,
+            criteriaExpression: 'Initial Population',
             result: true
           },
           {
             populationType: PopulationType.OBSERV,
+            criteriaExpression: 'MeasureObservation',
             result: false
           }
         ],

--- a/test/helpers/DetailedResultsHelpers.test.ts
+++ b/test/helpers/DetailedResultsHelpers.test.ts
@@ -1,4 +1,6 @@
-import { pruneDetailedResults, isDetailedResult } from '../../src/helpers/DetailedResultsHelpers';
+import { MeasureGroup, MeasureGroupPopulation } from 'fhir/r4';
+import { MeasureBundleHelpers } from '../../src';
+import { pruneDetailedResults, isDetailedResult, findObsMsrPopl } from '../../src/helpers/DetailedResultsHelpers';
 import {
   ExecutionResult,
   DetailedPopulationGroupResult,
@@ -151,5 +153,101 @@ describe('isDetailedResult', () => {
     };
 
     expect(isDetailedResult(sr)).toBe(false);
+  });
+});
+
+describe('findObsMsrPopl', () => {
+  test('should find basic measure population', () => {
+    const group: MeasureGroup = {
+      population: [
+        {
+          criteria: { language: 'text/cql.identifier', expression: 'Measure Population' },
+          code: {
+            coding: [
+              {
+                code: 'measure-population',
+                system: 'http://terminology.hl7.org/CodeSystem/measure-population'
+              }
+            ]
+          }
+        }
+      ]
+    };
+    const observationPop: MeasureGroupPopulation = {
+      criteria: { language: 'text/cql.identifier', expression: 'Irrelevant' }
+    };
+
+    const msrPop = findObsMsrPopl(group, observationPop);
+
+    expect(msrPop).toBeDefined();
+    expect(MeasureBundleHelpers.codeableConceptToPopulationType(msrPop?.code)).toBe('measure-population');
+  });
+
+  test('should find numerator population for Numerator Observations', () => {
+    const group: MeasureGroup = {
+      population: [
+        {
+          criteria: { language: 'text/cql.identifier', expression: 'Numerator' },
+          code: {
+            coding: [
+              {
+                code: 'numerator',
+                system: 'http://terminology.hl7.org/CodeSystem/measure-population'
+              }
+            ]
+          }
+        }
+      ]
+    };
+    const observationPop: MeasureGroupPopulation = {
+      criteria: { language: 'text/cql.identifier', expression: 'Numerator Observations' },
+      code: {
+        coding: [
+          {
+            code: 'measure-observation',
+            system: 'http://terminology.hl7.org/CodeSystem/measure-population'
+          }
+        ]
+      }
+    };
+
+    const msrPop = findObsMsrPopl(group, observationPop);
+
+    expect(msrPop).toBeDefined();
+    expect(MeasureBundleHelpers.codeableConceptToPopulationType(msrPop?.code)).toBe('numerator');
+  });
+
+  test('should find denominator population for Denominator Observations', () => {
+    const group: MeasureGroup = {
+      population: [
+        {
+          criteria: { language: 'text/cql.identifier', expression: 'Denominator' },
+          code: {
+            coding: [
+              {
+                code: 'denominator',
+                system: 'http://terminology.hl7.org/CodeSystem/measure-population'
+              }
+            ]
+          }
+        }
+      ]
+    };
+    const observationPop: MeasureGroupPopulation = {
+      criteria: { language: 'text/cql.identifier', expression: 'Denominator Observations' },
+      code: {
+        coding: [
+          {
+            code: 'measure-observation',
+            system: 'http://terminology.hl7.org/CodeSystem/measure-population'
+          }
+        ]
+      }
+    };
+
+    const msrPop = findObsMsrPopl(group, observationPop);
+
+    expect(msrPop).toBeDefined();
+    expect(MeasureBundleHelpers.codeableConceptToPopulationType(msrPop?.code)).toBe('denominator');
   });
 });


### PR DESCRIPTION
# Summary
Solves two problems:
1. The PopulationResult observations should be populated (with a number in this case, but could be a different type in other cases). Find where the PopulationResult (attribute of EpisodeResults) is populated, understand why the observation attribute is not populated, and populate with the appropriate number (which should be available from the raw results).
->This was fixed by reusing code to find the observation's associated population when one isn't specified.

2. For this measure, there are actually two observations: one associated with the numerator, and one associated with the denominator. When the detailed results are created, the populationType attribute is used to identify the PopulationResult, but because there are two PopulationResult's that are of type "measure-observation", there is know way to tell the difference between these results. We need to use some other way of identifying populations (probably an id or identifier?).
-> This was addressed using the cql identifier in the criteriaExpression. This identifier information also allowed for observation results to be appropriately associated with the correct measure-observation population.

## New behavior
Detailed results now have appropriately associated observation values in episodeResults

## Code changes

- `criteriaExpression` has been added as a required attribute to the `PopulationResult` type in Calculator.ts. This has resulted in changes to assign the value appropriately in ClauseResultsBuilder, DetailedResultsBuilder, and all of the top level testing files changed.
- Added `findObsMsrPopl` helper function to DetailedResultsHelpers and corresponding unit testing. This function finds a measure population for a given group and if not found, does special handling of ratio measures without specified populations for the observations. Function used in DetailedResultsBuilder and Execution.
- The `criteriaExpression` is also used in the DetailedResultsBuilder to differentiate between different observation populations as the population type is not enough alone to tell what population the result should be assigned to.

# Testing guidance
Run: `npm run test`
You can test this with CMS 871
Bundle directory: https://github.com/cqframework/ecqm-content-r4-2021/tree/master/bundles/measure/HospitalHarmHyperglycemiainHospitalizedPatientsFHIR
The numerator patient (and I think any other patient chosen from this folder) needs to be updated so that all of its datetimes use milliseconds (add `.0` to the end) to avoid an interval comparison problem. Feel free to reach out if you'd like me to just drop you my updated patient file.

VSCode launch: `
        "args": ["detailed","--debug","-m", "${workspaceFolder}/test/fixtures/connectathon/HospitalHarmHyperglycemiainHospitalizedPatientsFHIR-bundle.json", "-p", "${workspaceFolder}/test/fixtures/connectathon/tests-numer-EXM871-bundle.json", "-s", "20190101", "-e", "20191231", "-o", "test-output.json"]`

Result:
The output detailedResults file should have episodeResults with populationResults where a 9 is associated with the denominator observations and a 1 is associated with the numerator observations.
