### PR TITLE
Generate clause coverage HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ The options that we support for calculation are as follows:
 | reportType | string | yes | Type of MeasureReport to generate: "summary" or "individual". |
 | calculateSDEs | boolean | yes | Include Supplemental Data Elements in calculation. Defaults to false. |
 | calculateHTML | boolean | yes | Include HTML structure for highlighting. Defaults to false. |
+| calculateClauseCoverage | boolean | yes | Include HTML structure with coverage highlighting. Defaults to false. |
 | vsAPIKey | string | yes | API key, to be used to access a valueset API for downloading any missing valuesets |
 | useValueSetCaching | boolean | yes | Whether to cache valuesets obtained by an API on the filesystem |
 | profileValidation | boolean | yes | To "trust" the content of meta.profile as a source of truth for what profiles the data that cql-exec-fhir grabs validates against|

--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -65,7 +65,7 @@ export async function calculate<T extends CalculationOptions>(
   // Ensure the CalculationOptions have sane defaults, only if they're not set
   options.calculateHTML = options.calculateHTML ?? true;
   options.calculateSDEs = options.calculateSDEs ?? true;
-  options.calculateCoverageHTML = options.calculateCoverageHTML ?? true;
+  //options.calculateClauseCoverage = options.calculateClauseCoverage ?? true;
   
   // Get the default measurement period out of the Measure object
   const measurementPeriod = MeasureBundleHelpers.extractMeasurementPeriod(measureBundle);
@@ -143,18 +143,18 @@ export async function calculate<T extends CalculationOptions>(
         true,
         true
       );
-
-      if (options.calculateHTML || options.calculateCoverageHTML) {
-        let highlightingType;
-        if (options.calculateCoverageHTML) {
-          highlightingType = 'coverage';
-        }
+      
+      if (options.calculateHTML) {
+        let highlightCoverage;
+        if (options.calculateClauseCoverage) {
+          highlightCoverage = true;
+        } else highlightCoverage = false;
         const html = generateHTML(
           elmLibraries,
           detailedGroupResult.statementResults,
           detailedGroupResult.clauseResults,
           detailedGroupResult.groupId,
-          highlightingType
+          highlightCoverage
         );
         detailedGroupResult.html = html;
         if (debugObject && options.enableDebugOutput) {

--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -65,7 +65,6 @@ export async function calculate<T extends CalculationOptions>(
   // Ensure the CalculationOptions have sane defaults, only if they're not set
   options.calculateHTML = options.calculateHTML ?? true;
   options.calculateSDEs = options.calculateSDEs ?? true;
-  //options.calculateClauseCoverage = options.calculateClauseCoverage ?? true;
   
   // Get the default measurement period out of the Measure object
   const measurementPeriod = MeasureBundleHelpers.extractMeasurementPeriod(measureBundle);

--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -65,6 +65,8 @@ export async function calculate<T extends CalculationOptions>(
   // Ensure the CalculationOptions have sane defaults, only if they're not set
   options.calculateHTML = options.calculateHTML ?? true;
   options.calculateSDEs = options.calculateSDEs ?? true;
+  options.calculateCoverageHTML = options.calculateCoverageHTML ?? true;
+  
   // Get the default measurement period out of the Measure object
   const measurementPeriod = MeasureBundleHelpers.extractMeasurementPeriod(measureBundle);
   // Set the measurement period start/end, but only if the caller didn't specify one
@@ -142,12 +144,17 @@ export async function calculate<T extends CalculationOptions>(
         true
       );
 
-      if (options.calculateHTML) {
+      if (options.calculateHTML || options.calculateCoverageHTML) {
+        let highlightingType;
+        if (options.calculateCoverageHTML) {
+          highlightingType = 'coverage';
+        }
         const html = generateHTML(
           elmLibraries,
           detailedGroupResult.statementResults,
           detailedGroupResult.clauseResults,
-          detailedGroupResult.groupId
+          detailedGroupResult.groupId,
+          highlightingType
         );
         detailedGroupResult.html = html;
         if (debugObject && options.enableDebugOutput) {

--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -65,7 +65,6 @@ export async function calculate<T extends CalculationOptions>(
   // Ensure the CalculationOptions have sane defaults, only if they're not set
   options.calculateHTML = options.calculateHTML ?? true;
   options.calculateSDEs = options.calculateSDEs ?? true;
-  
   // Get the default measurement period out of the Measure object
   const measurementPeriod = MeasureBundleHelpers.extractMeasurementPeriod(measureBundle);
   // Set the measurement period start/end, but only if the caller didn't specify one
@@ -142,7 +141,7 @@ export async function calculate<T extends CalculationOptions>(
         true,
         true
       );
-      
+
       if (options.calculateHTML) {
         let highlightCoverage;
         if (options.calculateClauseCoverage) {

--- a/src/calculation/HTMLBuilder.ts
+++ b/src/calculation/HTMLBuilder.ts
@@ -90,7 +90,7 @@ export function generateHTML(
   statementResults: StatementResult[],
   clauseResults: ClauseResult[],
   groupId: string,
-  highlightCoverage: boolean
+  highlightCoverage?: boolean | undefined
 ): string {
   const relevantStatements = statementResults.filter(s => s.relevance === Relevance.TRUE);
 
@@ -117,15 +117,29 @@ export function generateHTML(
 
   let result = `<div><h2>Population Group: ${groupId}</h2>`;
   if (highlightCoverage) {
-    result += '<h2> Clause Coverage: XX%</h2>';
+    result += `<h2> Clause Coverage: ${calculateClauseCoverage(clauseResults)}%</h2>`;
   }
 
   // generate HTML clauses using hbs template for each annotation
   statementAnnotations.forEach(a => {
-    const res = main({ libraryName: a.libraryName, clauseResults: clauseResults, ...a.annotation[0].s, highlightCoverage: highlightCoverage});
+    const res = main({ libraryName: a.libraryName, clauseResults: clauseResults, ...a.annotation[0].s, highlightCoverage: highlightCoverage || false});
     result += res;
   });
 
   result += '</div>';
   return result;
 }
+
+/**
+ * Calculates clause coverage as the percentage of relevant clauses with FinalResult.TRUE
+ * out of all relevant clauses.
+ * @param clauseResults ClauseResult array from calculation
+ * @returns percentage out of 100, represented as a string
+ */
+export function calculateClauseCoverage(
+  clauseResults: ClauseResult[]): string {
+    const coveredClauses = clauseResults.filter((clauseResult) => {
+      return clauseResult.final === FinalResult.TRUE;
+    });
+    return (coveredClauses.length / clauseResults.length * 100).toPrecision(3);
+  }

--- a/src/calculation/HTMLBuilder.ts
+++ b/src/calculation/HTMLBuilder.ts
@@ -82,7 +82,7 @@ Handlebars.registerHelper('highlightCoverage', (localId, context) => {
  * @param statementResults StatementResult array from calculation
  * @param clauseResults ClauseResult array from calculation
  * @param groupId ID of population group
- * @param highlightingType string representing whether to apply coverage highlighting
+ * @param highlightCoverage boolean representing whether to apply coverage highlighting
  * @returns string of HTML representing the clauses for this group
  */
 export function generateHTML(
@@ -90,7 +90,7 @@ export function generateHTML(
   statementResults: StatementResult[],
   clauseResults: ClauseResult[],
   groupId: string,
-  highlightingType: string | undefined
+  highlightCoverage: boolean
 ): string {
   const relevantStatements = statementResults.filter(s => s.relevance === Relevance.TRUE);
 
@@ -116,13 +116,13 @@ export function generateHTML(
   });
 
   let result = `<div><h2>Population Group: ${groupId}</h2>`;
-  if (highlightingType === 'coverage') {
+  if (highlightCoverage) {
     result += '<h2> Clause Coverage: XX%</h2>';
   }
 
   // generate HTML clauses using hbs template for each annotation
   statementAnnotations.forEach(a => {
-    const res = main({ libraryName: a.libraryName, clauseResults: clauseResults, ...a.annotation[0].s, highlight: highlightingType});
+    const res = main({ libraryName: a.libraryName, clauseResults: clauseResults, ...a.annotation[0].s, highlightCoverage: highlightCoverage});
     result += res;
   });
 

--- a/src/calculation/HTMLBuilder.ts
+++ b/src/calculation/HTMLBuilder.ts
@@ -122,7 +122,12 @@ export function generateHTML(
 
   // generate HTML clauses using hbs template for each annotation
   statementAnnotations.forEach(a => {
-    const res = main({ libraryName: a.libraryName, clauseResults: clauseResults, ...a.annotation[0].s, highlightCoverage: highlightCoverage || false});
+    const res = main({
+      libraryName: a.libraryName,
+      clauseResults: clauseResults,
+      ...a.annotation[0].s,
+      highlightCoverage: highlightCoverage || false
+    });
     result += res;
   });
 
@@ -136,10 +141,9 @@ export function generateHTML(
  * @param clauseResults ClauseResult array from calculation
  * @returns percentage out of 100, represented as a string
  */
-export function calculateClauseCoverage(
-  clauseResults: ClauseResult[]): string {
-    const coveredClauses = clauseResults.filter((clauseResult) => {
-      return clauseResult.final === FinalResult.TRUE;
-    });
-    return (coveredClauses.length / clauseResults.length * 100).toPrecision(3);
-  }
+export function calculateClauseCoverage(clauseResults: ClauseResult[]): string {
+  const coveredClauses = clauseResults.filter(clauseResult => {
+    return clauseResult.final === FinalResult.TRUE;
+  });
+  return ((coveredClauses.length / clauseResults.length) * 100).toPrecision(3);
+}

--- a/src/templates/clause.ts
+++ b/src/templates/clause.ts
@@ -1,4 +1,6 @@
-export default `<span{{#if r}} data-ref-id="{{r}}" style="{{highlightClause r}}"{{/if}}>
+export default 
+`{{~#if @root.highlight~}}
+<span{{#if r}} data-ref-id="{{r}}" style="{{highlightCoverage r}}"{{/if}}>
 {{~#if value ~}}
 {{ concat value }}
 {{~/if ~}}
@@ -7,4 +9,16 @@ export default `<span{{#if r}} data-ref-id="{{r}}" style="{{highlightClause r}}"
 {{> clause ~}}
 {{~/each ~}}
 {{~/if~}}
-</span>`;
+</span>
+{{~else~}}
+<span{{#if r}} data-ref-id="{{r}}" style="{{highlightClause r}}"{{/if}}>
+{{~#if value ~}}
+{{ concat value }}
+{{~/if ~}}
+{{~#if s~}}
+{{~#each s~}}
+{{> clause ~}}
+{{~/each ~}}
+{{~/if~}}
+</span>
+{{~/if~}}`;

--- a/src/templates/clause.ts
+++ b/src/templates/clause.ts
@@ -1,5 +1,4 @@
-export default 
-`{{~#if @root.highlightCoverage~}}
+export default `{{~#if @root.highlightCoverage~}}
 <span{{#if r}} data-ref-id="{{r}}" style="{{highlightCoverage r}}"{{/if}}>
 {{~#if value ~}}
 {{ concat value }}

--- a/src/templates/clause.ts
+++ b/src/templates/clause.ts
@@ -1,5 +1,5 @@
 export default 
-`{{~#if @root.highlight~}}
+`{{~#if @root.highlightCoverage~}}
 <span{{#if r}} data-ref-id="{{r}}" style="{{highlightCoverage r}}"{{/if}}>
 {{~#if value ~}}
 {{ concat value }}

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -26,6 +26,8 @@ export interface CalculationOptions {
   calculateSDEs?: boolean;
   /** Include HTML structure for highlighting */
   calculateHTML?: boolean;
+  /** Include HTML structure with coverage highlighting */
+  calculateCoverageHTML?: boolean;
   /** Enable debug output including CQL, ELM, results */
   enableDebugOutput?: boolean;
   /** Enables the return of ELM Libraries and name of main library to be used for further processing. ex. gaps in care */

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -24,10 +24,10 @@ export interface CalculationOptions {
   patientSource?: DataProvider;
   /** Include SDEs in calculation */
   calculateSDEs?: boolean;
-  /** Include HTML structure for highlighting */
+  /** Include HTML structure for highlighting (defaults to logic highlighting) */
   calculateHTML?: boolean;
-  /** Include HTML structure with coverage highlighting */
-  calculateCoverageHTML?: boolean;
+  /** Include HTML structure with clause coverage highlighting */
+  calculateClauseCoverage?: boolean;
   /** Enable debug output including CQL, ELM, results */
   enableDebugOutput?: boolean;
   /** Enables the return of ELM Libraries and name of main library to be used for further processing. ex. gaps in care */

--- a/test/HTMLGenerator.test.ts
+++ b/test/HTMLGenerator.test.ts
@@ -74,12 +74,12 @@ describe('HTMLGenerator', () => {
   });
 
   test('simple HTML with generation with clause coverage styling', () => {
-     // Ignore tabs and new lines
-     const expectedHTML = getHTMLFixture('simpleCoverageAnnotation.html').replace(/\s/g, '');
-     const res = generateHTML([elm], statementResults, trueClauseResults, 'test', true);
- 
-     expect(res.replace(/\s/g, '')).toEqual(expectedHTML);
-     expect(res.includes(coverageStyleString)).toBeTruthy();
+    // Ignore tabs and new lines
+    const expectedHTML = getHTMLFixture('simpleCoverageAnnotation.html').replace(/\s/g, '');
+    const res = generateHTML([elm], statementResults, trueClauseResults, 'test', true);
+
+    expect(res.replace(/\s/g, '')).toEqual(expectedHTML);
+    expect(res.includes(coverageStyleString)).toBeTruthy();
   });
 
   test('no library found should error', () => {
@@ -104,5 +104,4 @@ describe('HTMLGenerator', () => {
       generateHTML([elm], badStatementResults, [], 'test');
     }).toThrowError();
   });
-
 });

--- a/test/HTMLGenerator.test.ts
+++ b/test/HTMLGenerator.test.ts
@@ -2,7 +2,8 @@ import {
   generateHTML,
   objToCSS,
   cqlLogicClauseTrueStyle,
-  cqlLogicClauseFalseStyle
+  cqlLogicClauseFalseStyle,
+  cqlLogicClauseCoveredStyle
 } from '../src/calculation/HTMLBuilder';
 import { StatementResult, ClauseResult } from '../src/types/Calculator';
 import { ELM, ELMStatement } from '../src/types/ELMTypes';
@@ -18,6 +19,7 @@ describe('HTMLGenerator', () => {
   const desiredLocalId = '119';
   const trueStyleString = objToCSS(cqlLogicClauseTrueStyle);
   const falseStyleString = objToCSS(cqlLogicClauseFalseStyle);
+  const coverageStyleString = objToCSS(cqlLogicClauseCoveredStyle);
 
   beforeEach(() => {
     elm = getELMFixture('elm/CMS723v0.json');
@@ -71,6 +73,15 @@ describe('HTMLGenerator', () => {
     expect(res.includes(falseStyleString)).toBeTruthy();
   });
 
+  test('simple HTML with generation with clause coverage styling', () => {
+     // Ignore tabs and new lines
+     const expectedHTML = getHTMLFixture('simpleCoverageAnnotation.html').replace(/\s/g, '');
+     const res = generateHTML([elm], statementResults, trueClauseResults, 'test', true);
+ 
+     expect(res.replace(/\s/g, '')).toEqual(expectedHTML);
+     expect(res.includes(coverageStyleString)).toBeTruthy();
+  });
+
   test('no library found should error', () => {
     elm.library.identifier.id = 'NOT REAL';
 
@@ -93,4 +104,5 @@ describe('HTMLGenerator', () => {
       generateHTML([elm], badStatementResults, [], 'test');
     }).toThrowError();
   });
+
 });

--- a/test/fixtures/html/simpleCoverageAnnotation.html
+++ b/test/fixtures/html/simpleCoverageAnnotation.html
@@ -1,0 +1,26 @@
+<div>
+    <h2>Population Group: test</h2>
+    <h2>Clause Coverage: 100%</h2>
+    <pre style="tab-size: 2; border-bottom-width: 4px; line-height: 1.4">
+      <code>
+        <span data-ref-id="119" style="background-color:#daeaf5;color:#004e82;border-bottom-color:#006cb4;border-bottom-style:dashed">
+          <span>define &quot;Denominator&quot;: </span>
+          <span data-ref-id="118" style="">
+            <span data-ref-id="116" style="">
+              <span data-ref-id="101" style="">
+                <span>&quot;Encounter with Atrial Ablation Procedure&quot;</span>
+              </span>
+              <span>union</span>
+              <span data-ref-id="115" style="">
+                <span>&quot;History of Atrial FibrillationFlutter&quot;</span>
+              </span>
+            </span>
+            <span>union</span>
+            <span data-ref-id="117" style="">
+              <span>&quot;Current Diagnosis Atrial FibrillationFlutter&quot;</span>
+            </span>
+          </span>
+        </span>
+      </code>
+    </pre>
+  </div>


### PR DESCRIPTION
# Summary
This PR adds functionality for calculating clause coverage during detailed results calculation, and showing the clause coverage in the generated HTML.

## New behavior
Previously, if the user specified `calculateHTML` as a calculation option, the HTML would get generated with (truthy/falsey) logic highlighting. This remains the default. However, if the user also specifies `calculateClauseCoverage` as a calculation option, the HTML gets generated with new CSS styling that highlights the “covered” clauses in blue rather than applying the logic highlighting. The generated HTML also notes the clause coverage as a percentage at the top of the generated HTML.

## Code changes
* New calculation option `calculateClauseCoverage` to apply the coverage styling instead of logic styling to the HTML
* New styling for clause coverage (dashed border bottom and blue highlighting)
* New Handlebars helper for highlighting covered clauses (gets applied in the clause.ts template)
* Helper function for calculating clause coverage as the percent of covered clauses (relevant clauses with final result === true) out of all relevant clauses
* Unit test that applies the coverage styling

# Testing guidance
* Run unit tests
* Run a “reports” calculation similar to the following:

```
Node build/cli.js reports -m <path to measure bundle> 
-p <path to patient bundle(s)> -s <measurement period start> 
-e <measurement period end> --debug
```
Running with “debug” will allow the generated html to appear in the `debug/html` folder. Open this in the browser - it should have the default logic highlighting applied to it.
* Run a “reports” calculation again, but set the calculation option `calculateClauseCoverage` to true. This time, when you open the generated HTML in the browser, the styling should be different, highlighting the covered clauses in blue (the covered clauses are equivalent to the clauses that are truthy/colored green with the usual logic highlighting). Check that the clause coverage is reflected as a percentage at the top of the generated HTML.
* Try running the clause coverage highlighting with multiple patients to check that more clauses get covered (I tested with EXM130 denom patient, then both EXM130 denom and numer patients to see the clause coverage change).
