### PR TITLE
README Updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ debug/
 test/fixtures/elm/queries/output/*
 test/fixtures/elm/queries/.start-translator
 connectathon/
+ecqm-content-r4-2021/
 fhir-patient-generator/
 coverage
 cache

--- a/README.md
+++ b/README.md
@@ -19,11 +19,13 @@ Library for executing FHIR-based Electronic Clinical Quality Measures (eCQMs) wr
   - [Testing](#testing)
   - [Checks](#checks)
 
+- [Contributions](#contributions)
+
 - [License](#license)
 
 ## Installation
 
-`fqm-execution` can be installed into your project with npm:
+`fqm-execution` can be installed into your project with [npm](https://www.npmjs.com/package/fqm-execution):
 
 ```bash
 npm install --save fqm-execution
@@ -40,33 +42,96 @@ npm install -g fqm-execution
 ### Module
 
 #### ES6
-
+Import the necessary modules:
 ```JavaScript
 import { Calculator, MeasureBundleHelpers } from 'fqm-execution';
+```
 
-const rawResults = await Calculator.calculateRaw(measureBundle, patientBundles, options, valueSetCache); // Get raw results from CQL engine for each patient
-const detailedResults = await Calculator.calculate(measureBundle, patientBundles, options, valueSetCache); // Get detailed population results for each patient
-const measureReports = await Calculator.calculateMeasureReports(measureBundle, patientBundles, options, valueSetCache); // Get individual FHIR MeasureReports for each patient
-const measureReports = await Calculator.calculateMeasureReports(measureBundle, [], options, valueSetCache); // Get individual FHIR MeasureReports for each patient given a custom patientSource in the options object
-const gapsInCare = await Calculator.calculateGapsInCare(measureBundle, patientBundles, options, valueSetCache); // Get gaps in care for each patient, if present
-const dataRequirements = await Calculator.calculateDataRequirements(measureBundle); // Get data requirements for a given measure (in a bundle)
-const queryInfo = await Calculator.calculateQueryInfo(measureBundle); // Get detailed query info for all statements in a measure
-const valueSets = await MeasureBundleHelpers.addValueSetsToMeasureBundle(measureBundle, options); // Add missing ValueSet resources to a measure bundle
+```JavaScript
+// Get raw results from CQL engine for each patient
+const rawResults = await Calculator.calculateRaw(measureBundle, patientBundles, options, valueSetCache);
+```
+
+```JavaScript
+// Get detailed population results for each patient
+const detailedResults = await Calculator.calculate(measureBundle, patientBundles, options, valueSetCache);
+```
+
+```JavaScript
+// Get individual FHIR MeasureReports for each patient
+const measureReports = await Calculator.calculateMeasureReports(measureBundle, patientBundles, options, valueSetCache);
+```
+
+```JavaScript
+// Get individual FHIR MeasureReports for each patient given a custom patientSource in the options object
+const measureReports = await Calculator.calculateMeasureReports(measureBundle, [], options, valueSetCache);
+```
+
+```JavaScript
+// Get gaps in care for each patient, if present
+const gapsInCare = await Calculator.calculateGapsInCare(measureBundle, patientBundles, options, valueSetCache);
+```
+
+```JavaScript
+// Get data requirements for a given measure (in a bundle)
+const dataRequirements = await Calculator.calculateDataRequirements(measureBundle);
+```
+
+```JavaScript
+// Get detailed query info for all statements in a measure
+const queryInfo = await Calculator.calculateQueryInfo(measureBundle);
+```
+
+```JavaScript
+// Add missing ValueSet resources to a measure bundle
+const valueSets = await MeasureBundleHelpers.addValueSetsToMeasureBundle(measureBundle, options);
 ```
 
 #### Require
 
+Import the necessary modules:
 ```JavaScript
 const { Calculator, MeasureBundleHelpers } = require('fqm-execution');
+```
 
-const rawResults = await Calculator.calculateRaw(measureBundle, patientBundles, options, valueSetCache); // Get raw results from CQL engine for each patient
-const detailedResults = await Calculator.calculate(measureBundle, patientBundles, options, valueSetCache); // Get detailed population results for each patient
-const measureReports = await Calculator.calculateMeasureReports(measureBundle, patientBundles, options, valueSetCache); // Get individual FHIR MeasureReports for each patient
-const measureReports = await Calculator.calculateMeasureReports(measureBundle, [], options, valueSetCache); // Get individual FHIR MeasureReports for each patient given a custom patientSource in the options object
-const gapsInCare = await Calculator.calculateGapsInCare(measureBundle, patientBundles, options, valueSetCache); // Get gaps in care for each patient, if present
-const dataRequirements = await Calculator.calculateDataRequirements(measureBundle); // Get data requirements for a given measure (in a bundle)
-const queryInfo = await Calculator.calculateQueryInfo(measureBundle); // Get detailed query info for all statements in a measure
-const valueSets = await MeasureBundleHelpers.addValueSetsToMeasureBundle(measureBundle, options); // Add missing ValueSet resources to a measure bundle
+```JavaScript
+// Get raw results from CQL engine for each patient
+const rawResults = await Calculator.calculateRaw(measureBundle, patientBundles, options, valueSetCache);
+```
+
+```JavaScript
+// Get detailed population results for each patient
+const detailedResults = await Calculator.calculate(measureBundle, patientBundles, options, valueSetCache);
+```
+
+```JavaScript
+// Get individual FHIR MeasureReports for each patient
+const measureReports = await Calculator.calculateMeasureReports(measureBundle, patientBundles, options, valueSetCache);
+```
+
+```JavaScript
+// Get individual FHIR MeasureReports for each patient given a custom patientSource in the options object
+const measureReports = await Calculator.calculateMeasureReports(measureBundle, [], options, valueSetCache);
+```
+
+```JavaScript
+// Get gaps in care for each patient, if present
+const gapsInCare = await Calculator.calculateGapsInCare(measureBundle, patientBundles, options, valueSetCache);
+```
+
+```JavaScript
+// Get data requirements for a given measure (in a bundle)
+const dataRequirements = await Calculator.calculateDataRequirements(measureBundle);
+```
+
+```JavaScript
+// Get detailed query info for all statements in a measure
+const queryInfo = await Calculator.calculateQueryInfo(measureBundle); 
+```
+
+```JavaScript
+// Add missing ValueSet resources to a measure bundle
+const valueSets = await MeasureBundleHelpers.addValueSetsToMeasureBundle(measureBundle, options);
 ```
 
 #### Arguments
@@ -84,20 +149,18 @@ The options that we support for calculation are as follows:
 | verboseCalculationResults | boolean | yes | Use the detailed results interfaces for calculation. Defaults to true. |
 | enableDebugOutput | boolean | yes | Enable debug output from function calls. Defaults to false. |
 | includeClauseResults | boolean | yes | Option to include clause results. Defaults to false. |
-| includePrettyResults | boolean | yes | Option to include pretty results on statement results. Defaults to false. |
-| includeHighlighting | boolean | yes | Include highlighting in MeasureReport narrative. Defaults to false. |
 | measurementPeriodStart | string | yes | Start of measurement period. |
 | measurementPeriodEnd | string | yes | End of measurement period. |
-| patientSource | DataProvider | yes | PatientSource to use. If provided, the patientBundles will not be required. The PatientSource/DataProvider interface is defined in TypeScript by [cql-execution](https://github.com/cqframework/cql-execution/blob/master/src/types/cql-patient.interfaces.ts). |
-| reportType | string | yes | Type of MeasureReport to generate: "summary" or "individual". |
-| calculateSDEs | boolean | yes | Include Supplemental Data Elements in calculation. Defaults to false. |
-| calculateHTML | boolean | yes | Include HTML structure for highlighting. Defaults to false. |
-| calculateClauseCoverage | boolean | yes | Include HTML structure with coverage highlighting. Defaults to false. |
-| vsAPIKey | string | yes | API key, to be used to access a valueset API for downloading any missing valuesets |
+| patientSource | DataProvider | yes | PatientSource to use. If provided, the patientBundles are not required. The PatientSource/DataProvider interface is defined in TypeScript by [cql-execution](https://github.com/cqframework/cql-execution/blob/master/src/types/cql-patient.interfaces.ts). |
+| reportType | string | yes | Type of MeasureReport to generate: "summary", "subject-list" (not yet supported), or "individual". |
+| calculateSDEs | boolean | yes | Include Supplemental Data Elements in calculation. Defaults to true. |
+| calculateHTML | boolean | yes | Include HTML structure for highlighting. Defaults to true. |
+| calculateClauseCoverage | boolean | yes | Include HTML structure with coverage highlighting. Defaults to true. |
+| vsAPIKey | string | yes | API key, to be used to access a valueset API for downloading any missing ValueSets |
 | useValueSetCaching | boolean | yes | Whether to cache valuesets obtained by an API on the filesystem. Defaults to false. |
 | useElmJsonsCaching | boolean | yes | Whether to cache the ELM JSONs and associated information from calculation. Defaults to false. |
 | clearElmJsonsCache | boolean | yes | Whether to clear the ELM JSONs cache before running calculation. Defaults to false. |
-| profileValidation | boolean | yes | To "trust" the content of meta.profile as a source of truth for what profiles the data that cql-exec-fhir grabs validates against|
+| profileValidation | boolean | yes | To "trust" the content of meta.profile as a source of truth for what profiles the data that cql-exec-fhir grabs validates against. Defaults to false.|
 
 ### CLI
 
@@ -121,11 +184,11 @@ Options:
   --slim                                      Use slimmed-down calculation results interfaces (default: false)
   --report-type <report-type>                 Type of report, "individual", "summary", "subject-list".
   -m, --measure-bundle <measure-bundle>       Path to measure bundle.
-  -p, --patient-bundles <patient-bundles...>  Paths to patient bundles. Required unless output type is dataRequirements.
+  -p, --patient-bundles <patient-bundles...>  Paths to patient bundles. Required unless output type is one of the following: dataRequirements, queryInfo, valueSets.
   --as-patient-source                         Load bundles by creating cql-exec-fhir PatientSource to pass into library calls.
   -s, --measurement-period-start <date>       Start date for the measurement period, in YYYY-MM-DD format (defaults to the start date defined in the Measure, or 2019-01-01 if not set there).
   -e, --measurement-period-end <date>         End date for the measurement period, in YYYY-MM-DD format (defaults to the end date defined in the Measure, or 2019-12-31 if not set there).
-  --vs-api-key <key>                          API key, to authenticate against the valueset service to be used for resolving missing valuesets.
+  --vs-api-key <key>                          API key, to authenticate against the ValueSet service to be used for resolving missing valuesets.
   --cache-valuesets                           Whether or not to cache ValueSets retrieved from the ValueSet service. (default: false)
   --profile-validation                        To "trust" the content of meta.profile as a source of truth for what profiles the data that cql-exec-fhir grabs validates against. (default: false)
   -o, --out-file [file-path]                  Path to a file that fqm-execution will write the calculation results to (default: output.json)
@@ -136,27 +199,27 @@ E.g.
 
 ```bash
 Generate a MeasureReport by calculating a measure on a patient bundle:
-  - fqm-execution reports -m /path/to/measure/bundle.json -p /path/to/patient/bundle.json > reports.json
+  - fqm-execution reports -m /path/to/measure/bundle.json -p /path/to/patient/bundle.json  -o reports.json
 
 Generate a MeasureReport by calculating a measure on multiple patient bundles:
-  - fqm-execution reports -m /path/to/measure/bundle.json -p /path/to/patient1/bundle.json /path/to/patient2/bundle.json > reports.json
+  - fqm-execution reports -m /path/to/measure/bundle.json -p /path/to/patient1/bundle.json /path/to/patient2/bundle.json -o reports.json
 ```
 
 ### ValueSets
 
-If the Measure bundle provided doesn't contain all the required `ValueSet` resources (with expansions or composes) to calculate the measure, an API key can be provided to resolve the valuesets from their provided URLs. Currently only tested with valuesets from [The NLM FHIR Valueset API](https://cts.nlm.nih.gov/fhir).
+If the Measure bundle provided doesn't contain all the required `ValueSet` resources (with expansions or composes) to calculate the measure, an API key can be provided to resolve the valuesets from their provided URLs. Currently only tested with ValueSets from [The NLM FHIR Valueset API](https://cts.nlm.nih.gov/fhir).
 
 To find your VSAC API key, sign into [the UTS homepage](https://uts.nlm.nih.gov/uts/), click on `My Profile` in the top right, and copy the `API KEY` value from the `UMLS Licensee Profile`.
 
 ### TypeScript
 
-`fqm-execution` exports custom-defined TypeScript interfaces used within the code to allow for easy integration into other TypeScript projects. The TypeScript files defining these interfaces can be found [here](https://github.com/projecttacoma/fqm-execution/tree/master/src/types)
+`fqm-execution` exports custom-defined TypeScript interfaces used within the code to allow for easy integration into other TypeScript projects. The TypeScript files defining these interfaces can be found [here](https://github.com/projecttacoma/fqm-execution/tree/master/src/types).
 
 ## Local Development
 
 ### Prerequisites
 
-- [Node.js >=10.15.1](https://nodejs.org/en/)
+- [Node.js >=14.0.0](https://nodejs.org/en/)
 - [Git](https://git-scm.com/)
 
 ### Local Installation/Usage
@@ -223,14 +286,15 @@ Add the following contents to `.vscode/launch.json` in the root of the project d
               "${workspaceFolder}/build/**/*.js"
             ],
             "internalConsoleOptions": "openOnSessionStart",
-            "args": ["-m", "${workspaceFolder}/relative/path/to/measure/bundle.json", "-p", "${workspaceFolder}/relative/path/to/patient/bundle.json", "-o", "<reports | detailed | raw | gaps>"]
+            "args": ["<reports | detailed | raw | gaps | dataRequirements | queryInfo | valueSets>", "-m", "${workspaceFolder}/relative/path/to/measure/bundle.json", "-p", "${workspaceFolder}/relative/path/to/patient/bundle.json", "-o"]
           }
     ]
 }
-
 ```
 
 This will allow you to run the CLI from the `Run` tab in VS Code, and will halt execution of the program at any breakpoints or `debugger` statements in the code, to allow for debugging of the functionality.
+
+(Note: the `dataRequirements`, `queryInfo`, and `valueSets` commands do not require patient bundle(s) to be specified in the `args` array)
 
 ### Testing
 
@@ -256,9 +320,12 @@ A visual representation of the calculate sequence of the application can be seen
 
 ![Calculate](doc/calculate_Sequence.png)
 
+## Contributions
+For suggestions or contributions, please use [GitHub Issues](https://github.com/projecttacoma/fqm-execution/issues) or open a [Pull Request](https://github.com/projecttacoma/fqm-execution/pulls).
+
 ## License
 
-Copyright 2020 The MITRE Corporation
+Copyright 2020-2022 The MITRE Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Import the necessary modules:
 ```JavaScript
 import { Calculator, MeasureBundleHelpers } from 'fqm-execution';
 ```
-
+Use the following API functions:
 ```JavaScript
 // Get raw results from CQL engine for each patient
 const rawResults = await Calculator.calculateRaw(measureBundle, patientBundles, options, valueSetCache);
@@ -93,7 +93,7 @@ Import the necessary modules:
 ```JavaScript
 const { Calculator, MeasureBundleHelpers } = require('fqm-execution');
 ```
-
+Use the following API functions:
 ```JavaScript
 // Get raw results from CQL engine for each patient
 const rawResults = await Calculator.calculateRaw(measureBundle, patientBundles, options, valueSetCache);

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Options:
   --as-patient-source                         Load bundles by creating cql-exec-fhir PatientSource to pass into library calls.
   -s, --measurement-period-start <date>       Start date for the measurement period, in YYYY-MM-DD format (defaults to the start date defined in the Measure, or 2019-01-01 if not set there).
   -e, --measurement-period-end <date>         End date for the measurement period, in YYYY-MM-DD format (defaults to the end date defined in the Measure, or 2019-12-31 if not set there).
-  --vs-api-key <key>                          API key, to authenticate against the ValueSet service to be used for resolving missing valuesets.
+  --vs-api-key <key>                          API key, to authenticate against the ValueSet service to be used for resolving missing ValueSets.
   --cache-valuesets                           Whether or not to cache ValueSets retrieved from the ValueSet service. (default: false)
   --profile-validation                        To "trust" the content of meta.profile as a source of truth for what profiles the data that cql-exec-fhir grabs validates against. (default: false)
   -o, --out-file [file-path]                  Path to a file that fqm-execution will write the calculation results to (default: output.json)
@@ -167,7 +167,7 @@ fqm-execution reports -m /path/to/measure/bundle.json -p /path/to/patient1/bundl
 
 ### ValueSets
 
-If the Measure bundle provided doesn't contain all the required `ValueSet` resources (with expansions or composes) to calculate the measure, an API key can be provided to resolve the valuesets from their provided URLs. Currently only tested with ValueSets from [The NLM FHIR Valueset API](https://cts.nlm.nih.gov/fhir).
+If the Measure bundle provided doesn't contain all the required `ValueSet` resources (with expansions or composes) to calculate the measure, an API key can be provided to resolve the ValueSets from their provided URLs. Currently only tested with ValueSets from [The NLM FHIR ValueSet API](https://cts.nlm.nih.gov/fhir).
 
 To find your VSAC API key, sign into [the UTS homepage](https://uts.nlm.nih.gov/uts/), click on `My Profile` in the top right, and copy the `API KEY` value from the `UMLS Licensee Profile`.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Library for executing FHIR-based Electronic Clinical Quality Measures (eCQMs) wr
 
 - [Usage](#usage)
 
-  - [Module](#module)
+  - [API](#api)
   - [Calculation Options](#calculation-options)
   - [CLI](#cli)
   - [TypeScript](#typescript)
@@ -14,7 +14,7 @@ Library for executing FHIR-based Electronic Clinical Quality Measures (eCQMs) wr
 - [Local Development](#local-development)
 
   - [Prerequisites](#prerequisites)
-  - [Local Installation/Usage](#local-installation%2Fusage)
+  - [Local Installation/Usage](#local-installationusage)
   - [Debugging in VS Code](#debugging-in-vs-code)
   - [Testing](#testing)
   - [Checks](#checks)
@@ -39,104 +39,64 @@ npm install -g fqm-execution
 
 ## Usage
 
-### Module
+### API
 
-#### ES6
 Import the necessary modules:
 ```JavaScript
 import { Calculator, MeasureBundleHelpers } from 'fqm-execution';
 ```
-Use the following API functions:
+The following API functions are defined:
+
+#### Calculator.calculateRaw()
+Get raw results from CQL engine for each patient.
 ```JavaScript
-// Get raw results from CQL engine for each patient
 const rawResults = await Calculator.calculateRaw(measureBundle, patientBundles, options, valueSetCache);
 ```
 
+#### Calculator.calculate()
+Get detailed population results for each patient.
 ```JavaScript
-// Get detailed population results for each patient
 const detailedResults = await Calculator.calculate(measureBundle, patientBundles, options, valueSetCache);
 ```
 
+#### Calculator.calculateMeasureReports() 
+Get individual FHIR MeasureReports for each patient.
 ```JavaScript
-// Get individual FHIR MeasureReports for each patient
 const measureReports = await Calculator.calculateMeasureReports(measureBundle, patientBundles, options, valueSetCache);
 ```
 
+#### Calculator.calculateMeasureReports() with custom patientSource
+Get individual FHIR MeasureReports for each patient given a custom patientSource in the options object.
 ```JavaScript
-// Get individual FHIR MeasureReports for each patient given a custom patientSource in the options object
 const measureReports = await Calculator.calculateMeasureReports(measureBundle, [], options, valueSetCache);
 ```
 
+#### Calculator.calculateGapsInCare()
+Get gaps in care for each patient, if present.
 ```JavaScript
-// Get gaps in care for each patient, if present
 const gapsInCare = await Calculator.calculateGapsInCare(measureBundle, patientBundles, options, valueSetCache);
 ```
 
+#### Calculator.calculateDataRequirements()
+Get data requirements for a given measure (in a bundle).
 ```JavaScript
-// Get data requirements for a given measure (in a bundle)
 const dataRequirements = await Calculator.calculateDataRequirements(measureBundle);
 ```
 
+#### Calculator.calculateQueryInfo()
+Get detailed query info for all statements in a measure.
 ```JavaScript
-// Get detailed query info for all statements in a measure
 const queryInfo = await Calculator.calculateQueryInfo(measureBundle);
 ```
 
+#### MeasureBundleHelpers.addValueSetsToMeasureBundle()
+Add missing ValueSet resources to a measure bundle.
 ```JavaScript
-// Add missing ValueSet resources to a measure bundle
-const valueSets = await MeasureBundleHelpers.addValueSetsToMeasureBundle(measureBundle, options);
-```
-
-#### Require
-
-Import the necessary modules:
-```JavaScript
-const { Calculator, MeasureBundleHelpers } = require('fqm-execution');
-```
-Use the following API functions:
-```JavaScript
-// Get raw results from CQL engine for each patient
-const rawResults = await Calculator.calculateRaw(measureBundle, patientBundles, options, valueSetCache);
-```
-
-```JavaScript
-// Get detailed population results for each patient
-const detailedResults = await Calculator.calculate(measureBundle, patientBundles, options, valueSetCache);
-```
-
-```JavaScript
-// Get individual FHIR MeasureReports for each patient
-const measureReports = await Calculator.calculateMeasureReports(measureBundle, patientBundles, options, valueSetCache);
-```
-
-```JavaScript
-// Get individual FHIR MeasureReports for each patient given a custom patientSource in the options object
-const measureReports = await Calculator.calculateMeasureReports(measureBundle, [], options, valueSetCache);
-```
-
-```JavaScript
-// Get gaps in care for each patient, if present
-const gapsInCare = await Calculator.calculateGapsInCare(measureBundle, patientBundles, options, valueSetCache);
-```
-
-```JavaScript
-// Get data requirements for a given measure (in a bundle)
-const dataRequirements = await Calculator.calculateDataRequirements(measureBundle);
-```
-
-```JavaScript
-// Get detailed query info for all statements in a measure
-const queryInfo = await Calculator.calculateQueryInfo(measureBundle); 
-```
-
-```JavaScript
-// Add missing ValueSet resources to a measure bundle
 const valueSets = await MeasureBundleHelpers.addValueSetsToMeasureBundle(measureBundle, options);
 ```
 
 #### Arguments
-
-- `measureBundle`: Bundle containing a FHIR Measure and its dependent Libraries. FHIR ValueSets may be included as well
+- `measureBundle`: Bundle containing a FHIR Measure and its dependent Libraries. FHIR ValueSets may be included as well.
 - `patientBundles`: Array of FHIR Bundles containing patient data
 - `options` (optional): Object of calculation options (see below)
 - `valueSetCache` (optional): Array of FHIR ValueSet resources to use for calculation
@@ -156,8 +116,8 @@ The options that we support for calculation are as follows:
 | calculateSDEs | boolean | yes | Include Supplemental Data Elements in calculation. Defaults to true. |
 | calculateHTML | boolean | yes | Include HTML structure for highlighting. Defaults to true. |
 | calculateClauseCoverage | boolean | yes | Include HTML structure with coverage highlighting. Defaults to true. |
-| vsAPIKey | string | yes | API key, to be used to access a valueset API for downloading any missing ValueSets |
-| useValueSetCaching | boolean | yes | Whether to cache valuesets obtained by an API on the filesystem. Defaults to false. |
+| vsAPIKey | string | yes | API key, to be used to access a ValueSet API for downloading any missing ValueSets |
+| useValueSetCaching | boolean | yes | Whether to cache ValueSets obtained by an API on the filesystem. Defaults to false. |
 | useElmJsonsCaching | boolean | yes | Whether to cache the ELM JSONs and associated information from calculation. Defaults to false. |
 | clearElmJsonsCache | boolean | yes | Whether to clear the ELM JSONs cache before running calculation. Defaults to false. |
 | profileValidation | boolean | yes | To "trust" the content of meta.profile as a source of truth for what profiles the data that cql-exec-fhir grabs validates against. Defaults to false.|
@@ -198,11 +158,11 @@ Options:
 E.g.
 
 ```bash
-Generate a MeasureReport by calculating a measure on a patient bundle:
-  - fqm-execution reports -m /path/to/measure/bundle.json -p /path/to/patient/bundle.json  -o reports.json
+# Generate a MeasureReport by calculating a measure on a patient bundle:
+fqm-execution reports -m /path/to/measure/bundle.json -p /path/to/patient/bundle.json  -o reports.json
 
-Generate a MeasureReport by calculating a measure on multiple patient bundles:
-  - fqm-execution reports -m /path/to/measure/bundle.json -p /path/to/patient1/bundle.json /path/to/patient2/bundle.json -o reports.json
+# Generate a MeasureReport by calculating a measure on multiple patient bundles:
+fqm-execution reports -m /path/to/measure/bundle.json -p /path/to/patient1/bundle.json /path/to/patient2/bundle.json -o reports.json
 ```
 
 ### ValueSets
@@ -214,6 +174,14 @@ To find your VSAC API key, sign into [the UTS homepage](https://uts.nlm.nih.gov/
 ### TypeScript
 
 `fqm-execution` exports custom-defined TypeScript interfaces used within the code to allow for easy integration into other TypeScript projects. The TypeScript files defining these interfaces can be found [here](https://github.com/projecttacoma/fqm-execution/tree/master/src/types).
+
+The TypeScript interfaces can be imported into another project like so:
+
+```JavaScript
+import { CalculatorTypes } from 'fqm-execution'
+
+const options: CalculatorTypes.CalculationOptions = { /* .. */ }
+```
 
 ## Local Development
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ The options that we support for calculation are as follows:
 | useValueSetCaching | boolean | yes | Whether to cache ValueSets obtained by an API on the filesystem. Defaults to false. |
 | useElmJsonsCaching | boolean | yes | Whether to cache the ELM JSONs and associated information from calculation. Defaults to false. |
 | clearElmJsonsCache | boolean | yes | Whether to clear the ELM JSONs cache before running calculation. Defaults to false. |
-| profileValidation | boolean | yes | To "trust" the content of meta.profile as a source of truth for what profiles the data that cql-exec-fhir grabs validates against. Defaults to false.|
+| profileValidation | boolean | yes | To "trust" the content of meta.profile as a source of truth for what profiles the data that [cql-exec-fhir](https://github.com/projecttacoma/cql-exec-fhir) grabs validates against. Defaults to false.|
 
 ### CLI
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -45,7 +45,7 @@ program
   .requiredOption('-m, --measure-bundle <measure-bundle>', 'Path to measure bundle.')
   .option(
     '-p, --patient-bundles <patient-bundles...>',
-    'Paths to patient bundles. Required unless output type is dataRequirements.'
+    'Paths to patient bundles. Required unless output type is one of the following: dataRequirements, queryInfo, valueSets.'
   )
   .option('--as-patient-source', 'Load bundles by creating cql-exec-fhir PatientSource to pass into library calls.')
   .option(
@@ -60,7 +60,7 @@ program
   )
   .option(
     '--vs-api-key <key>',
-    'API key, to authenticate against the valueset service to be used for resolving missing valuesets.',
+    'API key, to authenticate against the ValueSet service to be used for resolving missing valuesets.',
     undefined
   )
   .option('--cache-valuesets', 'Whether or not to cache ValueSets retrieved from the ValueSet service.', false)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -60,7 +60,7 @@ program
   )
   .option(
     '--vs-api-key <key>',
-    'API key, to authenticate against the ValueSet service to be used for resolving missing valuesets.',
+    'API key, to authenticate against the ValueSet service to be used for resolving missing ValueSets.',
     undefined
   )
   .option('--cache-valuesets', 'Whether or not to cache ValueSets retrieved from the ValueSet service.', false)

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -12,10 +12,6 @@ import { GracefulError } from './errors/GracefulError';
 export interface CalculationOptions {
   /** Option to include clause results. Defaults to false. */
   includeClauseResults?: boolean;
-  /** Option to include pretty results on statement results. Defaults to false. */
-  includePrettyResults?: boolean;
-  /** Include highlighting in MeasureReport narrative. Defaults to false. */
-  includeHighlighting?: boolean;
   /** Start of measurement period. */
   measurementPeriodStart?: string;
   /** End of measurement period */

--- a/test/integration-tests/fhirInteractions.ts
+++ b/test/integration-tests/fhirInteractions.ts
@@ -46,8 +46,6 @@ function setupCalcOptions(/* string paramName, boolean value*/): CalculationOpti
   calcOptions.calculateHTML = true;
   calcOptions.calculateSDEs = true;
   calcOptions.includeClauseResults = true;
-  calcOptions.includeHighlighting = true;
-  calcOptions.includePrettyResults = true;
   calcOptions.measurementPeriodEnd = PERIOD_END;
   calcOptions.measurementPeriodStart = PERIOD_START;
 


### PR DESCRIPTION
# Summary
Updates various parts of the README (Module section, calculation options, CLI options, launch.json, license, etc.)

## New Behavior
Behavior should remain unchanged.

## Code Changes
* Add `ecqm-content-r4-2021` to `.gitignore` so it can easily be used for testing
* README changes
    * Separate the documentation under the module section for each API function
    * Update calculation options - A few options listed the default value as being false when we set them to true in `Calculator.ts`, so they were changed to true.
    * Update `-p` CLI option to specify all output types that do not require patient bundles
    * Update required node version for local development
    * Update launch.json example - When testing, the `-o` flag would assume the command was the output file (ex. Saved the output to `dataRequirements`/`detailed`/etc.) so I changed the command arg to appear first in the `args` array)
    * Added “Contributions” section since we have been receiving more GH issues/traction from external projects
    * Updated license - there’s no real consistency across GH as to how to update the copyright year. Some projects keep the original year, others do something like “2020+”, and others do “2020-2022”. I decided to do “2020-2022” (Synthea does this) but open to other suggestions.
* Removed `includePrettyResults` and `includeHighlighting` calculation options since they are defined but never used throughout fqm-execution for any calculation logic.

# Testing Guidance
* Check the API function declarations in the “Module” section for accuracy
* Check that all calculation options exist and have the correct type, and that the description includes the correct default value (if applicable)
* Check that all CLI options exist and have accurate descriptions
* Check that no links in the README are broken
* Test using different node versions to ensure that the required node version is correct (GH actions uses 14.x and 16.x for reference)
    * Test all local installation commands to ensure that they work on node version >= 14.x
* Test the example `launch.json` file included in the README

