### PR TITLE
Npm 8 hotfixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [14.x, 16.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         measure: [EXM104, EXM105, EXM124, EXM125, EXM130, EXM506]
-        node-version: [12.x]
+        node-version: [16.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/README.md
+++ b/README.md
@@ -107,32 +107,29 @@ To run the globally installed CLI (see above), use the global `fqm-execution com
 Usage: fqm-execution [command] [options]
 
 Commands:
- detailed (default)
- raw
- reports
- gaps
- dataRequirements
- queryInfo
- valueSets
+  detailed
+  reports
+  raw
+  gaps
+  dataRequirements
+  queryInfo
+  valueSets
+  help [command]                              display help for command
 
 Options:
-  --debug                                     Enable debug output (default: false).
+  --debug                                     Enable debug output. (default: false)
   --slim                                      Use slimmed-down calculation results interfaces (default: false)
   --report-type <report-type>                 Type of report, "individual", "summary", "subject-list".
   -m, --measure-bundle <measure-bundle>       Path to measure bundle.
-  -p, --patient-bundles <patient-bundles...>  Paths to patient bundles. Required unless --patient-ids or --group-id is provided or output type is dataRequirements. Note: cannot be used with --patient-ids or --group-id.
-  --patient-ids <ids...>                      A list of patient ids an AsyncPatientSource will use to query a fhir server for patient data. Note: cannot be used with --patient-bundles or --group-id; --as-patient-source and --fhir-server-url are required when --patient-ids is provided.
-  --group-id <id>                             A group id an AsyncPatientSource will use to query a fhir server for patient data. Note: cannot be used with --patient-bundles or --patient-ids; --as-patient-source and --fhir-server-url are required when --group-id is provided.
+  -p, --patient-bundles <patient-bundles...>  Paths to patient bundles. Required unless output type is dataRequirements.
   --as-patient-source                         Load bundles by creating cql-exec-fhir PatientSource to pass into library calls.
-  --fhir-server-url <url>                     Loads bundles into an AsyncPatientSource which queries the passed in FHIR server URL for patient data. Note: --as-patient-source and either --patient-ids or --group-id are required when --fhir-server-url is provided.
-  -s, --measurement-period-start <date>       Start date for the measurement period, in YYYY-MM-DD format (defaults to the start date defined in the Measure, or 2019-01-01 if not set.
-                                              there)
+  -s, --measurement-period-start <date>       Start date for the measurement period, in YYYY-MM-DD format (defaults to the start date defined in the Measure, or 2019-01-01 if not set there).
   -e, --measurement-period-end <date>         End date for the measurement period, in YYYY-MM-DD format (defaults to the end date defined in the Measure, or 2019-12-31 if not set there).
   --vs-api-key <key>                          API key, to authenticate against the valueset service to be used for resolving missing valuesets.
-  --cache-valuesets                           Whether or not to cache ValueSets retrieved from the ValueSet service (default: false)
-  --profile-validation                        To "trust" the content of meta.profile as a source of truth for what profiles the data that cql-exec-fhir grabs validates against
-  -o, --output-file [file-path]               Path to a file that fqm-execution will write the calculation results to (default: output.json)
-  -h, --help                                  Display help for command.
+  --cache-valuesets                           Whether or not to cache ValueSets retrieved from the ValueSet service. (default: false)
+  --profile-validation                        To "trust" the content of meta.profile as a source of truth for what profiles the data that cql-exec-fhir grabs validates against. (default: false)
+  -o, --out-file [file-path]                  Path to a file that fqm-execution will write the calculation results to (default: output.json)
+  -h, --help                                  display help for command
 ```
 
 E.g.

--- a/README.md
+++ b/README.md
@@ -140,9 +140,6 @@ Generate a MeasureReport by calculating a measure on a patient bundle:
 
 Generate a MeasureReport by calculating a measure on multiple patient bundles:
   - fqm-execution reports -m /path/to/measure/bundle.json -p /path/to/patient1/bundle.json /path/to/patient2/bundle.json > reports.json
-
-Generate a MeasureReport by calculating a measure on a patient source which pulls its patient data from a FHIR server:
-  - fqm-execution reports -m /path/to/measure/bundle.json --as-patient-source --fhir-server-url http://example.com --patient-ids test_id_1 test_id_2 > reports.json
 ```
 
 ### ValueSets
@@ -176,23 +173,24 @@ Install dependencies:
 npm install
 ```
 
-Optionally, you can install the `ts-node` utility globally to execute the TypeScript files directly instead of running the build script:
-
-```bash
-npm install -g ts-node
-```
-
 Run the CLI with ts-node:
 
 ```bash
-ts-node --files src/cli.ts [options]
+npm run cli -- [command] [options]
 ```
 
 Or using the built JavaScript:
 
 ```bash
 npm run build
-node build/cli.js [options]
+node build/cli.js [command] [options]
+```
+
+Optionally, you can install the `ts-node` utility globally to execute the TypeScript files directly instead of running the build script:
+
+```bash
+npm install -g ts-node
+ts-node --files src/cli.ts [command] [options]
 ```
 
 ### Debug Option

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "atob": "^2.1.2",
         "axios": "^0.21.1",
         "commander": "^6.1.0",
-        "cql-exec-fhir": "git+https://git@github.com/projecttacoma/cql-exec-fhir",
+        "cql-exec-fhir": "^2.1.0",
         "cql-execution": "^3.0.0-beta.1",
         "handlebars": "^4.7.7",
         "lodash": "^4.17.21",
@@ -561,29 +561,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.19.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.19.4.tgz",
-      "integrity": "sha512-EXpLCrk55f+cYqmHsSR+yD/0gAIMxxA9QK9lnQWzhMCvt+YmoBN7Zx94s++Kv0+unHk39vxNO8t+CMA2WSS3wA==",
-      "dependencies": {
-        "regenerator-runtime": "^0.13.4"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/runtime-corejs3": {
-      "version": "7.19.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.19.4.tgz",
-      "integrity": "sha512-HzjQ8+dzdx7dmZy4DQ8KV8aHi/74AjEbBGTFutBmg/pd3dY5/q1sfuOGPTFGEytlQhWoeVXqcK5BwMgIkRkNDQ==",
-      "dependencies": {
-        "core-js-pure": "^3.25.1",
-        "regenerator-runtime": "^0.13.4"
-      },
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -2196,41 +2173,20 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/core-js-pure": {
-      "version": "3.25.5",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.25.5.tgz",
-      "integrity": "sha512-oml3M22pHM+igfWHDfdLVq2ShWmjM2V4L+dQEBs0DWVIqEm9WHCwGAlZ6BmyBQGy5sFrJmcx+856D9lVKyGWYg==",
-      "hasInstallScript": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
-    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "node_modules/cql-exec-fhir": {
-      "version": "2.0.2",
-      "resolved": "git+https://git@github.com/projecttacoma/cql-exec-fhir.git#d48d57c3c7e199cbaa02e41418cad9efcd148b15",
-      "license": "Apache-2.0",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cql-exec-fhir/-/cql-exec-fhir-2.1.0.tgz",
+      "integrity": "sha512-6dX325iFdygvs+Ee9gAfRu9LlbhevrB9TDB0qD4bRC8QjmRmVL5SzEMgKiVPhfCwvsIIBP+davkwGXxt1uBigg==",
       "dependencies": {
-        "@babel/runtime": "^7.17.2",
-        "@babel/runtime-corejs3": "^7.17.2",
-        "axios": "^0.26.0",
         "xml2js": "~0.4.23"
       },
       "peerDependencies": {
         "cql-execution": ">=1.3.0"
-      }
-    },
-    "node_modules/cql-exec-fhir/node_modules/axios": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-      "dependencies": {
-        "follow-redirects": "^1.14.8"
       }
     },
     "node_modules/cql-execution": {
@@ -5545,11 +5501,6 @@
         "util-deprecate": "~1.0.1"
       }
     },
-    "node_modules/regenerator-runtime": {
-      "version": "0.13.10",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz",
-      "integrity": "sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw=="
-    },
     "node_modules/regex-not": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -7926,23 +7877,6 @@
         "@babel/helper-plugin-utils": "^7.14.5"
       }
     },
-    "@babel/runtime": {
-      "version": "7.19.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.19.4.tgz",
-      "integrity": "sha512-EXpLCrk55f+cYqmHsSR+yD/0gAIMxxA9QK9lnQWzhMCvt+YmoBN7Zx94s++Kv0+unHk39vxNO8t+CMA2WSS3wA==",
-      "requires": {
-        "regenerator-runtime": "^0.13.4"
-      }
-    },
-    "@babel/runtime-corejs3": {
-      "version": "7.19.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.19.4.tgz",
-      "integrity": "sha512-HzjQ8+dzdx7dmZy4DQ8KV8aHi/74AjEbBGTFutBmg/pd3dY5/q1sfuOGPTFGEytlQhWoeVXqcK5BwMgIkRkNDQ==",
-      "requires": {
-        "core-js-pure": "^3.25.1",
-        "regenerator-runtime": "^0.13.4"
-      }
-    },
     "@babel/template": {
       "version": "7.18.10",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.10.tgz",
@@ -9208,34 +9142,17 @@
       "integrity": "sha512-XgZ0pFcakEUlbwQEVNg3+QAis1FyTL3Qel9FYy8pSkQqoG3PNoT0bOCQtOXcOkur21r2Eq2kI+IE+gsmAEVlYw==",
       "dev": true
     },
-    "core-js-pure": {
-      "version": "3.25.5",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.25.5.tgz",
-      "integrity": "sha512-oml3M22pHM+igfWHDfdLVq2ShWmjM2V4L+dQEBs0DWVIqEm9WHCwGAlZ6BmyBQGy5sFrJmcx+856D9lVKyGWYg=="
-    },
     "core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "cql-exec-fhir": {
-      "version": "git+https://git@github.com/projecttacoma/cql-exec-fhir.git#d48d57c3c7e199cbaa02e41418cad9efcd148b15",
-      "from": "cql-exec-fhir@git+https://git@github.com/projecttacoma/cql-exec-fhir",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cql-exec-fhir/-/cql-exec-fhir-2.1.0.tgz",
+      "integrity": "sha512-6dX325iFdygvs+Ee9gAfRu9LlbhevrB9TDB0qD4bRC8QjmRmVL5SzEMgKiVPhfCwvsIIBP+davkwGXxt1uBigg==",
       "requires": {
-        "@babel/runtime": "^7.17.2",
-        "@babel/runtime-corejs3": "^7.17.2",
-        "axios": "^0.26.0",
         "xml2js": "~0.4.23"
-      },
-      "dependencies": {
-        "axios": {
-          "version": "0.26.1",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-          "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-          "requires": {
-            "follow-redirects": "^1.14.8"
-          }
-        }
       }
     },
     "cql-execution": {
@@ -11778,11 +11695,6 @@
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
       }
-    },
-    "regenerator-runtime": {
-      "version": "0.13.10",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz",
-      "integrity": "sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw=="
     },
     "regex-not": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "axios": "^0.21.1",
         "commander": "^6.1.0",
         "cql-exec-fhir": "git+https://git@github.com/projecttacoma/cql-exec-fhir",
-        "cql-execution": "git+https://git@github.com/projecttacoma/cql-execution",
+        "cql-execution": "^3.0.0-beta.1",
         "handlebars": "^4.7.7",
         "lodash": "^4.17.21",
         "moment": "^2.29.4",
@@ -2235,9 +2235,9 @@
       }
     },
     "node_modules/cql-execution": {
-      "version": "2.4.0",
-      "resolved": "git+https://git@github.com/projecttacoma/cql-execution.git#d1c0e9341c763bb8cc641a5a702cedb0c8385c88",
-      "license": "Apache-2.0",
+      "version": "3.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.0-beta.1.tgz",
+      "integrity": "sha512-qhat3D6sqlU1RbfkV7lmPORCB7eCFXbmhWdpLIscVeHL5hKN9rwFWYUVsvwVGNTROtMMTEmlQF67L4dPHqLKtA==",
       "dependencies": {
         "@lhncbc/ucum-lhc": "^4.1.3",
         "luxon": "^1.25.0"
@@ -9295,8 +9295,9 @@
       }
     },
     "cql-execution": {
-      "version": "git+https://git@github.com/projecttacoma/cql-execution.git#d1c0e9341c763bb8cc641a5a702cedb0c8385c88",
-      "from": "cql-execution@git+https://git@github.com/projecttacoma/cql-execution",
+      "version": "3.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.0-beta.1.tgz",
+      "integrity": "sha512-qhat3D6sqlU1RbfkV7lmPORCB7eCFXbmhWdpLIscVeHL5hKN9rwFWYUVsvwVGNTROtMMTEmlQF67L4dPHqLKtA==",
       "requires": {
         "@lhncbc/ucum-lhc": "^4.1.3",
         "luxon": "^1.25.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "atob": "^2.1.2",
         "axios": "^0.21.1",
         "commander": "^6.1.0",
-        "cql-exec-fhir": "^2.1.0",
+        "cql-exec-fhir": "^2.1.1",
         "cql-execution": "^3.0.0-beta.1",
         "handlebars": "^4.7.7",
         "lodash": "^4.17.21",
@@ -2179,14 +2179,14 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "node_modules/cql-exec-fhir": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cql-exec-fhir/-/cql-exec-fhir-2.1.0.tgz",
-      "integrity": "sha512-6dX325iFdygvs+Ee9gAfRu9LlbhevrB9TDB0qD4bRC8QjmRmVL5SzEMgKiVPhfCwvsIIBP+davkwGXxt1uBigg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/cql-exec-fhir/-/cql-exec-fhir-2.1.1.tgz",
+      "integrity": "sha512-QLCo0AezAl9hTYHtt+f+UqNXyMWSHLWNg0EqUmerx8FJcErXlBFakrz8S9A5sHYy7PC8M2b7TGyCEMQp1xZtNw==",
       "dependencies": {
         "xml2js": "~0.4.23"
       },
       "peerDependencies": {
-        "cql-execution": ">=1.3.0"
+        "cql-execution": ">=1.3.0 | ^3.0.0-beta"
       }
     },
     "node_modules/cql-execution": {
@@ -8551,7 +8551,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -9148,9 +9149,9 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "cql-exec-fhir": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cql-exec-fhir/-/cql-exec-fhir-2.1.0.tgz",
-      "integrity": "sha512-6dX325iFdygvs+Ee9gAfRu9LlbhevrB9TDB0qD4bRC8QjmRmVL5SzEMgKiVPhfCwvsIIBP+davkwGXxt1uBigg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/cql-exec-fhir/-/cql-exec-fhir-2.1.1.tgz",
+      "integrity": "sha512-QLCo0AezAl9hTYHtt+f+UqNXyMWSHLWNg0EqUmerx8FJcErXlBFakrz8S9A5sHYy7PC8M2b7TGyCEMQp1xZtNw==",
       "requires": {
         "xml2js": "~0.4.23"
       }
@@ -10709,7 +10710,8 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "26.0.0",
@@ -13161,7 +13163,8 @@
       "version": "7.5.9",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
       "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,6 @@
         "jest": "^26.1.0",
         "opener": "^1.5.2",
         "prettier": "^2.0.5",
-        "shx": "^0.3.3",
         "ts-jest": "^26.1.3",
         "ts-node": "^9.1.1",
         "typescript": "^3.9.7"
@@ -3636,15 +3635,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
-    "node_modules/interpret": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/is-accessor-descriptor": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
@@ -5555,18 +5545,6 @@
         "util-deprecate": "~1.0.1"
       }
     },
-    "node_modules/rechoir": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
-      "dev": true,
-      "dependencies": {
-        "resolve": "^1.1.6"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/regenerator-runtime": {
       "version": "0.13.10",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz",
@@ -6153,45 +6131,12 @@
         "node": ">=8"
       }
     },
-    "node_modules/shelljs": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
-      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
-      },
-      "bin": {
-        "shjs": "bin/shjs"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/shellwords": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true,
       "optional": true
-    },
-    "node_modules/shx": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/shx/-/shx-0.3.4.tgz",
-      "integrity": "sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.3",
-        "shelljs": "^0.8.5"
-      },
-      "bin": {
-        "shx": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
@@ -8672,8 +8617,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -10370,12 +10314,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
-    "interpret": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
-      "dev": true
-    },
     "is-accessor-descriptor": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
@@ -10854,8 +10792,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "26.0.0",
@@ -11842,15 +11779,6 @@
         "util-deprecate": "~1.0.1"
       }
     },
-    "rechoir": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
-      "dev": true,
-      "requires": {
-        "resolve": "^1.1.6"
-      }
-    },
     "regenerator-runtime": {
       "version": "0.13.10",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz",
@@ -12309,33 +12237,12 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
-    "shelljs": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
-      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
-      "dev": true,
-      "requires": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
-      }
-    },
     "shellwords": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true,
       "optional": true
-    },
-    "shx": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/shx/-/shx-0.3.4.tgz",
-      "integrity": "sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.3",
-        "shelljs": "^0.8.5"
-      }
     },
     "signal-exit": {
       "version": "3.0.7",
@@ -13342,8 +13249,7 @@
       "version": "7.5.9",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
       "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "atob": "^2.1.2",
     "axios": "^0.21.1",
     "commander": "^6.1.0",
-    "cql-exec-fhir": "^2.1.0",
+    "cql-exec-fhir": "^2.1.1",
     "cql-execution": "^3.0.0-beta.1",
     "handlebars": "^4.7.7",
     "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -37,14 +37,13 @@
     "jest": "^26.1.0",
     "opener": "^1.5.2",
     "prettier": "^2.0.5",
-    "shx": "^0.3.3",
     "ts-jest": "^26.1.3",
     "ts-node": "^9.1.1",
     "typescript": "^3.9.7"
   },
   "scripts": {
-    "build": "shx rm -rf ./build && tsc",
-    "build:watch": "shx rm -rf ./build && tsc -w",
+    "build": "tsc",
+    "build:watch": "tsc -w",
     "coverage": "opener coverage/lcov-report/index.html",
     "lint": "tsc && eslint \"**/*.{js,ts}\"",
     "lint:fix": "tsc --noEmit && eslint \"**/*.{js,ts}\" --quiet --fix",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "scripts": {
     "build": "tsc",
     "build:watch": "tsc -w",
+    "cli": "ts-node --files src/cli.ts",
     "coverage": "opener coverage/lcov-report/index.html",
     "lint": "tsc && eslint \"**/*.{js,ts}\"",
     "lint:fix": "tsc --noEmit && eslint \"**/*.{js,ts}\" --quiet --fix",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "axios": "^0.21.1",
     "commander": "^6.1.0",
     "cql-exec-fhir": "git+https://git@github.com/projecttacoma/cql-exec-fhir",
-    "cql-execution": "git+https://git@github.com/projecttacoma/cql-execution",
+    "cql-execution": "^3.0.0-beta.1",
     "handlebars": "^4.7.7",
     "lodash": "^4.17.21",
     "moment": "^2.29.4",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "atob": "^2.1.2",
     "axios": "^0.21.1",
     "commander": "^6.1.0",
-    "cql-exec-fhir": "git+https://git@github.com/projecttacoma/cql-exec-fhir",
+    "cql-exec-fhir": "^2.1.0",
     "cql-execution": "^3.0.0-beta.1",
     "handlebars": "^4.7.7",
     "lodash": "^4.17.21",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env ts-node --files
+#!/usr/bin/env node
 
 import { program } from 'commander';
 import fs from 'fs';

--- a/src/helpers/DebugHelpers.ts
+++ b/src/helpers/DebugHelpers.ts
@@ -4,7 +4,7 @@ import fs from 'fs';
 
 export function clearDebugFolder(): void {
   if (fs.existsSync('debug/')) {
-    fs.rmdirSync('debug/', { recursive: true });
+    fs.rmSync('debug/', { recursive: true });
   }
 }
 

--- a/src/types/CQLExecFHIR.d.ts
+++ b/src/types/CQLExecFHIR.d.ts
@@ -7,9 +7,6 @@ declare module 'cql-exec-fhir' {
     findRecords(profile: string): FHIRObject;
     findRecord(profile: string): FHIRObject;
   }
-  class AsyncPatient extends FHIRObject implements IPatient {
-    findRecords(profile: string): FHIRObject;
-  }
   export class PatientSource implements IPatientSource {
     constructor();
     loadBundles(bundles: fhir4.Bundle[]): void;
@@ -17,15 +14,6 @@ declare module 'cql-exec-fhir' {
     nextPatient(): Patient | undefined;
     reset(): void;
     static FHIRv401(shouldCheckProfile?: boolean): PatientSource;
-  }
-  export class AsyncPatientSource {
-    constructor(serverInfo: string);
-    loadPatientIds(ids: string[]): void;
-    async loadGroupId(id: string): void;
-    currentPatient(): AsyncPatient | undefined;
-    nextPatient(): AsyncPatient | undefined;
-    reset: void;
-    static FHIRv401(serverInfo: string, shouldCheckProfile?: boolean): AsyncPatientSource;
   }
   export class FHIRWrapper {
     constructor(filePathOrXML: string);


### PR DESCRIPTION
# Summary

Everything broke on npm 8 

## New behavior

No more async patient source, things work, no more removing build directory on npm run build (not really necessary).

`./src/cli.ts` will no longer work, use `npm run cli -- --flags` instead

## Code changes

* Use npm deps for exec and exec fhir
* Remove shx and usage in build
* Remove ts-node shebang in CLI (this required all users of the cli to have ts node installed globally
* Remove uses of async patient sources from CLI
* Change `fs.rmDir` to `fs.rm` to get rid of deprecation warning for newer node versions`

# Testing guidance

* Ensure you don't have fqm-execution installed globally: `npm uninstall -g fqm-execution`
* Run `npm pack` to package up this branch as a tarball
* Run `npm install -g ./fqm-execution-1.0.0-beta.6.tgz` to install the snapshot of this branch globally. It should work.
* Use `fqm-execution <command> <flags>` to test some common cases and make sure the output stuff still works
