### PR TITLE
Add ratio measure score support

### DIFF
--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -304,7 +304,7 @@ export async function calculateAggregateMeasureReport(
     builder.addPatientResults(result);
   });
 
-  const report = builder.getReport(results);
+  const report = builder.getReport();
 
   if (debugOutput && options.enableDebugOutput) {
     debugOutput.measureReports = [report];

--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -304,7 +304,7 @@ export async function calculateAggregateMeasureReport(
     builder.addPatientResults(result);
   });
 
-  const report = builder.getReport();
+  const report = builder.getReport(results);
 
   if (debugOutput && options.enableDebugOutput) {
     debugOutput.measureReports = [report];

--- a/src/calculation/MeasureReportBuilder.ts
+++ b/src/calculation/MeasureReportBuilder.ts
@@ -87,7 +87,6 @@ export default class MeasureReportBuilder<T extends PopulationGroupResult> {
       group.population = [];
 
       // build each population group with 0 for initial value
-      // TODO: figure out how to represent multiple measure observations
       measureGroup.population?.forEach(measurePopulation => {
         const pop = <fhir4.MeasureReportGroupPopulation>{};
         pop.count = 0;
@@ -181,7 +180,6 @@ export default class MeasureReportBuilder<T extends PopulationGroupResult> {
             this.addScoreObservation(group.measureScore, this.measure, this.report);
           } else if (this.scoringCode === MeasureScoreType.RATIO) {
             const measureScore = this.calcMeasureScoreRatio(groupResults);
-            // TODO: update this when we support ratio for summary/subject-list reports
             if (this.isIndividual) {
               group.measureScore = measureScore;
             }
@@ -418,7 +416,6 @@ export default class MeasureReportBuilder<T extends PopulationGroupResult> {
   }
 
   // Ratio requires different input types than other scores
-  // TODO: figure out what to do for aggregate report
   private calcMeasureScoreRatio(detail: PopulationGroupResult, strataCode?: string) {
     let observations = [];
     if (detail.episodeResults) {
@@ -454,7 +451,6 @@ export default class MeasureReportBuilder<T extends PopulationGroupResult> {
     }
 
     // Calculate as (NUMER OBSERVATION) / (DENOM OBSERVATION)
-    // TODO: consider aggregate method?
     const numeratorCount = observations
       .filter(obs => obs.criteriaExpression === 'Numerator Observations')
       ?.map(o => o.observation)
@@ -465,7 +461,6 @@ export default class MeasureReportBuilder<T extends PopulationGroupResult> {
       .reduce((accumulator, currentValue) => accumulator.observation + currentValue.observation);
 
     return {
-      // TODO: what if value for denominator 0? ... do we need to subtract denex, dexecep... probably, as https://ecqi.healthit.gov/system/files/eCQM-Logic-and-Guidance-2018-0504.pdf
       value: denominatorCount === 0 ? 0 : (numeratorCount / denominatorCount) * 1.0
     };
   }

--- a/test/fixtures/measure/ratio-measure.json
+++ b/test/fixtures/measure/ratio-measure.json
@@ -1,0 +1,151 @@
+{
+    "resourceType": "Measure",
+    "id": "example",
+    "extension": [
+      {
+        "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis",
+        "valueCode": "boolean"
+      }
+    ],
+    "status": "active",
+    "url": "http://example.com/example",
+    "identifier": [
+      {
+        "system": "http://example.com",
+        "value": "example"
+      }
+    ],
+    "name": "Example Measure",
+    "effectivePeriod": {
+      "start": "2021-01-01",
+      "end": "2021-12-31"
+    },
+    "library": [
+      "Library/example"
+    ],
+    "scoring": {
+        "coding": [ {
+          "system": "http://terminology.hl7.org/CodeSystem/measure-scoring",
+          "code": "ratio",
+          "display": "Ratio"
+        } ]
+    },
+    "improvementNotation": {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/measure-improvement-notation",
+          "code": "increase"
+        }
+      ]
+    },
+    "group": [
+      {
+        "id": "group-1",
+        "population": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                  "code": "initial-population",
+                  "display": "Initial Population"
+                }
+              ]
+            },
+            "criteria": {
+              "language": "text/cql",
+              "expression": "Initial Population"
+            }
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                  "code": "numerator",
+                  "display": "Numerator"
+                }
+              ]
+            },
+            "criteria": {
+              "language": "text/cql",
+              "expression": "Numerator"
+            }
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                  "code": "denominator",
+                  "display": "Denominator"
+                }
+              ]
+            },
+            "criteria": {
+              "language": "text/cql",
+              "expression": "Denominator"
+            }
+          },
+          {
+            "id": "test-denom-observation",
+            "extension": [ {
+              "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-aggregateMethod",
+              "valueCode": "sum"
+            } ],
+            "code": {
+              "coding": [ {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "measure-observation",
+                "display": "Measure Observation"
+              } ]
+            },
+            "criteria": {
+              "language": "text/cql.identifier",
+              "expression": "Denominator Observations"
+            }
+          },
+          {
+            "id": "test-numer-observation",
+            "extension": [ {
+              "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-aggregateMethod",
+              "valueCode": "sum"
+            } ],
+            "code": {
+              "coding": [ {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "measure-observation",
+                "display": "Measure Observation"
+              } ]
+            },
+            "criteria": {
+              "language": "text/cql.identifier",
+              "expression": "Numerator Observations"
+            }
+          }
+        ]
+      }
+    ],
+    "supplementalData": [
+      {
+        "code": {
+          "text": "sde-code"
+        },
+        "usage": [
+          {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/measure-data-usage",
+                "code": "supplemental-data"
+              }
+            ]
+          }
+        ],
+        "criteria": {
+          "language": "text/cql",
+          "expression": "SDE"
+        }
+      }
+    ]
+  }
+  


### PR DESCRIPTION
# Summary
Adds measure score to individual and summary ratio measure reports.

## New behavior
When running calculation on a ratio measure, an individual report will now include the measure score for each patient, where the measure score is calculated as: `numerator measure observation / denominator measure observation`. 

## Code changes
Most changes occur in the `MeasureReportBuilder`. Uses the aggregate method for the numerator and denominator observations when calculating the measure score.

# Testing guidance
Test with the [EXM871 bundle from the ecqm-content-r4-2021 repo](https://github.com/cqframework/ecqm-content-r4-2021/tree/master/bundles/measure/HospitalHarmHyperglycemiainHospitalizedPatientsFHIR). 
Some tests to try out include:
* Test with the denominator patient - the final measure score should be 0 since there is no numerator observation
* Test with the numerator patient - the final measure score should be 0.1111 (or 1/9) since the numerator observation value is 1 and the denominator observation value is 9
* Test with both the denominator and numerator patient, and generate a summary report - the measure score should be 0.0833 (or 1/12) since the total numerator observation is 0+1 = 1, and the total denominator observation is 3+9=12

NOTE: When testing, you may run into CQL-related errors with these patient bundles. To fix these errors, you will need to edit the patient resource files locally so that the date times end in “.0” 
