### PR TITLE
Add support for PopulationBasis on a per-group basis

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1681,7 +1681,7 @@
       }
     },
     "cql-execution": {
-      "version": "github:projecttacoma/cql-execution#36346a0fe1526abf48bfe8bdb37fe9e8164292bb",
+      "version": "github:projecttacoma/cql-execution#d1c0e9341c763bb8cc641a5a702cedb0c8385c88",
       "from": "github:projecttacoma/cql-execution",
       "requires": {
         "@lhncbc/ucum-lhc": "^4.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1681,7 +1681,7 @@
       }
     },
     "cql-execution": {
-      "version": "github:projecttacoma/cql-execution#d1c0e9341c763bb8cc641a5a702cedb0c8385c88",
+      "version": "github:projecttacoma/cql-execution#36346a0fe1526abf48bfe8bdb37fe9e8164292bb",
       "from": "github:projecttacoma/cql-execution",
       "requires": {
         "@lhncbc/ucum-lhc": "^4.1.3",

--- a/src/calculation/DetailedResultsBuilder.ts
+++ b/src/calculation/DetailedResultsBuilder.ts
@@ -27,7 +27,7 @@ export function createPopulationValues(
   let episodeResults: EpisodeResults[] | undefined;
 
   // patient based measure
-  if (!MeasureBundleHelpers.isEpisodeOfCareMeasure(measure)) {
+  if (!MeasureBundleHelpers.isEpisodeOfCareGroup(measure, populationGroup)) {
     const popAndStratResults = createPatientPopulationValues(populationGroup, patientResults);
     populationResults = popAndStratResults.populationResults;
     stratifierResults = popAndStratResults.stratifierResults;

--- a/src/helpers/MeasureBundleHelpers.ts
+++ b/src/helpers/MeasureBundleHelpers.ts
@@ -29,6 +29,23 @@ export function isEpisodeOfCareMeasure(measure: fhir4.Measure): boolean {
 }
 
 /**
+ * Check if a group is an episode of care group or not. Look for the cqfm-populationBasis extension.
+ * If it is found return true if valueCode is not 'boolean'. If the extension cannot be found, fallback
+ * to looking at the measure
+ *
+ * @param {fhir4.Measure} measure FHIR Measure resource.
+ * @returns {boolean} true if this is an episode of care, false if it is a patient measure.
+ */
+export function isEpisodeOfCareGroup(measure: fhir4.Measure, group: fhir4.MeasureGroup): boolean {
+  const popBasisExt = group.extension?.find(ext => ext.url == POPULATION_BASIS_EXT);
+  if (popBasisExt != undefined) {
+    return popBasisExt.valueCode != 'boolean';
+  } else {
+    return isEpisodeOfCareMeasure(measure);
+  }
+}
+
+/**
  * Population Type Code system.
  */
 const POPULATION_TYPE_CODESYSTEM = 'http://terminology.hl7.org/CodeSystem/measure-population';

--- a/src/helpers/MeasureBundleHelpers.ts
+++ b/src/helpers/MeasureBundleHelpers.ts
@@ -31,7 +31,7 @@ export function isEpisodeOfCareMeasure(measure: fhir4.Measure): boolean {
 /**
  * Check if a group is an episode of care group or not. Look for the cqfm-populationBasis extension.
  * If it is found return true if valueCode is not 'boolean'. If the extension cannot be found, fallback
- * to looking at the measure
+ * to looking at the measure.
  *
  * @param {fhir4.Measure} measure FHIR Measure resource.
  * @returns {boolean} true if this is an episode of care, false if it is a patient measure.

--- a/test/helpers/MeasureBundleHelpers.test.ts
+++ b/test/helpers/MeasureBundleHelpers.test.ts
@@ -1,0 +1,85 @@
+import { isEpisodeOfCareGroup } from '../../src/helpers/MeasureBundleHelpers';
+
+describe('MeasureBundleHelpers tests', () => {
+  describe('isEpisodeOfCareGroup', () => {
+    it('can determine episode of care on group extension', () => {
+      const measure: fhir4.Measure = {
+        resourceType: 'Measure',
+        status: 'unknown',
+        group: [
+          {
+            extension: [
+              {
+                url: 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis',
+                valueCode: 'Procedure'
+              }
+            ]
+          }
+        ]
+      };
+      const group: fhir4.MeasureGroup = (measure.group as fhir4.MeasureGroup[])[0];
+      expect(isEpisodeOfCareGroup(measure, group)).toBe(true);
+    });
+
+    it('can determine patient based on group extension', () => {
+      const measure: fhir4.Measure = {
+        resourceType: 'Measure',
+        status: 'unknown',
+        group: [
+          {
+            extension: [
+              {
+                url: 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis',
+                valueCode: 'boolean'
+              }
+            ]
+          }
+        ]
+      };
+      const group: fhir4.MeasureGroup = (measure.group as fhir4.MeasureGroup[])[0];
+      expect(isEpisodeOfCareGroup(measure, group)).toBe(false);
+    });
+
+    it('can determine episode of care on measure extension', () => {
+      const measure: fhir4.Measure = {
+        resourceType: 'Measure',
+        status: 'unknown',
+        extension: [
+          {
+            url: 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis',
+            valueCode: 'Procedure'
+          }
+        ],
+        group: [{}]
+      };
+      const group: fhir4.MeasureGroup = (measure.group as fhir4.MeasureGroup[])[0];
+      expect(isEpisodeOfCareGroup(measure, group)).toBe(true);
+    });
+
+    it('can determine patient based on measure extension', () => {
+      const measure: fhir4.Measure = {
+        resourceType: 'Measure',
+        status: 'unknown',
+        extension: [
+          {
+            url: 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis',
+            valueCode: 'boolean'
+          }
+        ],
+        group: [{}]
+      };
+      const group: fhir4.MeasureGroup = (measure.group as fhir4.MeasureGroup[])[0];
+      expect(isEpisodeOfCareGroup(measure, group)).toBe(false);
+    });
+
+    it('defaults to patient based if extension is not found', () => {
+      const measure: fhir4.Measure = {
+        resourceType: 'Measure',
+        status: 'unknown',
+        group: [{}]
+      };
+      const group: fhir4.MeasureGroup = (measure.group as fhir4.MeasureGroup[])[0];
+      expect(isEpisodeOfCareGroup(measure, group)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
# Summary

Now supports measures that define population basis on a per group basis.

## New behavior

Looks for the population basis extension on the group, if it doesn't exist it will fall back to looking at the measure.

## Code changes

`helpers/MeasureBundleHelpers.ts` - New function to look for population basis on the group.
`calculator/DetailedResultsBuilder.ts` - Make use of new function instead of existing one that looked at measure only.

# Testing guidance

Check slack for a bundle of a hacked together bundle.
