### PR TITLE
Observations added to population results

### DIFF
--- a/src/calculation/ClauseResultsBuilder.ts
+++ b/src/calculation/ClauseResultsBuilder.ts
@@ -842,7 +842,8 @@ export function createOrSetResult(
   results: PopulationResult[],
   criteriaExpression?: string,
   populationId?: string,
-  criteriaReferenceId?: string
+  criteriaReferenceId?: string,
+  observations?: string[]
 ) {
   const popResult = findResult(populationType, results, criteriaExpression);
   if (popResult) {
@@ -855,7 +856,8 @@ export function createOrSetResult(
       criteriaExpression,
       result: newResult,
       ...(populationId ? { populationId } : {}),
-      ...(criteriaReferenceId ? { criteriaReferenceId } : {})
+      ...(criteriaReferenceId ? { criteriaReferenceId } : {}),
+      observations: observations
     });
   }
 }

--- a/src/calculation/ClauseResultsBuilder.ts
+++ b/src/calculation/ClauseResultsBuilder.ts
@@ -857,7 +857,7 @@ export function createOrSetResult(
       result: newResult,
       ...(populationId ? { populationId } : {}),
       ...(criteriaReferenceId ? { criteriaReferenceId } : {}),
-      observations: observations
+      ...(observations && { observations })
     });
   }
 }

--- a/src/calculation/DetailedResultsBuilder.ts
+++ b/src/calculation/DetailedResultsBuilder.ts
@@ -39,7 +39,7 @@ export function createPopulationValues(
 
     // if no episodes were found we need default populationResults/stratifierResults. just use the patient
     // level logic for this
-    if (episodeResults == undefined || episodeResults.length == 0) {
+    if (episodeResults === undefined || episodeResults.length === 0) {
       episodeResults = [];
       const popAndStratResults = createPatientPopulationValues(populationGroup, patientResults);
       populationResults = popAndStratResults.populationResults;
@@ -53,33 +53,22 @@ export function createPopulationValues(
       episodeResults.forEach(episodeResult => {
         episodeResult.populationResults.forEach(popResult => {
           const measureObsPops = populationResults.find(
-            pop => pop.populationType == PopulationType.OBSERV && popResult.criteriaExpression == pop.criteriaExpression
+            pop =>
+              pop.populationType === PopulationType.OBSERV && popResult.criteriaExpression === pop.criteriaExpression
           );
           if (!measureObsPops) {
-            // only add observations if it is not undefined
-            if (popResult.observations?.[0]) {
-              createOrSetResult(
-                popResult.populationType,
-                popResult.result,
-                populationResults,
-                popResult.criteriaExpression,
-                popResult.populationId,
-                popResult.criteriaReferenceId,
-                popResult.observations as string[]
-              );
-            } else {
-              createOrSetResult(
-                popResult.populationType,
-                popResult.result,
-                populationResults,
-                popResult.criteriaExpression,
-                popResult.populationId,
-                popResult.criteriaReferenceId
-              );
-            }
+            createOrSetResult(
+              popResult.populationType,
+              popResult.result,
+              populationResults,
+              popResult.criteriaExpression,
+              popResult.populationId,
+              popResult.criteriaReferenceId,
+              popResult.observations as string[]
+            );
           } else {
             if (measureObsPops.observations && popResult.observations) {
-              measureObsPops.observations = measureObsPops.observations.concat(popResult.observations);
+              measureObsPops.observations.push(...popResult.observations);
             }
           }
         });
@@ -372,14 +361,14 @@ export function createEpisodePopulationValues(
 
               // check if there is already an observation result with this cqlPopulation
               const observResult = episodeResult.populationResults.find(
-                result => result.populationType == populationType && result.criteriaExpression == cqlPopulation
+                result => result.populationType === populationType && result.criteriaExpression === cqlPopulation
               );
               if (observResult !== undefined) {
                 // push obs onto an existing populationResult
-                if (!observResult.observations && observation) {
-                  observResult.observations = [];
-                }
                 if (observation) {
+                  if (!observResult.observations) {
+                    observResult.observations = [];
+                  }
                   observResult.observations.push(observation);
                 }
                 observResult.result = true;
@@ -465,7 +454,7 @@ function createOrSetValueOfEpisodes(
       if (episodeResource.id.value != null) {
         // if an episode has already been created set the result for the population to true
         const episodeResults = episodeResultsSet.find(
-          episodeResults => episodeResults.episodeId == episodeResource.id.value
+          episodeResults => episodeResults.episodeId === episodeResource.id.value
         );
         if (episodeResults) {
           // set population value
@@ -476,7 +465,7 @@ function createOrSetValueOfEpisodes(
           } else if (strataCode) {
             if (episodeResults.stratifierResults) {
               const strataResult = episodeResults.stratifierResults.find(strataResult => {
-                return strataResult.strataCode == strataCode;
+                return strataResult.strataCode === strataCode;
               });
               if (strataResult) {
                 strataResult.result = true;
@@ -511,7 +500,7 @@ function createOrSetValueOfEpisodes(
               newEpisodeResults.stratifierResults?.push({
                 ...(strataId ? { strataId } : {}),
                 strataCode: newStrataCode,
-                result: newStrataCode == strataCode ? true : false
+                result: newStrataCode === strataCode ? true : false
               });
             });
           }

--- a/src/calculation/DetailedResultsBuilder.ts
+++ b/src/calculation/DetailedResultsBuilder.ts
@@ -68,11 +68,8 @@ export function createPopulationValues(
             );
           } else {
             if (popResult.observations) {
-              if (measureObsPop.observations == null) {
-                measureObsPop.observations = [...popResult.observations];
-              } else {
-                measureObsPop.observations.push(...popResult.observations);
-              }
+              // We are using .concat to avoid manipulating individual episode results as a side effect
+              measureObsPop.observations = (measureObsPop.observations ?? []).concat(popResult.observations);
             }
             setResult(
               measureObsPop.populationType,

--- a/src/calculation/DetailedResultsBuilder.ts
+++ b/src/calculation/DetailedResultsBuilder.ts
@@ -37,7 +37,7 @@ export function createPopulationValues(
     // collect results per episode
     episodeResults = createEpisodePopulationValues(populationGroup, patientResults);
 
-    // if no episodes were found we need default populationResults/stratifierResults. just use the patient
+    // if no episodes were found we need default populationResults/stratifierResults. Just use the patient
     // level logic for this
     if (episodeResults === undefined || episodeResults.length === 0) {
       episodeResults = [];

--- a/src/calculation/DetailedResultsBuilder.ts
+++ b/src/calculation/DetailedResultsBuilder.ts
@@ -45,8 +45,6 @@ export function createPopulationValues(
       populationResults = popAndStratResults.populationResults;
       stratifierResults = popAndStratResults.stratifierResults;
     } else {
-      // TODO: in the case of episode aggregation, we should consider collating the observation results at the root populationResults
-      // list as well
       populationResults = [];
       stratifierResults = [];
       // create patient level population and stratifier results based on episodes
@@ -306,8 +304,6 @@ export function createPatientPopulationValues(
       }
     });
   }
-
-  //TODO: Support patient level observations.
 
   return {
     populationResults,

--- a/src/calculation/DetailedResultsBuilder.ts
+++ b/src/calculation/DetailedResultsBuilder.ts
@@ -52,11 +52,11 @@ export function createPopulationValues(
       // create patient level population and stratifier results based on episodes
       episodeResults.forEach(episodeResult => {
         episodeResult.populationResults.forEach(popResult => {
-          const measureObsPops = populationResults.find(
+          const measureObsPop = populationResults.find(
             pop =>
               pop.populationType === PopulationType.OBSERV && popResult.criteriaExpression === pop.criteriaExpression
           );
-          if (!measureObsPops) {
+          if (!measureObsPop) {
             createOrSetResult(
               popResult.populationType,
               popResult.result,
@@ -64,12 +64,22 @@ export function createPopulationValues(
               popResult.criteriaExpression,
               popResult.populationId,
               popResult.criteriaReferenceId,
-              popResult.observations as string[]
+              popResult.observations
             );
           } else {
-            if (measureObsPops.observations && popResult.observations) {
-              measureObsPops.observations.push(...popResult.observations);
+            if (popResult.observations) {
+              if (measureObsPop.observations == null) {
+                measureObsPop.observations = [...popResult.observations];
+              } else {
+                measureObsPop.observations.push(...popResult.observations);
+              }
             }
+            setResult(
+              measureObsPop.populationType,
+              popResult.result,
+              populationResults,
+              measureObsPop.criteriaExpression
+            );
           }
         });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -131,7 +131,7 @@ async function populatePatientBundles() {
   if (!['dataRequirements', 'queryInfo', 'valueSets'].includes(program.outputType)) {
     // Since patient bundles are no longer a mandatory CLI option, we should check if we were given any before
     if (!program.patientBundles) {
-      console.error(`Must patient bundles when output type is "${program.outputType}"`);
+      console.error(`Must specify patient bundles when output type is "${program.outputType}"`);
       program.help();
     }
 

--- a/src/helpers/DetailedResultsHelpers.ts
+++ b/src/helpers/DetailedResultsHelpers.ts
@@ -116,21 +116,14 @@ export function nullCriteriaRefMeasureObs(
 ) {
   const measureObservationResults = populationResults.filter(result => result.populationType === PopulationType.OBSERV);
 
-  // If only 1 measure observation in the results, it does not matter what population it draws from
-  // and it can safely be nulled out
-  if (measureObservationResults.length === 1) {
-    measureObservationResults[0].result = false;
-    measureObservationResults[0].observations = null;
-  } else {
-    // Otherwise, we need to do a lookup based on the criteriaReference extension, and only null out that relevant observation
-    const relevantObservationResult = getObservationResultForPopulation(
-      group,
-      measureObservationResults,
-      desiredPopulationType
-    );
-    if (relevantObservationResult) {
-      relevantObservationResult.result = false;
-      relevantObservationResult.observations = null;
-    }
+  // We need to do a lookup based on the criteriaReference extension, and only null out that relevant observation
+  const relevantObservationResult = getObservationResultForPopulation(
+    group,
+    measureObservationResults,
+    desiredPopulationType
+  );
+  if (relevantObservationResult) {
+    relevantObservationResult.result = false;
+    relevantObservationResult.observations = null;
   }
 }

--- a/test/DetailedResultsBuilder.test.ts
+++ b/test/DetailedResultsBuilder.test.ts
@@ -784,13 +784,15 @@ describe('DetailedResultsBuilder', () => {
           { populationType: PopulationType.IPP, criteriaExpression: 'ipp', result: false },
           { populationType: PopulationType.DENOM, criteriaExpression: 'denom', result: false },
           { populationType: PopulationType.NUMER, criteriaExpression: 'numer', result: false },
-          { populationType: PopulationType.OBSERV, criteriaExpression: 'fun', result: true }
+          { populationType: PopulationType.OBSERV, criteriaExpression: 'numerFunc', result: true },
+          { populationType: PopulationType.OBSERV, criteriaExpression: 'denomFunc', result: true }
         ];
         const expectedHandledResults: PopulationResult[] = [
           { populationType: PopulationType.IPP, criteriaExpression: 'ipp', result: false },
           { populationType: PopulationType.DENOM, criteriaExpression: 'denom', result: false },
           { populationType: PopulationType.NUMER, criteriaExpression: 'numer', result: false },
-          { populationType: PopulationType.OBSERV, criteriaExpression: 'fun', result: false, observations: null }
+          { populationType: PopulationType.OBSERV, criteriaExpression: 'numerFunc', result: false, observations: null },
+          { populationType: PopulationType.OBSERV, criteriaExpression: 'denomFunc', result: false, observations: null }
         ];
 
         expect(DetailedResultsBuilder.handlePopulationValues(populationResults, groupWithObs)).toEqual(
@@ -803,13 +805,13 @@ describe('DetailedResultsBuilder', () => {
           { populationType: PopulationType.IPP, criteriaExpression: 'ipp', result: true },
           { populationType: PopulationType.DENOM, criteriaExpression: 'denom', result: false },
           { populationType: PopulationType.NUMER, criteriaExpression: 'numer', result: true },
-          { populationType: PopulationType.OBSERV, criteriaExpression: 'fun', result: true }
+          { populationType: PopulationType.OBSERV, criteriaExpression: 'numerFunc', result: true }
         ];
         const expectedHandledResults: PopulationResult[] = [
           { populationType: PopulationType.IPP, criteriaExpression: 'ipp', result: true },
           { populationType: PopulationType.DENOM, criteriaExpression: 'denom', result: false },
           { populationType: PopulationType.NUMER, criteriaExpression: 'numer', result: false },
-          { populationType: PopulationType.OBSERV, criteriaExpression: 'fun', result: false, observations: null }
+          { populationType: PopulationType.OBSERV, criteriaExpression: 'numerFunc', result: false, observations: null }
         ];
 
         expect(DetailedResultsBuilder.handlePopulationValues(populationResults, groupWithObs)).toEqual(

--- a/test/DetailedResultsBuilder.test.ts
+++ b/test/DetailedResultsBuilder.test.ts
@@ -543,7 +543,7 @@ describe('DetailedResultsBuilder', () => {
       );
 
       populationResults?.forEach(pr => {
-        expect(pr.observations).toBeUndefined;
+        expect(pr.observations).toBeUndefined();
       });
     });
 

--- a/test/DetailedResultsBuilder.test.ts
+++ b/test/DetailedResultsBuilder.test.ts
@@ -15,9 +15,8 @@ const cvMeasure = getJSONFixture('measure/cv-measure.json') as MeasureWithGroup;
 const simpleMeasureGroup = simpleMeasure.group[0];
 const cvMeasureGroup = cvMeasure.group[0];
 const groupWithObs = getJSONFixture('measure/groups/groupNumerAndDenomCriteria.json');
-
-const measure = getJSONFixture('measure/measure-measure-obs.json') as MeasureWithGroup;
-const group = (measure.group as [fhir4.MeasureGroup])[0];
+const measureWithMeasureObs = getJSONFixture('measure/measure-measure-obs.json') as MeasureWithGroup;
+const groupWithMeasureObs = (measureWithMeasureObs.group as [fhir4.MeasureGroup])[0];
 
 describe('DetailedResultsBuilder', () => {
   describe('Population Values', () => {
@@ -479,7 +478,11 @@ describe('DetailedResultsBuilder', () => {
         ]
       };
 
-      const { populationResults } = DetailedResultsBuilder.createPopulationValues(measure, group, statementResults);
+      const { populationResults } = DetailedResultsBuilder.createPopulationValues(
+        measureWithMeasureObs,
+        groupWithMeasureObs,
+        statementResults
+      );
 
       expect(populationResults).toEqual(
         expect.arrayContaining([
@@ -514,7 +517,11 @@ describe('DetailedResultsBuilder', () => {
         ]
       };
 
-      const { populationResults } = DetailedResultsBuilder.createPopulationValues(measure, group, statementResults);
+      const { populationResults } = DetailedResultsBuilder.createPopulationValues(
+        measureWithMeasureObs,
+        groupWithMeasureObs,
+        statementResults
+      );
 
       expect(populationResults).toEqual(
         expect.arrayContaining([
@@ -546,7 +553,11 @@ describe('DetailedResultsBuilder', () => {
         ]
       };
 
-      const { episodeResults } = DetailedResultsBuilder.createPopulationValues(measure, group, statementResults);
+      const { episodeResults } = DetailedResultsBuilder.createPopulationValues(
+        measureWithMeasureObs,
+        groupWithMeasureObs,
+        statementResults
+      );
 
       expect(episodeResults).toEqual(
         expect.arrayContaining([

--- a/test/DetailedResultsBuilder.test.ts
+++ b/test/DetailedResultsBuilder.test.ts
@@ -526,6 +526,52 @@ describe('DetailedResultsBuilder', () => {
       );
     });
 
+    test('Episode results should have observation array of one value', () => {
+      const statementResults: StatementResults = {
+        ipp: [
+          {
+            id: {
+              value: 'Encounter2'
+            }
+          },
+          {
+            id: {
+              value: 'Encounter3'
+            }
+          }
+        ],
+        obs_func_observe_ipp: [
+          { episode: { id: { value: 'Encounter2' } }, observation: 2 },
+          { episode: { id: { value: 'Encounter3' } }, observation: 3 }
+        ]
+      };
+
+      const { episodeResults } = DetailedResultsBuilder.createPopulationValues(measure, group, statementResults);
+
+      expect(episodeResults).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining<EpisodeResults>({
+            episodeId: 'Encounter2',
+            populationResults: expect.arrayContaining([
+              expect.objectContaining({
+                populationType: PopulationType.OBSERV,
+                observations: [2]
+              })
+            ])
+          }),
+          expect.objectContaining<EpisodeResults>({
+            episodeId: 'Encounter3',
+            populationResults: expect.arrayContaining([
+              expect.objectContaining({
+                populationType: PopulationType.OBSERV,
+                observations: [3]
+              })
+            ])
+          })
+        ])
+      );
+    });
+
     describe('multiple IPPs', () => {
       const group: fhir4.MeasureGroup = {
         population: [

--- a/test/DetailedResultsBuilder.test.ts
+++ b/test/DetailedResultsBuilder.test.ts
@@ -16,59 +16,7 @@ const simpleMeasureGroup = simpleMeasure.group[0];
 const cvMeasureGroup = cvMeasure.group[0];
 const groupWithObs = getJSONFixture('measure/groups/groupNumerAndDenomCriteria.json');
 
-const measure: fhir4.Measure = {
-  resourceType: 'Measure',
-  status: 'unknown',
-  extension: [
-    {
-      url: 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis',
-      valueCode: 'Encounter'
-    }
-  ],
-  group: [
-    {
-      population: [
-        {
-          id: 'initial-population-id',
-          code: {
-            coding: [
-              {
-                system: 'http://terminology.hl7.org/CodeSystem/measure-population',
-                code: 'initial-population'
-              }
-            ]
-          },
-          criteria: {
-            expression: 'ipp',
-            language: 'text/cql'
-          }
-        },
-        {
-          extension: [
-            {
-              url: 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-criteriaReference',
-              valueString: 'initial-population-id'
-            }
-          ],
-          code: {
-            coding: [
-              {
-                system: 'http://terminology.hl7.org/CodeSystem/measure-population',
-                code: 'measure-observation',
-                display: 'Measure Observation'
-              }
-            ]
-          },
-          criteria: {
-            language: 'text/cql.identifier',
-            expression: 'observe'
-          }
-        }
-      ]
-    }
-  ]
-};
-
+const measure = getJSONFixture('measure/measure-measure-obs.json') as MeasureWithGroup;
 const group = (measure.group as [fhir4.MeasureGroup])[0];
 
 describe('DetailedResultsBuilder', () => {
@@ -511,7 +459,6 @@ describe('DetailedResultsBuilder', () => {
       );
     });
 
-    // one test to make sure that
     test('Root population results should not contain arrays of observations', () => {
       const statementResults: StatementResults = {
         ipp: [

--- a/test/DetailedResultsBuilder.test.ts
+++ b/test/DetailedResultsBuilder.test.ts
@@ -69,6 +69,8 @@ const measure: fhir4.Measure = {
   ]
 };
 
+const group = (measure.group as [fhir4.MeasureGroup])[0];
+
 describe('DetailedResultsBuilder', () => {
   describe('Population Values', () => {
     test('NUMER population not modified by inclusion in NUMEX', () => {
@@ -510,9 +512,7 @@ describe('DetailedResultsBuilder', () => {
     });
 
     // one test to make sure that
-    test('Root population results should not contain an array of observations', () => {
-      const group = (measure.group as [fhir4.MeasureGroup])[0];
-
+    test('Root population results should not contain arrays of observations', () => {
       const statementResults: StatementResults = {
         ipp: [
           {
@@ -542,12 +542,12 @@ describe('DetailedResultsBuilder', () => {
         ])
       );
 
-      expect(JSON.stringify(populationResults)).not.toContain('observation:');
+      populationResults?.forEach(pr => {
+        expect(pr.observations).toBeUndefined;
+      });
     });
 
-    test('Root population results should contain an array of observations for corresponding population', () => {
-      const group = (measure.group as [fhir4.MeasureGroup])[0];
-
+    test('Root population results should contain an array of observations for corresponding episode', () => {
       const statementResults: StatementResults = {
         ipp: [
           {

--- a/test/fixtures/measure/measure-measure-obs.json
+++ b/test/fixtures/measure/measure-measure-obs.json
@@ -1,0 +1,52 @@
+{
+  "resourceType": "Measure",
+  "status": "unknown",
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis",
+      "valueCode": "Encounter"
+    }
+  ],
+  "group": [
+    {
+      "population": [
+        {
+          "id": "initial-population-id",
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "initial-population"
+              }
+            ]
+          },
+          "criteria": {
+            "expression": "ipp",
+            "language": "text/cql"
+          }
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-criteriaReference",
+              "valueString": "initial-population-id"
+            }
+          ],
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "measure-observation",
+                "display": "Measure Observation"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql.identifier",
+            "expression": "observe"
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
# Summary
Gathers all observation results as an array on the population results.

## New behavior
- Goes through the episodeResults to get observations on measurePopulation populationResults if they exist and adds them to an observations array on the corresponding root populationResult for that measureObservation.

## Code changes
- `src/calculation/ClauseResultsBuilder.ts` - Adds an optional observations parameter to the `createOrSetResult` function.
- `src/calculation/DetailedResultsBuilder.ts` - Adds observations that are on episodeResults measure observation populations to the overall population results for the corresponding measure observation. 
- `test/DetailedResultsBuilder.test.ts` - Tests the added functionality in `DetailedResultsBuilder.ts`.

# Testing guidance
- `npm run check` to ensure that there are no errors and that all tests pass.
- Run the cli with the files attached through the following command: `npm run cli -- detailed -m <ratio-encounter-mb.json> -p <patient-bundle.json> --debug -o`
- Look at the `output.json` file. The populationResults entry for the measure-observation should include an observations array of [2,2]. There should be no other observations arrays in the other populationResults entries. 
- Let me know if you have any questions!

[Test Files.zip](https://github.com/projecttacoma/fqm-execution/files/9940626/Test.Files.zip)
