### PR TITLE
Include irrelevant populations in measure highlighting

### DIFF
--- a/src/calculation/HTMLBuilder.ts
+++ b/src/calculation/HTMLBuilder.ts
@@ -100,7 +100,7 @@ export function generateHTML(
   clauseResults: ClauseResult[],
   groupId: string
 ): string {
-  const relevantStatements = statementResults.filter(s => s.relevance === Relevance.TRUE);
+  const relevantStatements = statementResults.filter(s => s.relevance !== Relevance.NA);
 
   // assemble array of statement annotations to be templated to HTML
   const statementAnnotations: { libraryName: string; annotation: Annotation[] }[] = [];


### PR DESCRIPTION
# Summary
Displays all statement results that are not of `Relevance.NA` so that the user can see all populations, even ones that are unhit.

## New behavior
Rather than containing populations of relevance `Relevance.TRUE`, the measure highlighting now includes populations of relevance `Relevance.TRUE` and `Relevance.FALSE`. 

## Code changes
- `HTMLBuilder.ts`- one line change so that `relevantStatements` now includes any statement `s` where `s.relevance !== Relevance.NA`.

# Testing guidance
1. In the `main` branch, run the cli on the `TestPatient.json` file attached in slack with the following commands: 
```
./src/cli.ts detailed -m <path to EXM 130 measure bundle> -p <path to TestPatient.json> -s 2019-01-01 -e 2019-12-31 --debug
open debug/html/clauses-group-1.html
```
2. The highlighting should pop up and not contain any defined procedures (such as "Flexible Sigmoidoscopy Performed", "CT Colonography Performed", etc.) This is because they were not "relevant" statements since the TestPatient.json does not fall in the denominator or numerator.
3. Run the same commands as above but in the `irrelevant-population` branch.
4. The highlighting should pop up and contain all of those defined procedures, even though they are highlighted red because they are not hit.

NOTE: `TestPatient.json` is simply a patient born in 1950 without any resources so that you can test that irrelevant statements are now shown. 
 