### PR TITLE
Coverage functions

### DIFF
--- a/src/calculation/ClauseResultsBuilder.ts
+++ b/src/calculation/ClauseResultsBuilder.ts
@@ -261,6 +261,8 @@ export function buildStatementAndClauseResults(
     statementResult.raw = rawStatementResult;
 
     const isFunction = ClauseResultsHelpers.isStatementFunction(elmLibrary, statementResult.statementName);
+    // set isFunction property so we can later filter out functions during clause coverage calculation
+    statementResult.isFunction = isFunction;
 
     //TODO: determine how SDEs should be handled
     //const isSDE = ClauseResultsHelpers.isSupplementalDataElementStatement(measure.supplementalData, statement_name);
@@ -273,9 +275,6 @@ export function buildStatementAndClauseResults(
       statementResult.final = FinalResult.UNHIT;
       // even if the statement wasn't hit, we want the pretty result to just
       // be FUNCTION for functions
-      // set isFunction property so we can later filter out functions during clause coverage calculation
-      statementResult.isFunction = isFunction;
-
       if (doPretty) {
         if (isFunction) {
           statementResult.pretty = 'FUNCTION';
@@ -290,8 +289,6 @@ export function buildStatementAndClauseResults(
       }
     } else {
       statementResult.final = FinalResult.FALSE;
-      // set isFunction property so we can later filter out functions during clause coverage calculation
-      statementResult.isFunction = isFunction;
       if (rawStatementResult instanceof Array && rawStatementResult.length === 0) {
         // Special case, handle empty array.
         if (doPretty) {

--- a/src/calculation/ClauseResultsBuilder.ts
+++ b/src/calculation/ClauseResultsBuilder.ts
@@ -273,7 +273,7 @@ export function buildStatementAndClauseResults(
       // be FUNCTION for functions
       const isFunction = ClauseResultsHelpers.isStatementFunction(elmLibrary, statementResult.statementName);
       // set isFunction property so we can later filter out functions during clause coverage calculation
-      statementResult.isFunction = isFunction ? 'TRUE' : 'FALSE';
+      statementResult.isFunction = isFunction;
 
       if (doPretty) {
         if (isFunction) {
@@ -291,7 +291,7 @@ export function buildStatementAndClauseResults(
       statementResult.final = FinalResult.FALSE;
       const isFunction = ClauseResultsHelpers.isStatementFunction(elmLibrary, statementResult.statementName);
       // set isFunction property so we can later filter out functions during clause coverage calculation
-      statementResult.isFunction = isFunction ? 'TRUE' : 'FALSE';
+      statementResult.isFunction = isFunction;
       if (rawStatementResult instanceof Array && rawStatementResult.length === 0) {
         // Special case, handle empty array.
         if (doPretty) {

--- a/src/calculation/ClauseResultsBuilder.ts
+++ b/src/calculation/ClauseResultsBuilder.ts
@@ -271,6 +271,10 @@ export function buildStatementAndClauseResults(
       statementResult.final = FinalResult.UNHIT;
       // even if the statement wasn't hit, we want the pretty result to just
       // be FUNCTION for functions
+      const isFunction = ClauseResultsHelpers.isStatementFunction(elmLibrary, statementResult.statementName);
+      // set isFunction property so we can later filter out functions during clause coverage calculation
+      statementResult.isFunction = isFunction ? 'TRUE' : 'FALSE';
+
       if (doPretty) {
         if (ClauseResultsHelpers.isStatementFunction(elmLibrary, statementResult.statementName)) {
           statementResult.pretty = 'FUNCTION';

--- a/src/calculation/ClauseResultsBuilder.ts
+++ b/src/calculation/ClauseResultsBuilder.ts
@@ -260,6 +260,8 @@ export function buildStatementAndClauseResults(
     );
     statementResult.raw = rawStatementResult;
 
+    const isFunction = ClauseResultsHelpers.isStatementFunction(elmLibrary, statementResult.statementName);
+
     //TODO: determine how SDEs should be handled
     //const isSDE = ClauseResultsHelpers.isSupplementalDataElementStatement(measure.supplementalData, statement_name);
     if (/*(!measure.calculate_sdes && isSDE) || */ statementResult.relevance == Relevance.NA) {
@@ -271,7 +273,6 @@ export function buildStatementAndClauseResults(
       statementResult.final = FinalResult.UNHIT;
       // even if the statement wasn't hit, we want the pretty result to just
       // be FUNCTION for functions
-      const isFunction = ClauseResultsHelpers.isStatementFunction(elmLibrary, statementResult.statementName);
       // set isFunction property so we can later filter out functions during clause coverage calculation
       statementResult.isFunction = isFunction;
 
@@ -289,7 +290,6 @@ export function buildStatementAndClauseResults(
       }
     } else {
       statementResult.final = FinalResult.FALSE;
-      const isFunction = ClauseResultsHelpers.isStatementFunction(elmLibrary, statementResult.statementName);
       // set isFunction property so we can later filter out functions during clause coverage calculation
       statementResult.isFunction = isFunction;
       if (rawStatementResult instanceof Array && rawStatementResult.length === 0) {

--- a/src/calculation/ClauseResultsBuilder.ts
+++ b/src/calculation/ClauseResultsBuilder.ts
@@ -276,7 +276,7 @@ export function buildStatementAndClauseResults(
       statementResult.isFunction = isFunction ? 'TRUE' : 'FALSE';
 
       if (doPretty) {
-        if (ClauseResultsHelpers.isStatementFunction(elmLibrary, statementResult.statementName)) {
+        if (isFunction) {
           statementResult.pretty = 'FUNCTION';
         } else {
           statementResult.pretty = 'UNHIT';
@@ -289,12 +289,15 @@ export function buildStatementAndClauseResults(
       }
     } else {
       statementResult.final = FinalResult.FALSE;
+      const isFunction = ClauseResultsHelpers.isStatementFunction(elmLibrary, statementResult.statementName);
+      // set isFunction property so we can later filter out functions during clause coverage calculation
+      statementResult.isFunction = isFunction ? 'TRUE' : 'FALSE';
       if (rawStatementResult instanceof Array && rawStatementResult.length === 0) {
         // Special case, handle empty array.
         if (doPretty) {
           statementResult.pretty = 'FALSE ([])';
         }
-      } else if (ClauseResultsHelpers.isStatementFunction(elmLibrary, statementResult.statementName)) {
+      } else if (isFunction) {
         if (doPretty) {
           statementResult.pretty = 'FUNCTION';
         }

--- a/src/calculation/HTMLBuilder.ts
+++ b/src/calculation/HTMLBuilder.ts
@@ -244,7 +244,7 @@ export function generateClauseCoverageHTML(
 export function calculateClauseCoverage(relevantStatements: StatementResult[], clauseResults: ClauseResult[]): string {
   // find all relevant clauses using localId and libraryName from relevant statements
   const allRelevantClauses = clauseResults.filter(c =>
-    relevantStatements.some(s => s.localId === c.localId && s.libraryName === c.libraryName && s.isFunction !== 'TRUE')
+    relevantStatements.some(s => s.localId === c.localId && s.libraryName === c.libraryName && !s.isFunction)
   );
   // get all unique clauses to use as denominator in percentage calculation
   const allUniqueClauses = uniqWith(

--- a/src/calculation/HTMLBuilder.ts
+++ b/src/calculation/HTMLBuilder.ts
@@ -244,7 +244,7 @@ export function generateClauseCoverageHTML(
 export function calculateClauseCoverage(relevantStatements: StatementResult[], clauseResults: ClauseResult[]): string {
   // find all relevant clauses using localId and libraryName from relevant statements
   const allRelevantClauses = clauseResults.filter(c =>
-    relevantStatements.some(s => s.localId === c.localId && s.libraryName === c.libraryName && s.isFunction === 'FALSE')
+    relevantStatements.some(s => s.localId === c.localId && s.libraryName === c.libraryName && s.isFunction !== 'TRUE')
   );
   // get all unique clauses to use as denominator in percentage calculation
   const allUniqueClauses = uniqWith(

--- a/src/calculation/HTMLBuilder.ts
+++ b/src/calculation/HTMLBuilder.ts
@@ -244,7 +244,7 @@ export function generateClauseCoverageHTML(
 export function calculateClauseCoverage(relevantStatements: StatementResult[], clauseResults: ClauseResult[]): string {
   // find all relevant clauses using localId and libraryName from relevant statements
   const allRelevantClauses = clauseResults.filter(c =>
-    relevantStatements.some(s => s.localId === c.localId && s.libraryName === c.libraryName)
+    relevantStatements.some(s => s.localId === c.localId && s.libraryName === c.libraryName && s.isFunction === 'FALSE')
   );
   // get all unique clauses to use as denominator in percentage calculation
   const allUniqueClauses = uniqWith(

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -177,6 +177,8 @@ export interface StatementResult {
   raw?: any;
   /** Pretty result for this statement. */
   pretty?: string;
+  /** TRUE if the statement is a function */
+  isFunction?: 'TRUE' | 'FALSE';
 }
 
 /**

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -178,7 +178,7 @@ export interface StatementResult {
   /** Pretty result for this statement. */
   pretty?: string;
   /** TRUE if the statement is a function */
-  isFunction?: 'TRUE' | 'FALSE';
+  isFunction?: boolean;
 }
 
 /**

--- a/test/unit/HTMLBuilder.test.ts
+++ b/test/unit/HTMLBuilder.test.ts
@@ -4,7 +4,8 @@ import {
   objToCSS,
   cqlLogicClauseTrueStyle,
   cqlLogicClauseFalseStyle,
-  cqlLogicClauseCoveredStyle
+  cqlLogicClauseCoveredStyle,
+  calculateClauseCoverage
 } from '../../src/calculation/HTMLBuilder';
 import {
   StatementResult,
@@ -151,5 +152,47 @@ describe('HTMLBuilder', () => {
     expect(() => {
       generateHTML([elm], badStatementResults, [], 'test');
     }).toThrowError();
+  });
+  test('clause coverage percent with a function ignores function in calculation', () => {
+    statementResults = [
+      {
+        libraryName: 'testLib',
+        statementName: 'testFunc',
+        localId: 'test-id-1',
+        final: FinalResult.FALSE,
+        relevance: Relevance.TRUE,
+        raw: undefined,
+        isFunction: 'TRUE',
+        pretty: 'FUNCTION'
+      },
+      {
+        libraryName: 'testLib',
+        statementName: 'testStatement',
+        localId: 'test-id-2',
+        final: FinalResult.FALSE,
+        relevance: Relevance.TRUE,
+        raw: false,
+        isFunction: 'FALSE',
+        pretty: 'FALSE (false)'
+      }
+    ];
+    const clauseResults = [
+      {
+        raw: undefined,
+        statementName: 'testFunc',
+        libraryName: 'testLib',
+        localId: 'test-id-1',
+        final: FinalResult.NA
+      },
+      {
+        raw: undefined,
+        statementName: 'testStatement',
+        libraryName: 'testLib',
+        localId: 'test-id-2',
+        final: FinalResult.TRUE
+      }
+    ];
+    const results = calculateClauseCoverage(statementResults, clauseResults);
+    expect(results).toEqual('100');
   });
 });

--- a/test/unit/HTMLBuilder.test.ts
+++ b/test/unit/HTMLBuilder.test.ts
@@ -162,7 +162,7 @@ describe('HTMLBuilder', () => {
         final: FinalResult.FALSE,
         relevance: Relevance.TRUE,
         raw: undefined,
-        isFunction: 'TRUE',
+        isFunction: true,
         pretty: 'FUNCTION'
       },
       {
@@ -172,7 +172,7 @@ describe('HTMLBuilder', () => {
         final: FinalResult.FALSE,
         relevance: Relevance.TRUE,
         raw: false,
-        isFunction: 'FALSE',
+        isFunction: false,
         pretty: 'FALSE (false)'
       }
     ];

--- a/test/unit/HTMLBuilder.test.ts
+++ b/test/unit/HTMLBuilder.test.ts
@@ -153,6 +153,7 @@ describe('HTMLBuilder', () => {
       generateHTML([elm], badStatementResults, [], 'test');
     }).toThrowError();
   });
+
   test('clause coverage percent with a function ignores function in calculation', () => {
     statementResults = [
       {

--- a/test/unit/HTMLBuilder.test.ts
+++ b/test/unit/HTMLBuilder.test.ts
@@ -16,7 +16,7 @@ import { ELM, ELMStatement } from '../../src/types/ELMTypes';
 import { FinalResult, Relevance } from '../../src/types/Enums';
 import { getELMFixture, getHTMLFixture } from './helpers/testHelpers';
 
-describe('HTMLGenerator', () => {
+describe('HTMLBuilder', () => {
   let elm = <ELM>{};
   let simpleExpression: ELMStatement | undefined;
   let statementResults: StatementResult[];


### PR DESCRIPTION
# Summary
Remove CQL functions from clause coverage calculation

## New behavior
Previously, functions counted as clauses when calculating clause coverage. This led to coverage numbers being lower than appropriate. Functions are now identified and marked during statement and clause result generation, then filtered out during clause coverage calculation

## Code changes
 - Add line to `buildStatementAndClauseResults` that sets `isFunction` property to true if appropriate
 - Filter out clauses with `isFunction` set to `TRUE` in `calculateClauseCoverage`
 - add `isFunction` property to `StatementResult` interface
 - Updated HTMLGenerator test file to HTMLBuilder to reflect file name change

# Testing guidance
 - `npm run check`
 - download the attached measure and patient bundle and store at root level of fqm-execution
 - run `npm run build`
 - `node build/cli.js detailed  -m "./coverage-calc/measure-bundle.json" -p "./coverage-calc/patient-numer-bundle.json" --debug -o -s "2022-01-01" -e "2022-12-31"`
 - Head into the generated `debug/html` folder and view the `clause-coverage` file. Coverage should now be `100%`
 - `node build/cli.js detailed  -m "./coverage-calc/measure-bundle.json" -p "./coverage-calc/patient-denom-bundle.json" --debug -o -s "2022-01-01" -e "2022-12-31"`
 - Head into the generated `debug/html` folder and view the `clause-coverage` file. Coverage should now be `75%`
[coverage-calc.zip](https://github.com/projecttacoma/fqm-execution/files/10314563/coverage-calc.zip)
