### PR TITLE
Update coding system and reasonDetail extension URLs

### DIFF
--- a/src/gaps/GapsReportBuilder.ts
+++ b/src/gaps/GapsReportBuilder.ts
@@ -217,7 +217,6 @@ export function generateGuidanceResponses(
 
     let gapCoding: fhir4.Coding[];
 
-    // TODO: update system to be full URL once defined
     if (q.reasonDetail?.hasReasonDetail && q.reasonDetail.reasons.length > 0) {
       gapCoding = q.reasonDetail.reasons.map(generateReasonCoding);
     } else {
@@ -225,14 +224,14 @@ export function generateGuidanceResponses(
         improvementNotation === ImprovementNotation.POSITIVE
           ? [
               {
-                system: 'CareGapReasonCodeSystem',
+                system: 'http://hl7.org/fhir/us/davinci-deqm/CodeSystem/care-gap-reason',
                 code: CareGapReasonCode.NOTFOUND,
                 display: CareGapReasonCodeDisplay[CareGapReasonCode.NOTFOUND]
               }
             ]
           : [
               {
-                system: 'CareGapReasonCodeSystem',
+                system: 'http://hl7.org/fhir/us/davinci-deqm/CodeSystem/care-gap-reason',
                 code: CareGapReasonCode.PRESENT,
                 display: CareGapReasonCodeDisplay[CareGapReasonCode.PRESENT]
               }
@@ -282,7 +281,7 @@ export function generateGuidanceResponses(
  */
 export function generateReasonCoding(reason: ReasonDetailData): fhir4.Coding {
   const reasonCoding: fhir4.Coding = {
-    system: 'CareGapReasonCodeSystem',
+    system: 'http://hl7.org/fhir/us/davinci-deqm/CodeSystem/care-gap-reason',
     code: reason.code,
     display: CareGapReasonCodeDisplay[reason.code]
   };
@@ -290,7 +289,7 @@ export function generateReasonCoding(reason: ReasonDetailData): fhir4.Coding {
   // If there is a referenced resource create and add the extension
   if (reason.reference) {
     const detailExt: fhir4.Extension = {
-      url: 'ReasonDetail',
+      url: 'http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/reasonDetail',
       extension: [
         {
           url: 'reference',

--- a/src/types/Enums.ts
+++ b/src/types/Enums.ts
@@ -106,7 +106,7 @@ export enum CareGapReasonCode {
   VALUEINRANGE = 'ValueInRange',
   VALUEOUTOFRANGE = 'ValueOutOfRange',
   COUNTINRANGE = 'CountInRange',
-  COUNTOUTOFRANGE = 'CountOutOfRange',
+  COUNTOUTOFRANGE = 'CountOutOfRange'
 }
 
 /**
@@ -122,5 +122,5 @@ export const CareGapReasonCodeDisplay = {
   [CareGapReasonCode.VALUEINRANGE]: 'Value is within specified range',
   [CareGapReasonCode.VALUEOUTOFRANGE]: 'Value is out of specified range',
   [CareGapReasonCode.COUNTINRANGE]: 'Count is within specified range',
-  [CareGapReasonCode.COUNTOUTOFRANGE]: 'Count is out of specified range',
+  [CareGapReasonCode.COUNTOUTOFRANGE]: 'Count is out of specified range'
 };

--- a/src/types/Enums.ts
+++ b/src/types/Enums.ts
@@ -95,7 +95,6 @@ export enum ImprovementNotation {
  * 'VALUEOUTOFRANGE': Gap is due to a value being out of range
  * 'COUNTINRANGE': Gap is due to count of data elements being within a range
  * 'COUNTOUTOFRANGE': Gap is due to a count of resources being out of range
- * 'NOTALLOWED': Data Element was not used in care gap calculation due to an external requirement
  */
 export enum CareGapReasonCode {
   NOTFOUND = 'NotFound',
@@ -108,7 +107,6 @@ export enum CareGapReasonCode {
   VALUEOUTOFRANGE = 'ValueOutOfRange',
   COUNTINRANGE = 'CountInRange',
   COUNTOUTOFRANGE = 'CountOutOfRange',
-  NOTALLOWED = 'NotAllowed'
 }
 
 /**
@@ -125,5 +123,4 @@ export const CareGapReasonCodeDisplay = {
   [CareGapReasonCode.VALUEOUTOFRANGE]: 'Value is out of specified range',
   [CareGapReasonCode.COUNTINRANGE]: 'Count is within specified range',
   [CareGapReasonCode.COUNTOUTOFRANGE]: 'Count is out of specified range',
-  [CareGapReasonCode.NOTALLOWED]: 'Data Element was not used in care gap calculation due to an external requirement'
 };

--- a/test/GapsInCareHelpers.test.ts
+++ b/test/GapsInCareHelpers.test.ts
@@ -1525,12 +1525,12 @@ describe('Guidance Response', () => {
       {
         coding: [
           {
-            system: 'CareGapReasonCodeSystem',
+            system: 'http://hl7.org/fhir/us/davinci-deqm/CodeSystem/care-gap-reason',
             code: 'DateOutOfRange',
             display: 'Date is out of specified range',
             extension: [
               {
-                url: 'ReasonDetail',
+                url: 'http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/reasonDetail',
                 extension: [
                   {
                     url: 'reference',
@@ -1568,7 +1568,7 @@ describe('Guidance Response ReasonCode Coding', () => {
       code: CareGapReasonCode.MISSING
     };
     const expectedCoding: fhir4.Coding = {
-      system: 'CareGapReasonCodeSystem',
+      system: 'http://hl7.org/fhir/us/davinci-deqm/CodeSystem/care-gap-reason',
       code: 'Missing',
       display: 'Missing Data Element'
     };
@@ -1581,12 +1581,12 @@ describe('Guidance Response ReasonCode Coding', () => {
       reference: 'Procedure/denom-EXM130-2'
     };
     const expectedCoding: fhir4.Coding = {
-      system: 'CareGapReasonCodeSystem',
+      system: 'http://hl7.org/fhir/us/davinci-deqm/CodeSystem/care-gap-reason',
       code: 'Present',
       display: 'Data Element is Present',
       extension: [
         {
-          url: 'ReasonDetail',
+          url: 'http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/reasonDetail',
           extension: [
             {
               url: 'reference',
@@ -1608,12 +1608,12 @@ describe('Guidance Response ReasonCode Coding', () => {
       path: 'performed.end'
     };
     const expectedCoding: fhir4.Coding = {
-      system: 'CareGapReasonCodeSystem',
+      system: 'http://hl7.org/fhir/us/davinci-deqm/CodeSystem/care-gap-reason',
       code: 'DateOutOfRange',
       display: 'Date is out of specified range',
       extension: [
         {
-          url: 'ReasonDetail',
+          url: 'http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/reasonDetail',
           extension: [
             {
               url: 'reference',
@@ -1660,7 +1660,7 @@ describe('Guidance Response ReasonCode Coding', () => {
           {
             coding: [
               {
-                system: 'CareGapReasonCodeSystem',
+                system: 'http://hl7.org/fhir/us/davinci-deqm/CodeSystem/care-gap-reason',
                 code: CareGapReasonCode.VALUEOUTOFRANGE
               }
             ]
@@ -1679,7 +1679,7 @@ describe('Guidance Response ReasonCode Coding', () => {
           {
             coding: [
               {
-                system: 'CareGapReasonCodeSystem',
+                system: 'http://hl7.org/fhir/us/davinci-deqm/CodeSystem/care-gap-reason',
                 code: CareGapReasonCode.NOTFOUND
               }
             ]
@@ -1698,7 +1698,7 @@ describe('Guidance Response ReasonCode Coding', () => {
           {
             coding: [
               {
-                system: 'CareGapReasonCodeSystem',
+                system: 'http://hl7.org/fhir/us/davinci-deqm/CodeSystem/care-gap-reason',
                 code: CareGapReasonCode.PRESENT
               }
             ]
@@ -1717,7 +1717,7 @@ describe('Guidance Response ReasonCode Coding', () => {
           {
             coding: [
               {
-                system: 'CareGapReasonCodeSystem',
+                system: 'http://hl7.org/fhir/us/davinci-deqm/CodeSystem/care-gap-reason',
                 code: CareGapReasonCode.VALUEOUTOFRANGE
               }
             ]
@@ -1725,7 +1725,7 @@ describe('Guidance Response ReasonCode Coding', () => {
           {
             coding: [
               {
-                system: 'CareGapReasonCodeSystem',
+                system: 'http://hl7.org/fhir/us/davinci-deqm/CodeSystem/care-gap-reason',
                 code: CareGapReasonCode.PRESENT
               }
             ]

--- a/test/fixtures/gaps/example-detected-issue.json
+++ b/test/fixtures/gaps/example-detected-issue.json
@@ -30,7 +30,7 @@
               {
                 "code": "NotFound",
                 "display": "Data Element Not Found",
-                "system": "CareGapReasonCodeSystem"
+                "system": "http://hl7.org/fhir/us/davinci-deqm/CodeSystem/care-gap-reason"
               }
             ]
           }
@@ -83,7 +83,7 @@
               {
                 "code": "NotFound",
                 "display": "Data Element Not Found",
-                "system": "CareGapReasonCodeSystem"
+                "system": "http://hl7.org/fhir/us/davinci-deqm/CodeSystem/care-gap-reason"
               }
             ]
           }
@@ -141,7 +141,7 @@
               {
                 "code": "NotFound",
                 "display": "Data Element Not Found",
-                "system": "CareGapReasonCodeSystem"
+                "system": "http://hl7.org/fhir/us/davinci-deqm/CodeSystem/care-gap-reason"
               }
             ]
           }
@@ -194,7 +194,7 @@
               {
                 "code": "NotFound",
                 "display": "Data Element Not Found",
-                "system": "CareGapReasonCodeSystem"
+                "system": "http://hl7.org/fhir/us/davinci-deqm/CodeSystem/care-gap-reason"
               }
             ]
           }

--- a/test/fixtures/gaps/guidanceResponse/guidance-combination.json
+++ b/test/fixtures/gaps/guidanceResponse/guidance-combination.json
@@ -34,12 +34,12 @@
     {
       "coding": [
         {
-          "system": "CareGapReasonCodeSystem",
+          "system": "http://hl7.org/fhir/us/davinci-deqm/CodeSystem/care-gap-reason",
           "code": "DateOutOfRange",
           "display": "Data element was found, date was out of range"
         },
         {
-          "system": "CareGapReasonCodeSystem",
+          "system": "http://hl7.org/fhir/us/davinci-deqm/CodeSystem/care-gap-reason",
           "code": "IncorectAttribute",
           "display": "Data element had an incorrect attribute value"
         }

--- a/test/fixtures/gaps/guidanceResponse/guidance-date-out-of-range.json
+++ b/test/fixtures/gaps/guidanceResponse/guidance-date-out-of-range.json
@@ -25,7 +25,7 @@
     {
       "coding": [
         {
-          "system": "CareGapReasonCodeSystem",
+          "system": "http://hl7.org/fhir/us/davinci-deqm/CodeSystem/care-gap-reason",
           "code": "DateOutOfRange",
           "display": "Date of required data was out of range"
         }

--- a/test/fixtures/gaps/guidanceResponse/guidance-incorrect-attribute.json
+++ b/test/fixtures/gaps/guidanceResponse/guidance-incorrect-attribute.json
@@ -23,7 +23,7 @@
     {
       "coding": [
         {
-          "system": "CareGapReasonCodeSystem",
+          "system": "http://hl7.org/fhir/us/davinci-deqm/CodeSystem/care-gap-reason",
           "code": "IncorectAttribute",
           "display": "Data element had an incorrect attribute value"
         }

--- a/test/fixtures/gaps/guidanceResponse/guidance-invalid-duration.json
+++ b/test/fixtures/gaps/guidanceResponse/guidance-invalid-duration.json
@@ -26,7 +26,7 @@
     {
       "coding": [
         {
-          "system": "CareGapReasonCodeSystem",
+          "system": "http://hl7.org/fhir/us/davinci-deqm/CodeSystem/care-gap-reason",
           "code": "InvalidDuration",
           "display": "Data element was found, but duration was invalid"
         }

--- a/test/fixtures/gaps/guidanceResponse/guidance-missing-retrieve.json
+++ b/test/fixtures/gaps/guidanceResponse/guidance-missing-retrieve.json
@@ -16,7 +16,7 @@
     {
       "coding": [
         {
-          "system": "CareGapReasonCodeSystem",
+          "system": "http://hl7.org/fhir/us/davinci-deqm/CodeSystem/care-gap-reason",
           "code": "Missing",
           "display": "No Data Element found from Value Set"
         }

--- a/test/fixtures/gaps/guidanceResponse/guidance-missing-value-extension.json
+++ b/test/fixtures/gaps/guidanceResponse/guidance-missing-value-extension.json
@@ -36,7 +36,7 @@
     {
       "coding": [
         {
-          "system": "CareGapReasonCodeSystem",
+          "system": "http://hl7.org/fhir/us/davinci-deqm/CodeSystem/care-gap-reason",
           "code": "MissingValue",
           "display": "Data element was found, but value was missing"
         }

--- a/test/fixtures/gaps/guidanceResponse/guidance-missing-value-reference.json
+++ b/test/fixtures/gaps/guidanceResponse/guidance-missing-value-reference.json
@@ -25,7 +25,7 @@
     "code": {
       "coding": [
         {
-          "system": "CareGapReasonCodeSystem",
+          "system": "http://hl7.org/fhir/us/davinci-deqm/CodeSystem/care-gap-reason",
           "code": "MissingValue",
           "display": "Data element was found, but value was missing"
         }

--- a/test/fixtures/gaps/guidanceResponse/guidance-value-out-of-range-extension.json
+++ b/test/fixtures/gaps/guidanceResponse/guidance-value-out-of-range-extension.json
@@ -36,7 +36,7 @@
     {
       "coding": [
         {
-          "system": "CareGapReasonCodeSystem",
+          "system": "http://hl7.org/fhir/us/davinci-deqm/CodeSystem/care-gap-reason",
           "code": "ValueOutOfRange",
           "display": "Value is out of specified range"
         }

--- a/test/fixtures/gaps/guidanceResponse/guidance-value-out-of-range-reference.json
+++ b/test/fixtures/gaps/guidanceResponse/guidance-value-out-of-range-reference.json
@@ -25,7 +25,7 @@
     "code": {
       "coding": [
         {
-          "system": "CareGapReasonCodeSystem",
+          "system": "http://hl7.org/fhir/us/davinci-deqm/CodeSystem/care-gap-reason",
           "code": "ValueOutOfRange",
           "display": "Value is out of specified range"
         }


### PR DESCRIPTION
# Summary
Updates instances of hard-coded coding system/reasonDetail extension URLs with the correct URLs from the FHIR January ballot.

## New behavior
Behavior should remain unchanged. For reference on these changes, see the following links with the correct URLS:
- https://build.fhir.org/ig/HL7/davinci-deqm/branches/2023-Jan-Ballot/CodeSystem-care-gap-reason.html
- https://build.fhir.org/ig/HL7/davinci-deqm/branches/2023-Jan-Ballot/StructureDefinition-reasonDetail.html

## Code changes

- All instances of 'CareGapReasonCodeSystem' were changed to 'http://hl7.org/fhir/us/davinci-deqm/CodeSystem/care-gap-reason'.
- All instances of 'ReasonDetail' were changed to 'http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/reasonDetail'.
- Removed all instances of 'NOTALLOWED' reason code since it no longer appears in the spec.

# Testing guidance

- Run unit tests
- Check that all instances of 'CareGapReasonCodeSystem'/'ReasonDetail' have been changed to the correct URL (this can be done via searching in vscode)
