### PR TITLE
Clause coverage highlighting for multiple groups

### DIFF
--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -196,7 +196,7 @@ export async function calculate<T extends CalculationOptions>(
           name: `clause-coverage-${groupId}.html`,
           html: result
         };
-        if (Array.isArray(debugObject.html) && debugObject.html?.length !== 0) {
+        if (Array.isArray(debugObject.html)) {
           debugObject.html?.push(debugHtml);
         } else {
           debugObject.html = [debugHtml];

--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -192,14 +192,14 @@ export async function calculate<T extends CalculationOptions>(
     Object.entries(groupClauseCoverageHTML).forEach(([groupId, result]) => {
       overallClauseCoverageHTML += result;
       if (debugObject && options.enableDebugOutput) {
-        const debugHtml = {
+        const debugHTML = {
           name: `clause-coverage-${groupId}.html`,
           html: result
         };
         if (Array.isArray(debugObject.html)) {
-          debugObject.html.push(debugHtml);
+          debugObject.html.push(debugHTML);
         } else {
-          debugObject.html = [debugHtml];
+          debugObject.html = [debugHTML];
         }
       }
     });

--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -197,7 +197,7 @@ export async function calculate<T extends CalculationOptions>(
           html: result
         };
         if (Array.isArray(debugObject.html)) {
-          debugObject.html?.push(debugHtml);
+          debugObject.html.push(debugHtml);
         } else {
           debugObject.html = [debugHtml];
         }

--- a/src/calculation/HTMLBuilder.ts
+++ b/src/calculation/HTMLBuilder.ts
@@ -6,6 +6,7 @@ import mainTemplate from '../templates/main';
 import clauseTemplate from '../templates/clause';
 import { UnexpectedProperty, UnexpectedResource } from '../types/errors/CustomErrors';
 import { uniqWith } from 'lodash';
+import { connect } from 'http2';
 
 export const cqlLogicClauseTrueStyle = {
   'background-color': '#ccebe0',
@@ -171,15 +172,8 @@ export function generateClauseCoverageHTML(
   // go through the lookup object of each of the groups with their total
   // detailedResults and calculate the clause coverage html for each group
   Object.entries(groupResultLookup).forEach(([groupId, detailedResults]) => {
-    const statementResults: StatementResult[][] = [];
-    const clauseResults: ClauseResult[][] = [];
-    const statements = detailedResults.flatMap(s => s.statementResults);
-    statementResults.push(statements);
-
-    const clauses = detailedResults.flatMap(c => (c.clauseResults ? c.clauseResults : []));
-    clauseResults.push(clauses);
-    const flattenedStatementResults = statementResults.flatMap(s => s);
-    const flattenedClauseResults = clauseResults.flatMap(c => c);
+    const flattenedStatementResults = detailedResults.flatMap(s => s.statementResults);
+    const flattenedClauseResults = detailedResults.flatMap(c => (c.clauseResults ? c.clauseResults : []));
 
     // Grab every statement with any relevance other than N/A
     // There may be multiple entries for a given statement across the results,

--- a/src/calculation/HTMLBuilder.ts
+++ b/src/calculation/HTMLBuilder.ts
@@ -6,7 +6,6 @@ import mainTemplate from '../templates/main';
 import clauseTemplate from '../templates/clause';
 import { UnexpectedProperty, UnexpectedResource } from '../types/errors/CustomErrors';
 import { uniqWith } from 'lodash';
-import { connect } from 'http2';
 
 export const cqlLogicClauseTrueStyle = {
   'background-color': '#ccebe0',
@@ -184,7 +183,7 @@ export function generateClauseCoverageHTML(
     ).filter(s => s.relevance !== Relevance.NA);
 
     // From all the relevant ones, filter out any duplicate statements
-    // uniqWith appears to pick the first element in encounters that matches the uniqueness condition
+    // uniqWith appears to pick the first element it encounters that matches the uniqueness condition
     // when iterating, which is fine because the relevance not being N/A is the only thing that matters now
     const uniqueRelevantStatements = uniqWith(
       relevantStatements,

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -356,6 +356,7 @@ export interface CalculationOutput<T extends CalculationOptions> extends Calcula
   mainLibraryName?: string;
   parameters?: { [key: string]: any };
   coverageHTML?: string;
+  groupClauseCoverageHTML?: Record<string, string>;
 }
 
 /**

--- a/test/HTMLGenerator.test.ts
+++ b/test/HTMLGenerator.test.ts
@@ -92,8 +92,37 @@ describe('HTMLGenerator', () => {
     ];
     const res = generateClauseCoverageHTML([elm], executionResults);
 
-    expect(res.replace(/\s/g, '')).toEqual(expectedHTML);
-    expect(res.includes(coverageStyleString)).toBeTruthy();
+    expect(res.test.replace(/\s/g, '')).toEqual(expectedHTML);
+    expect(res.test.includes(coverageStyleString)).toBeTruthy();
+  });
+
+  test('simple HTML for two groups with generation with clause coverage styling', () => {
+    // Ignore tabs and new lines
+    const expectedHTML = getHTMLFixture('simpleCoverageAnnotation.html').replace(/\s/g, '');
+    const expectedHTML2 = getHTMLFixture('simpleCoverageAnnotation2.html').replace(/\s/g, '');
+    const executionResults: ExecutionResult<DetailedPopulationGroupResult>[] = [
+      {
+        patientId: 'testid',
+        detailedResults: [
+          {
+            statementResults: statementResults,
+            clauseResults: [trueClauseResults[0], falseClauseResults[0]],
+            groupId: 'test'
+          },
+          {
+            statementResults: statementResults,
+            clauseResults: [trueClauseResults[0], falseClauseResults[0]],
+            groupId: 'test2'
+          }
+        ]
+      }
+    ];
+    const res = generateClauseCoverageHTML([elm], executionResults);
+
+    expect(res.test.replace(/\s/g, '')).toEqual(expectedHTML);
+    expect(res.test2.replace(/\s/g, '')).toEqual(expectedHTML2);
+    expect(res.test.includes(coverageStyleString)).toBeTruthy();
+    expect(res.test2.includes(coverageStyleString)).toBeTruthy();
   });
 
   test('no library found should error', () => {

--- a/test/fixtures/html/simpleCoverageAnnotation.html
+++ b/test/fixtures/html/simpleCoverageAnnotation.html
@@ -1,6 +1,6 @@
 <div>
-    <h2>Clause Coverage: 100%</h2>
-    <pre style="tab-size: 2; border-bottom-width: 4px; line-height: 1.4">
+  <h2>test Clause Coverage: 100%</h2>
+  <pre style="tab-size: 2; border-bottom-width: 4px; line-height: 1.4">
       <code>
         <span data-ref-id="119" style="background-color:#daeaf5;color:#004e82;border-bottom-color:#006cb4;border-bottom-style:dashed">
           <span>define &quot;Denominator&quot;: </span>
@@ -22,4 +22,4 @@
         </span>
       </code>
     </pre>
-  </div>
+</div>

--- a/test/fixtures/html/simpleCoverageAnnotation2.html
+++ b/test/fixtures/html/simpleCoverageAnnotation2.html
@@ -1,0 +1,25 @@
+<div>
+  <h2>test2 Clause Coverage: 100%</h2>
+  <pre style="tab-size: 2; border-bottom-width: 4px; line-height: 1.4">
+        <code>
+          <span data-ref-id="119" style="background-color:#daeaf5;color:#004e82;border-bottom-color:#006cb4;border-bottom-style:dashed">
+            <span>define &quot;Denominator&quot;: </span>
+            <span data-ref-id="118" style="background-color:white;color:black;border-bottom-color:white;border-bottom-style:solid">
+              <span data-ref-id="116" style="background-color:white;color:black;border-bottom-color:white;border-bottom-style:solid">
+                <span data-ref-id="101" style="background-color:white;color:black;border-bottom-color:white;border-bottom-style:solid">
+                  <span>&quot;Encounter with Atrial Ablation Procedure&quot;</span>
+                </span>
+                <span>union</span>
+                <span data-ref-id="115" style="background-color:white;color:black;border-bottom-color:white;border-bottom-style:solid">
+                  <span>&quot;History of Atrial FibrillationFlutter&quot;</span>
+                </span>
+              </span>
+              <span>union</span>
+              <span data-ref-id="117" style="background-color:white;color:black;border-bottom-color:white;border-bottom-style:solid">
+                <span>&quot;Current Diagnosis Atrial FibrillationFlutter&quot;</span>
+              </span>
+            </span>
+          </span>
+        </code>
+      </pre>
+</div>


### PR DESCRIPTION
# Summary
Before, the coverage highlighting only happened for one measure group. Now, it calculates the coverage for all patients for each individual group.

## New behavior
`generateClauseCoverageHTML` now returns a lookup object where the key is the groupId and the value is the clause coverage html for that group. There is an additional property on the CalculationOutput interface for `groupClauseCoverageHTML`. 

## Code changes
- `src/calculation/Calculator.ts`- The lookup object created by `generateClauseCoverageHTML` is now returned as part of the CalculationOutput in the `calculate` function. If the debug output is enabled, an html file for the overall clause coverage html is created and contains the html for each group. In addition, an html file is created for each of the groups clause coverage html.
- `src/Calculation/HTMLBuilder.ts`- `generateClauseCoverageHtml` iterates through each execution result and adds the detailedResult to a lookup object where the key is its corresponding groupId. Then, it iterates through that lookup object and calculates the clauseCoverageHtml for each of the groups in that lookup object. The html for each group is added to another lookup object where the key is the groupId and the value is the clause coverage html for that group. That lookup object is then returned.
- `src/types/Calculator.ts`- The optional `groupClauseCoverageHTML` property was added to the `CalculationOutput` interface.
- `test/HTMLGenerator.test.ts`- Tests were changed to reflect the changes to the return type of `generateClauseCoverageHTML`.
- `test/fixtures/html/SimpleCoverageAnnotation.html`- This file was modified to include the group name.
- `test/fixtures/html/SimpleCoverageAnnotation2.html`- This file was added for the unit test that tests `generateClauseCoverageHTML` on multiple groups.

# Testing guidance
1. `npm run check` to ensure that unit tests pass and there are no prettier or lint errors/warnings.
2. Using the files attached below, run the following command: `npm run cli -- detailed -m <path-to-measure-bundle.json> -p <path-to-pt1.json> <path-to-pt2.json> -o --debug`
3. Look at the html files in the debug directory. There should be 4 files: two for each group that includes that group's clause coverage and two for each group that includes that group's measure highlighting.
4. Let me know if you have any questions and more importantly if you have any suggestions for additional unit tests or testing methods. 

[coverage-test-case.zip](https://github.com/projecttacoma/fqm-execution/files/10125052/coverage-test-case.zip)
