### PR TITLE
Fix types and arguments for meta.profile checking

### DIFF
--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -329,7 +329,7 @@ export async function calculateAggregateMeasureReport(
 export async function calculateRaw(
   measureBundle: fhir4.Bundle,
   patientBundles: fhir4.Bundle[],
-  options: CalculationOptions,
+  options: CalculationOptions = {},
   valueSetCache: fhir4.ValueSet[] = []
 ): Promise<RCalculationOutput> {
   const debugObject: DebugOutput | undefined = options.enableDebugOutput ? <DebugOutput>{} : undefined;

--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -662,7 +662,7 @@ function resolvePatientSource(patientBundles: fhir4.Bundle[], options: Calculati
     if (patientBundles.filter(pb => pb.entry?.length).length === 0) {
       throw new UnexpectedResource('No entries found in passed patient bundles');
     }
-    const patientSource = PatientSource.FHIRv401(options.trustMetaProfile);
+    const patientSource = PatientSource.FHIRv401({ requireProfileTagging: options.trustMetaProfile ?? false });
     patientSource.loadBundles(patientBundles);
     return patientSource;
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -140,7 +140,7 @@ async function populatePatientBundles() {
     // if we want to pass patient data into the fqm-execution API as a cql-exec-fhir patient source. Build patientSource
     // from patientBundles and wipe patientBundles to be an empty array.
     if (program.asPatientSource) {
-      const patientSource = PatientSource.FHIRv401(program.profileValidation);
+      const patientSource = PatientSource.FHIRv401({ requireProfileTagging: program.profileValidation });
       patientSource.loadBundles(patientBundles);
       calcOptions.patientSource = patientSource;
       patientBundles = [];

--- a/src/types/CQLExecFHIR.d.ts
+++ b/src/types/CQLExecFHIR.d.ts
@@ -1,23 +1,31 @@
 declare module 'cql-exec-fhir' {
-  import { IPatientSource, IPatient, IRecord } from 'cql-execution';
-  class FHIRObject implements IRecord {
+  import { RecordObject, PatientObject, DataProvider, RetrieveDetails } from 'cql-execution';
+
+  interface PatientSourceOptions {
+    requireProfileTagging: boolean;
+  }
+
+  class FHIRObject implements RecordObject {
     get(field: string): any;
   }
-  class Patient extends FHIRObject implements IPatient {
-    findRecords(profile: string): FHIRObject;
-    findRecord(profile: string): FHIRObject;
+
+  class Patient extends FHIRObject implements PatientObject {
+    findRecords(profile: string, retrieveDetails?: RetrieveDetails): FHIRObject;
+    findRecord(profile: string, retrieveDetails?: RetrieveDetails): FHIRObject;
   }
-  export class PatientSource implements IPatientSource {
-    constructor();
+
+  export class PatientSource implements DataProvider {
+    constructor(filePathOrXML: string, patientSourceOptions?: PatientSourceOptions);
     loadBundles(bundles: fhir4.Bundle[]): void;
     currentPatient(): Patient | undefined;
     nextPatient(): Patient | undefined;
     reset(): void;
-    static FHIRv401(shouldCheckProfile?: boolean): PatientSource;
+    static FHIRv401(patientSourceOptions?: PatientSourceOptions): PatientSource;
   }
+
   export class FHIRWrapper {
     constructor(filePathOrXML: string);
-    wrap(fhirJson: R4, fhirResourceType?: string): any;
+    wrap(fhirJson: fhir4.FhirResource, fhirResourceType?: string): any;
     static FHIRv401(): FHIRWrapper;
   }
 }

--- a/src/types/CQLExecFHIR.d.ts
+++ b/src/types/CQLExecFHIR.d.ts
@@ -25,7 +25,7 @@ declare module 'cql-exec-fhir' {
 
   export class FHIRWrapper {
     constructor(filePathOrXML: string);
-    wrap(fhirJson: fhir4.FhirResource, fhirResourceType?: string): any;
+    wrap(fhirJson: any, fhirResourceType?: string): any;
     static FHIRv401(): FHIRWrapper;
   }
 }


### PR DESCRIPTION
# Summary

Per https://github.com/cqframework/cql-exec-fhir/pull/29, the API for enabling meta.profile validation in cql-exec-fhir changed to be an object of patient source options rather than a boolean constructor arg.

This PR updates our internal cql-exec-fhir types to reflect the latest structure of cql-exec-fhir proper, and updates and calls to enable meta.profile checking to use the proper `requireProfileTagging` option in cql-exec-fhir.

## New behavior

`meta.profile` checking works again

## Code changes

* Update `CQLExecFhir.d.ts` to use proper type defs now exported from `cql-execution` (previous code was out of date)
* Update constructor calls to PatientSource to use `requireProfileTagging` instead
* Smartly default calaultionOptions to `{}` in `calculateRaw` (previously would throw an error if calculationOptions were omitted (bad))

# Testing guidance

Working behavior can be seen in the following constructed test case: [meta-profile-tests.zip](https://github.com/projecttacoma/fqm-execution/files/10060829/meta-profile-tests.zip). Instructions are in the README.

