### PR TITLE
Add populationId and criteriaReferenceId to all results when present

### DIFF
--- a/src/calculation/ClauseResultsBuilder.ts
+++ b/src/calculation/ClauseResultsBuilder.ts
@@ -606,8 +606,21 @@ export function buildPopulationRelevanceForAllEpisodes(
     masterRelevanceResults.forEach(masterPopResults => {
       // find relevance in episode and if true, make master relevance true, only if not already true
       if (masterPopResults.result === false) {
-        if (getResult(masterPopResults.populationType, episodeRelevance) === true) {
-          masterPopResults.result = true;
+        const matchingEpisodeResult = findResult(
+          masterPopResults.populationType,
+          episodeRelevance,
+          masterPopResults.criteriaExpression
+        );
+        if (matchingEpisodeResult) {
+          if (matchingEpisodeResult.populationId) {
+            masterPopResults.populationId = matchingEpisodeResult.populationId;
+          }
+          if (matchingEpisodeResult.criteriaReferenceId) {
+            masterPopResults.criteriaReferenceId = matchingEpisodeResult.criteriaReferenceId;
+          }
+          if (matchingEpisodeResult.result === true) {
+            masterPopResults.result = true;
+          }
         }
       }
     });
@@ -639,6 +652,8 @@ export function buildPopulationRelevanceMap(
   // Create initial results starting with all true to create the basis for relevance.
   const relevantResults: PopulationResult[] = results.map(result => {
     return {
+      ...(result.populationId ? { populationId: result.populationId } : {}),
+      ...(result.criteriaReferenceId ? { criteriaReferenceId: result.criteriaReferenceId } : {}),
       populationType: result.populationType,
       criteriaExpression: result.criteriaExpression,
       result: true
@@ -823,9 +838,11 @@ export function setResult(
 // create a result for the given population type and result or update the existing value to true if newResult is true
 export function createOrSetResult(
   populationType: PopulationType,
-  criteriaExpression: string | undefined,
   newResult: boolean,
-  results: PopulationResult[]
+  results: PopulationResult[],
+  criteriaExpression?: string,
+  populationId?: string,
+  criteriaReferenceId?: string
 ) {
   const popResult = findResult(populationType, results, criteriaExpression);
   if (popResult) {
@@ -836,7 +853,9 @@ export function createOrSetResult(
     results.push({
       populationType,
       criteriaExpression,
-      result: newResult
+      result: newResult,
+      ...(populationId ? { populationId } : {}),
+      ...(criteriaReferenceId ? { criteriaReferenceId } : {})
     });
   }
 }

--- a/src/helpers/DetailedResultsHelpers.ts
+++ b/src/helpers/DetailedResultsHelpers.ts
@@ -3,7 +3,8 @@ import {
   ExecutionResult,
   DetailedPopulationGroupResult,
   SimplePopulationGroupResult,
-  PopulationGroupResult
+  PopulationGroupResult,
+  PopulationResult
 } from '../types/Calculator';
 import { PopulationType } from '../types/Enums';
 import { getCriteriaReferenceIdFromPopulation } from './MeasureBundleHelpers';
@@ -85,4 +86,17 @@ export function findObsMsrPopl(
     }
   }
   return msrPop;
+}
+
+export function addIdsToPopulationResult(populationResult: PopulationResult, population: fhir4.MeasureGroupPopulation) {
+  if (population.id) {
+    populationResult.populationId = population.id;
+  }
+
+  if (population.extension) {
+    const criteriaRefId = MeasureBundleHelpers.getCriteriaReferenceIdFromPopulation(population);
+    if (criteriaRefId) {
+      populationResult.criteriaReferenceId = criteriaRefId;
+    }
+  }
 }

--- a/src/helpers/MeasureBundleHelpers.ts
+++ b/src/helpers/MeasureBundleHelpers.ts
@@ -6,6 +6,20 @@ import { getMissingDependentValuesets } from '../execution/ValueSetHelper';
 import { ValueSetResolver } from '../execution/ValueSetResolver';
 import { ExtractedLibrary } from '../types/CQLTypes';
 
+export function findPopulationInGroup(
+  group: fhir4.MeasureGroup,
+  populationType: PopulationType,
+  criteriaExpression?: string
+) {
+  return group.population?.find(p => {
+    if (codeableConceptToPopulationType(p.code) === populationType) {
+      return criteriaExpression ? p.criteria.expression === criteriaExpression : true;
+    }
+
+    return false;
+  });
+}
+
 /**
  * The extension that defines the population basis. This is used to determine if the measure is an episode of care or
  * patient based measure.

--- a/src/helpers/MeasureBundleHelpers.ts
+++ b/src/helpers/MeasureBundleHelpers.ts
@@ -6,20 +6,6 @@ import { getMissingDependentValuesets } from '../execution/ValueSetHelper';
 import { ValueSetResolver } from '../execution/ValueSetResolver';
 import { ExtractedLibrary } from '../types/CQLTypes';
 
-export function findPopulationInGroup(
-  group: fhir4.MeasureGroup,
-  populationType: PopulationType,
-  criteriaExpression?: string
-) {
-  return group.population?.find(p => {
-    if (codeableConceptToPopulationType(p.code) === populationType) {
-      return criteriaExpression ? p.criteria.expression === criteriaExpression : true;
-    }
-
-    return false;
-  });
-}
-
 /**
  * The extension that defines the population basis. This is used to determine if the measure is an episode of care or
  * patient based measure.

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -195,12 +195,17 @@ export interface StratifierResult {
    * True if patient or episode is in stratifier. False if not.
    */
   result: boolean;
+  strataId?: string;
 }
 
 /**
  * Result for a patient or episode for a population
  */
 export interface PopulationResult {
+  /* ID of the population, if defined in the Measure */
+  populationId?: string;
+  /* ID of the population referenced by the cqfm-criteriaReference extension in this population, if present */
+  criteriaReferenceId?: string;
   /** Type of population matching http://hl7.org/fhir/ValueSet/measure-population */
   populationType: PopulationType;
   /** The population criteria expression, which may be used to further identify the population (i.e. a cql identifier) */

--- a/test/ClauseResultsBuilder.test.ts
+++ b/test/ClauseResultsBuilder.test.ts
@@ -244,6 +244,34 @@ describe('ClauseResultsBuilder', () => {
         ])
       );
     });
+
+    test('should add populationId to relevance map when present on results', () => {
+      const results: PopulationResult[] = [
+        {
+          populationType: PopulationType.IPP,
+          populationId: 'example-pop-id',
+          result: true
+        }
+      ];
+
+      const relevantPops = ClauseResultsBuilder.buildPopulationRelevanceMap(results);
+
+      expect(relevantPops).toEqual(results);
+    });
+
+    test('should add criteriaReferenceId to relevance map when present on results', () => {
+      const results: PopulationResult[] = [
+        {
+          populationType: PopulationType.IPP,
+          criteriaReferenceId: 'example-pop-id',
+          result: true
+        }
+      ];
+
+      const relevantPops = ClauseResultsBuilder.buildPopulationRelevanceMap(results);
+
+      expect(relevantPops).toEqual(results);
+    });
   });
 
   describe('episodes', () => {


### PR DESCRIPTION
# Summary

Marking this as draft for now since it is branched off of #160. I made that the base branch so the code diff is clean to look at here

Fixes #146 

This PR adds more information to all population and stratifier results when defined on the Measure group

## New behavior

* If a population has an `id`, that `id` will be included on the root populationResults for that population, and on any populationResults for individual episodes in the episodeResults
* If a population references another using `cqfm-criteriaReference`, the `id` of that referenced population (aka the `valueString` of that extension) will be included on all relevant results similar to above
* If a strata in the Measure Group's stratifier has an `id`, that will show up as `strataId` on all stratifier results (including for individual episodes)

## Code changes

* New helper function for adding populationId and criteriaReferenceId to a given populationResult
* Anywhere a populationResult is created, add the relevant IDs using the above function
* Detect when a strata has an ID and ensure it is present on all created stratifier results

# Testing guidance

* Unit tests are the best bet for the stratifier stuff
* For everything else, test detailed results using the following cases (the test cases provided in #152 and #160 might be useful here)
  * Boolean measure with population IDs
  * Boolean measure with a measure observation (uses criteriaReference)
  * Episode measure with population IDs
  * Episode measure with a measure observation (uses criteriaReference)

For the above cases, you should see IDs and criteriaReferenceIds present on the results where appropriate
