### PR TITLE
Implement Proper Measure Observations for Boolean/Episode Measures

### DIFF
--- a/src/calculation/DetailedResultsBuilder.ts
+++ b/src/calculation/DetailedResultsBuilder.ts
@@ -45,6 +45,8 @@ export function createPopulationValues(
       populationResults = popAndStratResults.populationResults;
       stratifierResults = popAndStratResults.stratifierResults;
     } else {
+      // TODO: in the case of episode aggregation, we should consider collating the observation results at the root populationResults
+      // list as well
       populationResults = [];
       stratifierResults = [];
       // create patient level population and stratifier results based on episodes
@@ -304,6 +306,8 @@ export function createEpisodePopulationValues(
                 observResult.result = true;
               } else {
                 // create new populationResult with obs
+                // TODO: Episode-level results could probably be just the value, not an array of one value
+                // Future changes to fqm-execution might modify this structure
                 episodeResult.populationResults.push({
                   populationType: PopulationType.OBSERV,
                   criteriaExpression: cqlPopulation,

--- a/src/calculation/DetailedResultsBuilder.ts
+++ b/src/calculation/DetailedResultsBuilder.ts
@@ -177,16 +177,40 @@ export function createPatientPopulationValues(
     // Grab CQL result value and adjust for ECQME
 
     const populationType = MeasureBundleHelpers.codeableConceptToPopulationType(population.code);
+
     // If this is a valid population type and there is a defined cql population pull out the values
     if (populationType != null && cqlPopulation != null) {
-      const value = patientResults[cqlPopulation];
-      const result = isStatementValueTruthy(value);
-      const newPopulationResult: PopulationResult = {
-        populationType: populationType,
-        criteriaExpression: population.criteria.expression,
-        result: result
-      };
-      populationResults.push(newPopulationResult);
+      // For measure observations observing a boolean population, match the result with the population it is observing
+      // and pull the observations from the generated ELM JSON function with no parameters
+      if (populationType === PopulationType.OBSERV) {
+        const observingPopulation = DetailedResultsHelpers.findObsMsrPopl(populationGroup, population);
+        const value = observingPopulation?.criteria.expression
+          ? patientResults[observingPopulation.criteria.expression]
+          : null;
+        const result = isStatementValueTruthy(value);
+
+        const observRawResult = patientResults[`obs_func_${cqlPopulation}`];
+        const newPopulationResult: PopulationResult = {
+          populationType: populationType,
+          criteriaExpression: population.criteria.expression,
+          result
+        };
+
+        if (observRawResult) {
+          newPopulationResult.observations = [observRawResult];
+        }
+
+        populationResults.push(newPopulationResult);
+      } else {
+        const value = patientResults[cqlPopulation];
+        const result = isStatementValueTruthy(value);
+        const newPopulationResult: PopulationResult = {
+          populationType: populationType,
+          criteriaExpression: population.criteria.expression,
+          result: result
+        };
+        populationResults.push(newPopulationResult);
+      }
     }
   });
 
@@ -194,7 +218,7 @@ export function createPatientPopulationValues(
   let stratifierResults: StratifierResult[] | undefined;
   if (populationGroup.stratifier) {
     stratifierResults = [];
-    // index used incase the text for the stratifier could not be found
+    // index used in case the text for the stratifier could not be found
     let strataIndex = 1;
     populationGroup.stratifier.forEach(strata => {
       if (strata.criteria?.expression) {
@@ -430,7 +454,7 @@ export function setValueSetVersionsToUndefined(elm: ELM[]): ELM[] {
  * @param {string} parameter - Name of the define statement to use as the parameter list. Usually "Measure Population".
  * @returns {ELMStatement} The ELM function to inject into the ELM library before executing.
  */
-export function generateELMJSONFunction(functionName: string, parameter: string): ELMStatement {
+export function generateEpisodeELMJSONFunction(functionName: string, parameter: string): ELMStatement {
   const elmFunction: ELMStatement = {
     name: `obs_func_${functionName}_${parameter}`,
     context: 'Patient',
@@ -477,5 +501,25 @@ export function generateELMJSONFunction(functionName: string, parameter: string)
       }
     }
   };
+  return elmFunction;
+}
+
+/*
+ * This is used for boolean-based measures that do a measure observation
+ * In this case, the function will not have any arguments, so we simplify the generation of
+ * this ELM JSON function to simply just call the function rather than do a query
+ */
+export function generateBooleanELMJSONFunction(functionName: string) {
+  const elmFunction: ELMStatement = {
+    name: `obs_func_${functionName}`,
+    context: 'Patient',
+    accessLevel: 'Public',
+    expression: {
+      type: 'FunctionRef',
+      name: functionName,
+      operand: []
+    }
+  };
+
   return elmFunction;
 }

--- a/src/helpers/MeasureBundleHelpers.ts
+++ b/src/helpers/MeasureBundleHelpers.ts
@@ -49,6 +49,9 @@ export function isEpisodeOfCareGroup(measure: fhir4.Measure, group: fhir4.Measur
  * Measure Observation populations can specify which population in the measure they are drawing observations from (e.g. Numerator/Denominator/etc.)
  * This is done by referencing the ID of that population in the valueString of the cqfm-criteriaReference extension
  * This function identifies the ID used in one of those measure observation populations
+ *
+ * @param population within a Measure resource that may reference another population within the same Measure
+ * @returns the corresponding ID from the extension used in the population, or null if none is found
  */
 export function getCriteriaReferenceIdFromPopulation(population: fhir4.MeasureGroupPopulation): string | null {
   return (

--- a/src/helpers/MeasureBundleHelpers.ts
+++ b/src/helpers/MeasureBundleHelpers.ts
@@ -46,6 +46,19 @@ export function isEpisodeOfCareGroup(measure: fhir4.Measure, group: fhir4.Measur
 }
 
 /**
+ * Measure Observation populations can specify which population in the measure they are drawing observations from (e.g. Numerator/Denominator/etc.)
+ * This is done by referencing the ID of that population in the valueString of the cqfm-criteriaReference extension
+ * This function identifies the ID used in one of those measure observation populations
+ */
+export function getCriteriaReferenceIdFromPopulation(population: fhir4.MeasureGroupPopulation): string | null {
+  return (
+    population.extension?.find(
+      e => e.url === 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-criteriaReference'
+    )?.valueString ?? null
+  );
+}
+
+/**
  * Population Type Code system.
  */
 const POPULATION_TYPE_CODESYSTEM = 'http://terminology.hl7.org/CodeSystem/measure-population';

--- a/src/helpers/elm/ELMInfoCache.ts
+++ b/src/helpers/elm/ELMInfoCache.ts
@@ -1,11 +1,15 @@
 import { CodeService, Repository } from 'cql-execution';
 import { MeasureBundleHelpers } from '../..';
-import { generateELMJSONFunction } from '../../calculation/DetailedResultsBuilder';
+import {
+  generateEpisodeELMJSONFunction,
+  generateBooleanELMJSONFunction
+} from '../../calculation/DetailedResultsBuilder';
 import { valueSetsForCodeService } from '../../execution/ValueSetHelper';
 import { ExtractedLibrary, ValueSetMap } from '../../types/CQLTypes';
 import { ELM, ELMIdentifier } from '../../types/ELMTypes';
 import { PopulationType } from '../../types/Enums';
 import { findObsMsrPopl } from '../DetailedResultsHelpers';
+import { isEpisodeOfCareGroup } from '../MeasureBundleHelpers';
 
 export interface ELMInfoCacheType {
   rep: Repository;
@@ -54,9 +58,11 @@ export function retrieveELMInfo(
           if (msrPop?.criteria?.expression && obsrvPop.criteria?.expression) {
             const mainLib = elmJSONs.find(elm => elm.library.identifier.id === rootLibIdentifier.id);
             if (mainLib) {
-              mainLib.library.statements.def.push(
-                generateELMJSONFunction(obsrvPop.criteria.expression, msrPop.criteria.expression)
-              );
+              const elmFunction = isEpisodeOfCareGroup(measure, group)
+                ? generateEpisodeELMJSONFunction(obsrvPop.criteria.expression, msrPop.criteria.expression)
+                : generateBooleanELMJSONFunction(obsrvPop.criteria.expression);
+
+              mainLib.library.statements.def.push(elmFunction);
             }
           }
         });

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -204,7 +204,7 @@ export interface PopulationResult {
   /** Type of population matching http://hl7.org/fhir/ValueSet/measure-population */
   populationType: PopulationType;
   /** The population criteria expression, which may be used to further identify the population (i.e. a cql identifier) */
-  criteriaExpression: string | undefined;
+  criteriaExpression?: string;
   /** True if this patient or episode calculates with membership in this population. */
   result: boolean;
   /** Observations made for this population. */

--- a/test/DetailedResultsBuilder.test.ts
+++ b/test/DetailedResultsBuilder.test.ts
@@ -4,7 +4,7 @@ import { getJSONFixture } from './helpers/testHelpers';
 import { PopulationType } from '../src/types/Enums';
 import { StatementResults } from '../src/types/CQLTypes';
 import { PopulationResult } from '../src/types/Calculator';
-import { ELMExpressionRef, ELMQuery, ELMTuple } from '../src/types/ELMTypes';
+import { ELMExpressionRef, ELMQuery, ELMTuple, ELMFunctionRef } from '../src/types/ELMTypes';
 
 type MeasureWithGroup = fhir4.Measure & {
   group: fhir4.MeasureGroup[];
@@ -206,10 +206,10 @@ describe('DetailedResultsBuilder', () => {
   });
 
   describe('ELM JSON Function', () => {
-    test('should properly generate ELM JSON given name and parameter', () => {
+    test('should properly generate episode-based ELM JSON given name and parameter', () => {
       const exampleFunctionName = 'exampleFunction';
       const exampleParameterName = 'exampleParameter';
-      const fn = DetailedResultsBuilder.generateELMJSONFunction(exampleFunctionName, exampleParameterName);
+      const fn = DetailedResultsBuilder.generateEpisodeELMJSONFunction(exampleFunctionName, exampleParameterName);
 
       expect(fn.name).toEqual(`obs_func_${exampleFunctionName}_${exampleParameterName}`);
       expect(((fn.expression as ELMQuery).source[0].expression as ELMExpressionRef).name).toEqual(exampleParameterName);
@@ -232,6 +232,19 @@ describe('DetailedResultsBuilder', () => {
           }
         ])
       );
+    });
+
+    test('should properly generate boolean-based ELM JSON given name', () => {
+      const exampleFunctionName = 'exampleFunction';
+      const fn = DetailedResultsBuilder.generateBooleanELMJSONFunction(exampleFunctionName);
+
+      expect(fn.name).toEqual(`obs_func_${exampleFunctionName}`);
+      expect(fn.expression.type).toEqual('FunctionRef');
+
+      const functionRef = fn.expression as ELMFunctionRef;
+
+      expect(functionRef.name).toEqual(exampleFunctionName);
+      expect(functionRef.operand).toEqual([]);
     });
   });
 });

--- a/test/MeasureBundleHelpers.test.ts
+++ b/test/MeasureBundleHelpers.test.ts
@@ -365,4 +365,51 @@ describe('MeasureBundleHelpers', () => {
       jest.restoreAllMocks();
     });
   });
+
+  describe('getCriteriaReferenceIdFromPopulation', () => {
+    test('should identify valueString when present', () => {
+      const pop: fhir4.MeasureGroupPopulation = {
+        extension: [
+          {
+            url: 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-criteriaReference',
+            valueString: 'test-id'
+          }
+        ],
+        criteria: {
+          language: 'text/cql',
+          expression: 'Test'
+        }
+      };
+
+      expect(MeasureBundleHelpers.getCriteriaReferenceIdFromPopulation(pop)).toEqual('test-id');
+    });
+
+    test('should return null with no matching extension', () => {
+      const pop: fhir4.MeasureGroupPopulation = {
+        extension: [
+          {
+            url: 'http://example.com/not-a-real-extension',
+            valueString: 'test-id'
+          }
+        ],
+        criteria: {
+          language: 'text/cql',
+          expression: 'Test'
+        }
+      };
+
+      expect(MeasureBundleHelpers.getCriteriaReferenceIdFromPopulation(pop)).toBeNull();
+    });
+
+    test('should return null with extension at all', () => {
+      const pop: fhir4.MeasureGroupPopulation = {
+        criteria: {
+          language: 'text/cql',
+          expression: 'Test'
+        }
+      };
+
+      expect(MeasureBundleHelpers.getCriteriaReferenceIdFromPopulation(pop)).toBeNull();
+    });
+  });
 });

--- a/test/helpers/DetailedResultsHelpers.test.ts
+++ b/test/helpers/DetailedResultsHelpers.test.ts
@@ -183,7 +183,42 @@ describe('findObsMsrPopl', () => {
     expect(MeasureBundleHelpers.codeableConceptToPopulationType(msrPop?.code)).toBe('measure-population');
   });
 
-  test('should find numerator population for Numerator Observations', () => {
+  test('should find population referenced using cqfm-criteriaExpression', () => {
+    const examplePopId = 'example-observ-pop';
+
+    const observedPop: MeasureGroupPopulation = {
+      id: examplePopId,
+      criteria: { language: 'text/cql.identifier', expression: 'Example Function' }
+    };
+
+    const observingPop: MeasureGroupPopulation = {
+      extension: [
+        {
+          url: 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-criteriaReference',
+          valueString: examplePopId
+        }
+      ],
+      code: {
+        coding: [
+          {
+            code: 'numerator',
+            system: 'http://terminology.hl7.org/CodeSystem/measure-population'
+          }
+        ]
+      },
+      criteria: { language: 'text/cql.identifier', expression: 'Example Numerator' }
+    };
+
+    const group: MeasureGroup = {
+      population: [observingPop, observedPop]
+    };
+
+    const msrPop = findObsMsrPopl(group, observingPop);
+    expect(msrPop).toBeDefined();
+    expect(msrPop).toEqual(observedPop);
+  });
+
+  test('should fallback to criteria expression with no criteria reference for numerator', () => {
     const group: MeasureGroup = {
       population: [
         {
@@ -217,7 +252,7 @@ describe('findObsMsrPopl', () => {
     expect(MeasureBundleHelpers.codeableConceptToPopulationType(msrPop?.code)).toBe('numerator');
   });
 
-  test('should find denominator population for Denominator Observations', () => {
+  test('should fallback to criteria expression with no criteria reference for denominator', () => {
     const group: MeasureGroup = {
       population: [
         {


### PR DESCRIPTION
# Summary

Fixes #144 
Fixes #145

Per these issues, fqm-execution was not properly reporting measure observations for certain measure types/cases. The following is the breakdown of why

*CV Boolean and Ratio Boolean*

In the case of a boolean-based measure, we were not including logic to add a call to the observation function into the ELM and report those results. This PR adds similar logic that we do for episode-based measures to boolean measures where a `measure-observation` is used.

*Episode-based Ratio*

This was incorrect because we were using our workaround where we assumed that the numerator and denominator observation functions would have specific criteria expressions. This PR uses [cqfm-criteriaReference](https://build.fhir.org/ig/HL7/cqf-measures/StructureDefinition-cqfm-criteriaReference.html) to look up the observed population by ID, which is what the groups in the #144 test cases do (thanks @nmorasb!).

## New behavior

* CV Boolean reports observation results in `populationResults`
* Ratio Boolean reports observation results in `populationResults`
* Ratio episode reports observation results in each `episodeResult`

## Code changes

* Add ELM JSON Function generation in boolean cases to be a function with no argument (this is the fix for #145)
* Update `findObsMsrPopl` function to use the criteria reference when provided
* Update detailed results processing to use the results of the new ELM JSON function in boolean cases to report observation results
* Add tests

# Testing guidance

* Download [issue-144-test-cases.zip](https://github.com/projecttacoma/fqm-execution/files/9788337/issue-144-test-cases.zip). This includes individual measure bundles for CV boolean, Ratio Boolean, and Ratio Encounter. These come from the big bundle that @nmorasb provided, but with the individual groups extracted for simplicitly in looking at the results
* Move all the files to the root of `fqm-execution`
* run `./run.sh` -- this will generate detailed results json for each of the cases:

*cv-boolean-output.json*

Should have this in the `populationResults`:

```
{
  "populationType": "measure-observation",
  "criteriaExpression": "fun",
  "result": true,
  "observations": [
    1
  ]
}
```


*ratio-boolean-output.json*

Should have this in the `populationResults`:

```
{
  "populationType": "measure-observation",
  "criteriaExpression": "fun",
  "result": true,
  "observations": [
    1
  ]
}
```


*ratio-encounter-output.json*

Should have this in the `episodeResults`:

```
episodeResults entry for Encounter2 (denom only so fun3 is false):

{
  "populationType": "measure-observation",
  "criteriaExpression": "fun2",
  "result": true,
  "observations": [
    2
  ]
},
{
  "populationType": "measure-observation",
  "criteriaExpression": "fun3",
  "result": false
}
```

```
episodeResults entry for Encounter3 (numer so has results for both):

{
  "populationType": "measure-observation",
  "criteriaExpression": "fun2",
  "result": true,
  "observations": [
    2
  ]
},
{
  "populationType": "measure-observation",
  "criteriaExpression": "fun3",
  "result": true,
  "observations": [
    4
  ]
}
```
