### PR TITLE
Handle cqfm-scoring Extension

### DIFF
--- a/src/calculation/MeasureReportBuilder.ts
+++ b/src/calculation/MeasureReportBuilder.ts
@@ -49,10 +49,10 @@ export default class MeasureReportBuilder<T extends PopulationGroupResult> {
   }
 
   private getGroupScoringCode(group: fhir4.MeasureGroup) {
-    const debug = group?.extension?.find(
-      ext => ext.url === 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-scoring'
+    return (
+      group?.extension?.find(ext => ext.url === 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-scoring')
+        ?.valueCodeableConcept?.coding?.[0].code || this.scoringCode
     );
-    return debug?.valueCodeableConcept?.coding?.[0].code || this.scoringCode;
   }
 
   private setupBasicStructure() {

--- a/src/calculation/MeasureReportBuilder.ts
+++ b/src/calculation/MeasureReportBuilder.ts
@@ -48,6 +48,13 @@ export default class MeasureReportBuilder<T extends PopulationGroupResult> {
     this.setupPopulationGroups();
   }
 
+  private getGroupScoringCode(group: fhir4.MeasureGroup) {
+    const debug = group?.extension?.find(
+      ext => ext.url === 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-scoring'
+    );
+    return debug?.valueCodeableConcept?.coding?.[0].code || this.scoringCode;
+  }
+
   private setupBasicStructure() {
     // simple fields
     this.report.period = {
@@ -83,11 +90,12 @@ export default class MeasureReportBuilder<T extends PopulationGroupResult> {
       }
 
       group.population = [];
+      const groupScoringCode = this.getGroupScoringCode(measureGroup);
 
       // build each population group with 0 for initial value
       measureGroup.population?.forEach(measurePopulation => {
         if (
-          this.scoringCode === MeasureScoreType.RATIO &&
+          groupScoringCode === MeasureScoreType.RATIO &&
           measurePopulation.code?.coding?.[0].code === 'measure-observation'
         ) {
           if (measurePopulation.criteria.expression === 'Numerator Observations') {
@@ -176,23 +184,29 @@ export default class MeasureReportBuilder<T extends PopulationGroupResult> {
 
       // find corresponding group in report
       // default to index if group is missing an ID
+      let groupScoringCode = this.scoringCode;
       const group = this.report.group?.find(g => g.id == groupResults.groupId) || this.report.group?.[i];
       if (!group) {
         throw new UnexpectedProperty(`Group ${groupResults.groupId} not found in measure report`);
       }
-
+      if (group.id) {
+        const measureGroup = this.measure?.group?.find(g => g.id === group.id);
+        if (measureGroup) {
+          groupScoringCode = this.getGroupScoringCode(measureGroup);
+        }
+      }
       // iterate over population results for episodes and increment the counters
       // TODO: handle EXM111 (doesn't identify itself as a episode of care measure). if it's an episode of care, you need to iterate over
       // stratifications : may need to clone results for one population group and adjust (in this case, just a straight clone)
       if (groupResults?.episodeResults) {
         groupResults.episodeResults.forEach(er => {
           er.populationResults?.forEach(pr => {
-            this.incrementPopulationInGroup(group, pr);
+            this.incrementPopulationInGroup(group, pr, groupScoringCode);
           });
 
           // TODO: update this when we support CV for summary/subject-list reports
           // Consider moving measure score calculation out of this function
-          if (this.scoringCode === MeasureScoreType.CV) {
+          if (groupScoringCode === MeasureScoreType.CV) {
             group.measureScore = this.calcMeasureScoreCV(this.measure, groupResults, group.id || '');
             this.addScoreObservation(group.measureScore, this.measure, this.report);
           }
@@ -206,10 +220,10 @@ export default class MeasureReportBuilder<T extends PopulationGroupResult> {
                 const stratum = strata?.stratum?.[0];
                 if (stratum) {
                   er.populationResults?.forEach(pr => {
-                    this.incrementPopulationInStratum(stratum, pr);
+                    this.incrementPopulationInStratum(stratum, pr, groupScoringCode);
                   });
                   // TODO: update this when we support CV for summary/subject-list reports
-                  if (this.scoringCode === MeasureScoreType.CV) {
+                  if (groupScoringCode === MeasureScoreType.CV) {
                     stratum.measureScore = this.calcMeasureScoreCV(
                       this.measure,
                       groupResults,
@@ -228,10 +242,10 @@ export default class MeasureReportBuilder<T extends PopulationGroupResult> {
         });
       } else {
         groupResults.populationResults?.forEach(pr => {
-          this.incrementPopulationInGroup(group, pr);
+          this.incrementPopulationInGroup(group, pr, groupScoringCode);
         });
         // TODO: update this when we support CV for summary/subject-list reports
-        if (this.scoringCode === MeasureScoreType.CV) {
+        if (groupScoringCode === MeasureScoreType.CV) {
           group.measureScore = this.calcMeasureScoreCV(this.measure, groupResults, group.id || '');
           this.addScoreObservation(group.measureScore, this.measure, this.report);
         }
@@ -244,10 +258,10 @@ export default class MeasureReportBuilder<T extends PopulationGroupResult> {
               const stratum = strata?.stratum?.[0];
               if (stratum) {
                 groupResults.populationResults?.forEach(pr => {
-                  this.incrementPopulationInStratum(stratum, pr);
+                  this.incrementPopulationInStratum(stratum, pr, groupScoringCode);
                 });
                 // TODO: update this when we support CV for summary/subject-list reports
-                if (this.scoringCode === MeasureScoreType.CV) {
+                if (groupScoringCode === MeasureScoreType.CV) {
                   stratum.measureScore = this.calcMeasureScoreCV(
                     this.measure,
                     groupResults,
@@ -283,8 +297,12 @@ export default class MeasureReportBuilder<T extends PopulationGroupResult> {
     this.patientCount++;
   }
 
-  private incrementPopulationInStratum(stratum: fhir4.MeasureReportGroupStratifierStratum, pr: PopulationResult) {
-    if (this.scoringCode === MeasureScoreType.RATIO) {
+  private incrementPopulationInStratum(
+    stratum: fhir4.MeasureReportGroupStratifierStratum,
+    pr: PopulationResult,
+    groupScoringCode: string
+  ) {
+    if (groupScoringCode === MeasureScoreType.RATIO) {
       if (pr.criteriaExpression === 'Numerator Observations') {
         // find numerator group population and add observation value to it
         const numerPop = stratum.population?.find(pop => pop.code?.coding && pop.code.coding[0].code === 'numerator');
@@ -316,8 +334,8 @@ export default class MeasureReportBuilder<T extends PopulationGroupResult> {
     }
   }
 
-  private incrementPopulationInGroup(group: fhir4.MeasureReportGroup, pr: PopulationResult) {
-    if (this.scoringCode === MeasureScoreType.RATIO && pr.populationType !== 'initial-population') {
+  private incrementPopulationInGroup(group: fhir4.MeasureReportGroup, pr: PopulationResult, groupScoringCode: string) {
+    if (groupScoringCode === MeasureScoreType.RATIO && pr.populationType !== 'initial-population') {
       if (pr.criteriaExpression === 'Numerator Observations') {
         // find numerator group population and add observation value to it
         const numerPop = group.population?.find(pop => pop.code?.coding && pop.code.coding[0].code === 'numerator');
@@ -434,6 +452,7 @@ export default class MeasureReportBuilder<T extends PopulationGroupResult> {
   // http://build.fhir.org/ig/HL7/cqf-measures/ValueSet-aggregate-method.html
   private aggregate(aggregation: string, observations: number[]) {
     // Note: add break for any non-returning case
+    console.log(aggregation);
     switch (aggregation) {
       case AggregationType.SUM:
         // sum	Sum	The measure score is determined by adding together the observations derived from the measure population.
@@ -582,11 +601,18 @@ export default class MeasureReportBuilder<T extends PopulationGroupResult> {
     }
 
     this.report.group?.forEach(group => {
+      let groupScoringCode = this.scoringCode;
+      if (group.id) {
+        const measureGroup = this.measure.group?.find(g => g.id === group.id);
+        if (measureGroup) {
+          groupScoringCode = this.getGroupScoringCode(measureGroup);
+        }
+      }
       if (group.population) {
-        if (this.scoringCode === MeasureScoreType.CV) {
+        if (groupScoringCode === MeasureScoreType.CV) {
           //this...
         } else {
-          group.measureScore = this.calcMeasureScore(this.scoringCode, group.population);
+          group.measureScore = this.calcMeasureScore(groupScoringCode, group.population);
         }
       } else {
         throw new UnexpectedProperty(`Group ${group.id} is missing population results.`);
@@ -596,10 +622,10 @@ export default class MeasureReportBuilder<T extends PopulationGroupResult> {
       group.stratifier?.forEach(strat => {
         strat.stratum?.forEach(stratum => {
           if (stratum.population) {
-            if (this.scoringCode === MeasureScoreType.CV) {
+            if (groupScoringCode === MeasureScoreType.CV) {
               //
             } else {
-              stratum.measureScore = this.calcMeasureScore(this.scoringCode, stratum.population);
+              stratum.measureScore = this.calcMeasureScore(groupScoringCode, stratum.population);
             }
           } else {
             throw new UnexpectedProperty(`Group ${group.id} Stratifier ${strat.id} is missing population results.`);

--- a/src/calculation/MeasureReportBuilder.ts
+++ b/src/calculation/MeasureReportBuilder.ts
@@ -452,7 +452,6 @@ export default class MeasureReportBuilder<T extends PopulationGroupResult> {
   // http://build.fhir.org/ig/HL7/cqf-measures/ValueSet-aggregate-method.html
   private aggregate(aggregation: string, observations: number[]) {
     // Note: add break for any non-returning case
-    console.log(aggregation);
     switch (aggregation) {
       case AggregationType.SUM:
         // sum	Sum	The measure score is determined by adding together the observations derived from the measure population.

--- a/test/MeasureReportBuilder.test.ts
+++ b/test/MeasureReportBuilder.test.ts
@@ -22,6 +22,7 @@ const patient2Id = '08fc9439-b7ff-4309-b409-4d143388594c';
 const simpleMeasure = getJSONFixture('measure/simple-measure.json') as fhir4.Measure;
 const ratioMeasure = getJSONFixture('measure/ratio-measure.json') as fhir4.Measure;
 const cvMeasure = getJSONFixture('measure/cv-measure.json') as fhir4.Measure;
+const cvMeasureScoringOnGroup = getJSONFixture('measure/group-score-cv-measure.json');
 
 const simpleMeasureBundle: fhir4.Bundle = {
   resourceType: 'Bundle',
@@ -52,6 +53,18 @@ const cvMeasureBundle: fhir4.Bundle = {
     }
   ]
 };
+
+function buildTestMeasureBundle(measure: fhir4.Measure): fhir4.Bundle {
+  return {
+    resourceType: 'Bundle',
+    type: 'collection',
+    entry: [
+      {
+        resource: measure
+      }
+    ]
+  };
+}
 
 const executionResults: ExecutionResult<DetailedPopulationGroupResult>[] = [
   {
@@ -399,6 +412,47 @@ describe('MeasureReportBuilder Static', () => {
       mr.group?.forEach(g => {
         expect(g.stratifier).toBeDefined();
       });
+    });
+  });
+});
+
+describe('Measure with specified group CV scoring', () => {
+  let measureReports: fhir4.MeasureReport[];
+  beforeAll(() => {
+    measureReports = MeasureReportBuilder.buildMeasureReports(
+      buildTestMeasureBundle(cvMeasureScoringOnGroup),
+      cvExecutionResults,
+      calculationOptions
+    );
+  });
+
+  test('should generate MeasureReport', () => {
+    expect(measureReports).toBeDefined();
+    expect(measureReports).toHaveLength(1);
+  });
+
+  test('should include CV-specific properties despite ratio scoring on measure', () => {
+    const [mr] = measureReports;
+
+    expect(mr.contained).toBeDefined();
+    expect(mr.contained).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          resourceType: 'Observation',
+          code: {
+            text: 'MeasureObservation'
+          }
+        })
+      ])
+    );
+  });
+
+  test('should include stratifier in each group', () => {
+    const [mr] = measureReports;
+
+    expect(mr.group).toBeDefined();
+    mr.group?.forEach(g => {
+      expect(g.stratifier).toBeDefined();
     });
   });
 });

--- a/test/MeasureReportBuilder.test.ts
+++ b/test/MeasureReportBuilder.test.ts
@@ -35,9 +35,9 @@ function buildTestMeasureBundle(measure: fhir4.Measure): fhir4.Bundle {
     ]
   };
 }
-const simpleMeasureBundle: fhir4.Bundle = buildTestMeasureBundle(simpleMeasure);
+const simpleMeasureBundle = buildTestMeasureBundle(simpleMeasure);
 const ratioMeasureBundle = buildTestMeasureBundle(ratioMeasure);
-const cvMeasureBundle: fhir4.Bundle = buildTestMeasureBundle(cvMeasure);
+const cvMeasureBundle = buildTestMeasureBundle(cvMeasure);
 
 const executionResults: ExecutionResult<DetailedPopulationGroupResult>[] = [
   {

--- a/test/MeasureReportBuilder.test.ts
+++ b/test/MeasureReportBuilder.test.ts
@@ -24,36 +24,6 @@ const ratioMeasure = getJSONFixture('measure/ratio-measure.json') as fhir4.Measu
 const cvMeasure = getJSONFixture('measure/cv-measure.json') as fhir4.Measure;
 const cvMeasureScoringOnGroup = getJSONFixture('measure/group-score-cv-measure.json');
 
-const simpleMeasureBundle: fhir4.Bundle = {
-  resourceType: 'Bundle',
-  type: 'collection',
-  entry: [
-    {
-      resource: simpleMeasure
-    }
-  ]
-};
-
-const ratioMeasureBundle: fhir4.Bundle = {
-  resourceType: 'Bundle',
-  type: 'collection',
-  entry: [
-    {
-      resource: ratioMeasure
-    }
-  ]
-};
-
-const cvMeasureBundle: fhir4.Bundle = {
-  resourceType: 'Bundle',
-  type: 'collection',
-  entry: [
-    {
-      resource: cvMeasure
-    }
-  ]
-};
-
 function buildTestMeasureBundle(measure: fhir4.Measure): fhir4.Bundle {
   return {
     resourceType: 'Bundle',
@@ -65,6 +35,9 @@ function buildTestMeasureBundle(measure: fhir4.Measure): fhir4.Bundle {
     ]
   };
 }
+const simpleMeasureBundle: fhir4.Bundle = buildTestMeasureBundle(simpleMeasure);
+const ratioMeasureBundle = buildTestMeasureBundle(ratioMeasure);
+const cvMeasureBundle: fhir4.Bundle = buildTestMeasureBundle(cvMeasure);
 
 const executionResults: ExecutionResult<DetailedPopulationGroupResult>[] = [
   {

--- a/test/fixtures/measure/group-score-cv-measure.json
+++ b/test/fixtures/measure/group-score-cv-measure.json
@@ -1,0 +1,156 @@
+{
+  "resourceType": "Measure",
+  "id": "cv-example",
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis",
+      "valueCode": "Encounter"
+    },
+    {
+      "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-softwaresystem",
+      "valueReference": {
+        "reference": "#cqf-tooling"
+      }
+    }
+  ],
+  "url": "http://example.com/cv-example",
+  "name": "CV Example",
+  "status": "active",
+  "effectivePeriod": {
+    "start": "2021-01-01",
+    "end": "2021-12-31"
+  },
+  "library": ["Library/example-cv"],
+  "scoring": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/measure-scoring",
+        "code": "ratio"
+      }
+    ]
+  },
+  "improvementNotation": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/measure-improvement-notation",
+        "code": "increase"
+      }
+    ]
+  },
+  "group": [
+    {
+      "id": "group-1",
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-scoring",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-scoring",
+                "code": "continuous-variable",
+                "display": "Continuous Variable"
+              }
+            ]
+          }
+        }
+      ],
+      "population": [
+        {
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "initial-population",
+                "display": "Initial Population"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql",
+            "expression": "Initial Population"
+          }
+        },
+        {
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "measure-population",
+                "display": "Measure Population"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql",
+            "expression": "Measure Population"
+          }
+        },
+        {
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "measure-population-exclusion",
+                "display": "Measure Population Exclusion"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql",
+            "expression": "Measure Population Exclusions"
+          }
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-criteriaReference",
+              "valueString": "measure-population-identifier"
+            },
+            {
+              "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-aggregateMethod",
+              "valueCode": "median"
+            }
+          ],
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "measure-observation",
+                "display": "Measure Observation"
+              }
+            ]
+          },
+          "description": "The duration from the Decision to Admit (order or assessment) to the departure from the Emergency Department",
+          "criteria": {
+            "language": "text/cql",
+            "expression": "MeasureObservation"
+          }
+        }
+      ],
+      "stratifier": [
+        {
+          "code": {
+            "text": "stratification-1"
+          },
+          "description": "Patient encounters without a principal diagnosis (rank=1) of 'Psychiatric/Mental Health Diagnosis'",
+          "criteria": {
+            "name": "stratification-1",
+            "language": "text/cql",
+            "expression": "Stratification 1"
+          }
+        },
+        {
+          "code": {
+            "text": "stratification-2"
+          },
+          "description": "Patient encounters with a principal diagnosis (rank=1) of 'Psychiatric/Mental Health Diagnosis'",
+          "criteria": {
+            "name": "stratification-2",
+            "language": "text/cql",
+            "expression": "Stratification 2"
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
# Summary
Part 1 of a fix for #144. The `cqfm-scoring` extension allows MeasureGroups to specify the group's scoring code on the group rather than the measure. Prior to this PR, we only looked at the Measure.scoring to determine a group's score. Now fqm-execution prioritizes scoring codes specified on groups via the `cqfm-scoring` extension and falls back to the Measure.scoring when the extension is not present

## New behavior
Measure groups that specify their scoring code via the `cqfm-scoring` extension will now be properly accounted for in the MeasureReportsBuilder. All other functionality should remain unchanged

## Code changes
 - Added code in MeasureReportBuilder.ts to check for presence of `cqfm-scoring` extension, then pass that score through for groups that use it. Default to `Measure.scoring` when absent
 - Added testing

# Testing guidance
 - `npm run check`
 - Testing here is probably most easily done in the debugger. Contact me for an altered MeasureBundle which should trigger the newly added code and fail on master. Place a breakpoint wherever `groupScoringCode` is used in MeasureReportBuilder.ts and ensure that the correct value is retrieved and persisted through for the group in calculation
