### PR TITLE
v1.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fqm-execution",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "fqm-execution",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/fhir": "0.0.34",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fqm-execution",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "FHIR Quality Measure Execution",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
# Summary
npm version bump for new release!
## New behavior
none
## Code changes
version bump to v1.0.1 in package.json and package-lock.json
# Testing guidance
Ensure that package and package lock are consistent with instruction in [matt's release instructions](https://confluence.mitre.org/display/TAC/How+to+Release+a+Package+to+NPM), and no other changes.
