### PR TITLE
Implement library data requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,15 @@ Get data requirements for a given measure (in a bundle).
 const dataRequirements = await Calculator.calculateDataRequirements(measureBundle);
 ```
 
+#### Calculator.calculateLibraryDataRequirements()
+
+Get data requirements for a given library bundle with a root Library reference.
+In this case, the measureBundle is a Library Bundle.
+
+```Javascript
+const libraryDataRequirements = await Calculator.calculateLibraryDataRequirements(measureBundle, rootLibRef);
+```
+
 #### Calculator.calculateQueryInfo()
 
 Get detailed query info for all statements in a measure.
@@ -154,6 +163,7 @@ Commands:
   raw
   gaps
   dataRequirements
+  libraryDataRequirements
   queryInfo
   valueSets
   help [command]                              display help for command
@@ -171,6 +181,7 @@ Options:
   --cache-valuesets                           Whether or not to cache ValueSets retrieved from the ValueSet service. (default: false)
   --profile-validation                        To "trust" the content of meta.profile as a source of truth for what profiles the data that cql-exec-fhir grabs validates against. (default: false)
   -o, --out-file [file-path]                  Path to a file that fqm-execution will write the calculation results to (default: output.json)
+  --root-lib-ref <root-lib-ref>               Reference to the root Library
   -h, --help                                  display help for command
 ```
 

--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -516,9 +516,9 @@ export async function calculateGapsInCare<T extends OneOrMultiPatient>(
 }
 
 /**
- * Get data requirements for this library
+ * Get data requirements for a Library bundle
  *
- * @param libraryBundle Bundle with a LibraryResource and all necessary data for execution
+ * @param libraryBundle Bundle of library resources
  * @param options Options for calculation.
  *
  * @returns FHIR Library of data requirements
@@ -538,75 +538,6 @@ export async function calculateLibraryDataRequirements(
   );
 
   return DataRequirementHelpers.getDataRequirements(cqls, rootLibIdentifier, elmJSONs, options);
-
-  // const rootLib = elmJSONs.find(ej => ej.library.identifier == rootLibIdentifier);
-
-  // const { startCql, endCql } = Execution.getCQLIntervalEndpoints(options);
-
-  // // We need a root library to run dataRequirements properly. If we don't have one, error out.
-  // if (!rootLib?.library) {
-  //   throw new UnexpectedResource("root library doesn't contain a library object"); //unexpected resource
-  // }
-
-  // const parameters = { 'Measurement Period': new Interval(startCql, endCql) };
-
-  // const withErrors: GracefulError[] = [];
-  // // get the retrieves for every statement in the root lirbary
-  // const allRetrieves = rootLib.library.statements.def.flatMap(statement => {
-  //   if (statement.expression && statement.name != 'Patient') {
-  //     const retrievesOutput = RetrievesHelper.findRetrieves(rootLib, elmJSONs, statement.expression);
-  //     withErrors.push(...retrievesOutput.withErrors);
-  //     return retrievesOutput.results;
-  //   } else {
-  //     return [] as DataTypeQuery[];
-  //   }
-  // });
-
-  // const allRetrievesPromises = allRetrieves.map(async retrieve => {
-  //   // If the retrieves have a localId for the query and a known library name, we can get more info
-  //   // on how the query filters the sources.
-  //   if (retrieve.queryLocalId && retrieve.queryLibraryName) {
-  //     const library = elmJSONs.find(lib => lib.library.identifier.id === retrieve.queryLibraryName);
-  //     if (library) {
-  //       retrieve.queryInfo = await parseQueryInfo(
-  //         library,
-  //         elmJSONs,
-  //         retrieve.queryLocalId,
-  //         retrieve.valueComparisonLocalId,
-  //         parameters
-  //       );
-  //     }
-  //   }
-  // });
-
-  // await Promise.all(allRetrievesPromises);
-
-  // const results: fhir4.Library = {
-  //   resourceType: 'Library',
-  //   type: { coding: [{ code: 'module-definition', system: 'http://terminology.hl7.org/CodeSystem/library-type' }] },
-  //   status: 'unknown'
-  // };
-  // results.dataRequirement = uniqBy(
-  //   allRetrieves.map(retrieve => {
-  //     const dr = generateDataRequirement(retrieve);
-  //     GapsInCareHelpers.addFiltersToDataRequirement(retrieve, dr, withErrors);
-  //     addFhirQueryPatternToDataRequirements(dr);
-  //     return dr;
-  //   }),
-  //   JSON.stringify
-  // );
-
-  // return {
-  //   results: results,
-  //   debugOutput: {
-  //     cql: cqls,
-  //     elm: elmJSONs,
-  //     gaps: {
-  //       retrieves: allRetrieves
-  //     }
-  //   },
-  //   withErrors
-  // };
 }
 
 /**
@@ -625,73 +556,6 @@ export async function calculateDataRequirements(
   const { cqls, rootLibIdentifier, elmJSONs } = MeasureBundleHelpers.extractLibrariesFromMeasureBundle(measureBundle);
 
   return DataRequirementHelpers.getDataRequirements(cqls, rootLibIdentifier, elmJSONs, options);
-  // const rootLib = elmJSONs.find(ej => ej.library.identifier == rootLibIdentifier);
-
-  // const { startCql, endCql } = Execution.getCQLIntervalEndpoints(options);
-
-  // // We need a root library to run dataRequirements properly. If we don't have one, error out.
-  // if (!rootLib?.library) {
-  //   throw new UnexpectedResource("root library doesn't contain a library object"); //unexpected resource
-  // }
-
-  // const parameters = { 'Measurement Period': new Interval(startCql, endCql) };
-  // const withErrors: GracefulError[] = [];
-  // // get the retrieves for every statement in the root library
-  // const allRetrieves = rootLib.library.statements.def.flatMap(statement => {
-  //   if (statement.expression && statement.name != 'Patient') {
-  //     const retrievesOutput = RetrievesHelper.findRetrieves(rootLib, elmJSONs, statement.expression);
-  //     withErrors.push(...retrievesOutput.withErrors);
-  //     return retrievesOutput.results;
-  //   } else {
-  //     return [] as DataTypeQuery[];
-  //   }
-  // });
-
-  // const allRetrievesPromises = allRetrieves.map(async retrieve => {
-  //   // If the retrieves have a localId for the query and a known library name, we can get more info
-  //   // on how the query filters the sources.
-  //   if (retrieve.queryLocalId && retrieve.queryLibraryName) {
-  //     const library = elmJSONs.find(lib => lib.library.identifier.id === retrieve.queryLibraryName);
-  //     if (library) {
-  //       retrieve.queryInfo = await parseQueryInfo(
-  //         library,
-  //         elmJSONs,
-  //         retrieve.queryLocalId,
-  //         retrieve.valueComparisonLocalId,
-  //         parameters
-  //       );
-  //     }
-  //   }
-  // });
-
-  // await Promise.all(allRetrievesPromises);
-
-  // const results: fhir4.Library = {
-  //   resourceType: 'Library',
-  //   type: { coding: [{ code: 'module-definition', system: 'http://terminology.hl7.org/CodeSystem/library-type' }] },
-  //   status: 'unknown'
-  // };
-  // results.dataRequirement = uniqBy(
-  //   allRetrieves.map(retrieve => {
-  //     const dr = generateDataRequirement(retrieve);
-  //     GapsInCareHelpers.addFiltersToDataRequirement(retrieve, dr, withErrors);
-  //     addFhirQueryPatternToDataRequirements(dr);
-  //     return dr;
-  //   }),
-  //   JSON.stringify
-  // );
-
-  // return {
-  //   results: results,
-  //   debugOutput: {
-  //     cql: cqls,
-  //     elm: elmJSONs,
-  //     gaps: {
-  //       retrieves: allRetrieves
-  //     }
-  //   },
-  //   withErrors
-  // };
 }
 
 /**

--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -531,7 +531,7 @@ export async function calculateLibraryDataRequirements(
     throw new UnexpectedProperty('Root lib ref must be provided in order to calculate library dataRequirements');
   }
 
-  // Extract the library ELM, and the id of the root library, from the measure bundle
+  // Extract the library ELM, and the id of the root library, from the library bundle
   const { cqls, rootLibIdentifier, elmJSONs } = MeasureBundleHelpers.extractLibrariesFromLibraryBundle(
     libraryBundle,
     options.rootLibRef

--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -21,13 +21,12 @@ import * as Execution from '../execution/Execution';
 import * as CalculatorHelpers from './DetailedResultsBuilder';
 import * as MeasureBundleHelpers from '../helpers/MeasureBundleHelpers';
 import * as ResultsHelpers from './ClauseResultsBuilder';
+import * as DataRequirementHelpers from '../helpers/DataRequirementHelpers';
 import MeasureReportBuilder from './MeasureReportBuilder';
 import * as GapsInCareHelpers from '../gaps/GapsReportBuilder';
 import { generateHTML, generateClauseCoverageHTML } from './HTMLBuilder';
 import { parseQueryInfo } from '../gaps/QueryFilterParser';
 import * as RetrievesHelper from '../gaps/RetrievesFinder';
-import { uniqBy } from 'lodash';
-import { generateDataRequirement, addFhirQueryPatternToDataRequirements } from '../helpers/DataRequirementHelpers';
 import { GracefulError } from '../types/errors/GracefulError';
 import {
   ErrorWithDebugInfo,
@@ -517,6 +516,100 @@ export async function calculateGapsInCare<T extends OneOrMultiPatient>(
 }
 
 /**
+ * Get data requirements for this library
+ *
+ * @param libraryBundle Bundle with a LibraryResource and all necessary data for execution
+ * @param options Options for calculation.
+ *
+ * @returns FHIR Library of data requirements
+ */
+export async function calculateLibraryDataRequirements(
+  libraryBundle: fhir4.Bundle,
+  options: CalculationOptions = {}
+): Promise<DRCalculationOutput> {
+  if (options.rootLibRef === undefined) {
+    throw new UnexpectedProperty('Root lib ref must be provided in order to calculate library dataRequirements');
+  }
+
+  // Extract the library ELM, and the id of the root library, from the measure bundle
+  const { cqls, rootLibIdentifier, elmJSONs } = MeasureBundleHelpers.extractLibrariesFromLibraryBundle(
+    libraryBundle,
+    options.rootLibRef
+  );
+
+  return DataRequirementHelpers.getDataRequirements(cqls, rootLibIdentifier, elmJSONs, options);
+
+  // const rootLib = elmJSONs.find(ej => ej.library.identifier == rootLibIdentifier);
+
+  // const { startCql, endCql } = Execution.getCQLIntervalEndpoints(options);
+
+  // // We need a root library to run dataRequirements properly. If we don't have one, error out.
+  // if (!rootLib?.library) {
+  //   throw new UnexpectedResource("root library doesn't contain a library object"); //unexpected resource
+  // }
+
+  // const parameters = { 'Measurement Period': new Interval(startCql, endCql) };
+
+  // const withErrors: GracefulError[] = [];
+  // // get the retrieves for every statement in the root lirbary
+  // const allRetrieves = rootLib.library.statements.def.flatMap(statement => {
+  //   if (statement.expression && statement.name != 'Patient') {
+  //     const retrievesOutput = RetrievesHelper.findRetrieves(rootLib, elmJSONs, statement.expression);
+  //     withErrors.push(...retrievesOutput.withErrors);
+  //     return retrievesOutput.results;
+  //   } else {
+  //     return [] as DataTypeQuery[];
+  //   }
+  // });
+
+  // const allRetrievesPromises = allRetrieves.map(async retrieve => {
+  //   // If the retrieves have a localId for the query and a known library name, we can get more info
+  //   // on how the query filters the sources.
+  //   if (retrieve.queryLocalId && retrieve.queryLibraryName) {
+  //     const library = elmJSONs.find(lib => lib.library.identifier.id === retrieve.queryLibraryName);
+  //     if (library) {
+  //       retrieve.queryInfo = await parseQueryInfo(
+  //         library,
+  //         elmJSONs,
+  //         retrieve.queryLocalId,
+  //         retrieve.valueComparisonLocalId,
+  //         parameters
+  //       );
+  //     }
+  //   }
+  // });
+
+  // await Promise.all(allRetrievesPromises);
+
+  // const results: fhir4.Library = {
+  //   resourceType: 'Library',
+  //   type: { coding: [{ code: 'module-definition', system: 'http://terminology.hl7.org/CodeSystem/library-type' }] },
+  //   status: 'unknown'
+  // };
+  // results.dataRequirement = uniqBy(
+  //   allRetrieves.map(retrieve => {
+  //     const dr = generateDataRequirement(retrieve);
+  //     GapsInCareHelpers.addFiltersToDataRequirement(retrieve, dr, withErrors);
+  //     addFhirQueryPatternToDataRequirements(dr);
+  //     return dr;
+  //   }),
+  //   JSON.stringify
+  // );
+
+  // return {
+  //   results: results,
+  //   debugOutput: {
+  //     cql: cqls,
+  //     elm: elmJSONs,
+  //     gaps: {
+  //       retrieves: allRetrieves
+  //     }
+  //   },
+  //   withErrors
+  // };
+}
+
+/**
  * Get data requirements for this measure
  *
  * @param measureBundle Bundle with a MeasureResource and all necessary data for execution.
@@ -529,74 +622,76 @@ export async function calculateDataRequirements(
   options: CalculationOptions = {}
 ): Promise<DRCalculationOutput> {
   // Extract the library ELM, and the id of the root library, from the measure bundle
-  const { cqls, rootLibIdentifier, elmJSONs } = MeasureBundleHelpers.extractLibrariesFromBundle(measureBundle);
-  const rootLib = elmJSONs.find(ej => ej.library.identifier == rootLibIdentifier);
+  const { cqls, rootLibIdentifier, elmJSONs } = MeasureBundleHelpers.extractLibrariesFromMeasureBundle(measureBundle);
 
-  const { startCql, endCql } = Execution.getCQLIntervalEndpoints(options);
+  return DataRequirementHelpers.getDataRequirements(cqls, rootLibIdentifier, elmJSONs, options);
+  // const rootLib = elmJSONs.find(ej => ej.library.identifier == rootLibIdentifier);
 
-  // We need a root library to run dataRequirements properly. If we don't have one, error out.
-  if (!rootLib?.library) {
-    throw new UnexpectedResource("root library doesn't contain a library object"); //unexpected resource
-  }
+  // const { startCql, endCql } = Execution.getCQLIntervalEndpoints(options);
 
-  const parameters = { 'Measurement Period': new Interval(startCql, endCql) };
-  const withErrors: GracefulError[] = [];
-  // get the retrieves for every statement in the root library
-  const allRetrieves = rootLib.library.statements.def.flatMap(statement => {
-    if (statement.expression && statement.name != 'Patient') {
-      const retrievesOutput = RetrievesHelper.findRetrieves(rootLib, elmJSONs, statement.expression);
-      withErrors.push(...retrievesOutput.withErrors);
-      return retrievesOutput.results;
-    } else {
-      return [] as DataTypeQuery[];
-    }
-  });
+  // // We need a root library to run dataRequirements properly. If we don't have one, error out.
+  // if (!rootLib?.library) {
+  //   throw new UnexpectedResource("root library doesn't contain a library object"); //unexpected resource
+  // }
 
-  const allRetrievesPromises = allRetrieves.map(async retrieve => {
-    // If the retrieves have a localId for the query and a known library name, we can get more info
-    // on how the query filters the sources.
-    if (retrieve.queryLocalId && retrieve.queryLibraryName) {
-      const library = elmJSONs.find(lib => lib.library.identifier.id === retrieve.queryLibraryName);
-      if (library) {
-        retrieve.queryInfo = await parseQueryInfo(
-          library,
-          elmJSONs,
-          retrieve.queryLocalId,
-          retrieve.valueComparisonLocalId,
-          parameters
-        );
-      }
-    }
-  });
+  // const parameters = { 'Measurement Period': new Interval(startCql, endCql) };
+  // const withErrors: GracefulError[] = [];
+  // // get the retrieves for every statement in the root library
+  // const allRetrieves = rootLib.library.statements.def.flatMap(statement => {
+  //   if (statement.expression && statement.name != 'Patient') {
+  //     const retrievesOutput = RetrievesHelper.findRetrieves(rootLib, elmJSONs, statement.expression);
+  //     withErrors.push(...retrievesOutput.withErrors);
+  //     return retrievesOutput.results;
+  //   } else {
+  //     return [] as DataTypeQuery[];
+  //   }
+  // });
 
-  await Promise.all(allRetrievesPromises);
+  // const allRetrievesPromises = allRetrieves.map(async retrieve => {
+  //   // If the retrieves have a localId for the query and a known library name, we can get more info
+  //   // on how the query filters the sources.
+  //   if (retrieve.queryLocalId && retrieve.queryLibraryName) {
+  //     const library = elmJSONs.find(lib => lib.library.identifier.id === retrieve.queryLibraryName);
+  //     if (library) {
+  //       retrieve.queryInfo = await parseQueryInfo(
+  //         library,
+  //         elmJSONs,
+  //         retrieve.queryLocalId,
+  //         retrieve.valueComparisonLocalId,
+  //         parameters
+  //       );
+  //     }
+  //   }
+  // });
 
-  const results: fhir4.Library = {
-    resourceType: 'Library',
-    type: { coding: [{ code: 'module-definition', system: 'http://terminology.hl7.org/CodeSystem/library-type' }] },
-    status: 'unknown'
-  };
-  results.dataRequirement = uniqBy(
-    allRetrieves.map(retrieve => {
-      const dr = generateDataRequirement(retrieve);
-      GapsInCareHelpers.addFiltersToDataRequirement(retrieve, dr, withErrors);
-      addFhirQueryPatternToDataRequirements(dr);
-      return dr;
-    }),
-    JSON.stringify
-  );
+  // await Promise.all(allRetrievesPromises);
 
-  return {
-    results: results,
-    debugOutput: {
-      cql: cqls,
-      elm: elmJSONs,
-      gaps: {
-        retrieves: allRetrieves
-      }
-    },
-    withErrors
-  };
+  // const results: fhir4.Library = {
+  //   resourceType: 'Library',
+  //   type: { coding: [{ code: 'module-definition', system: 'http://terminology.hl7.org/CodeSystem/library-type' }] },
+  //   status: 'unknown'
+  // };
+  // results.dataRequirement = uniqBy(
+  //   allRetrieves.map(retrieve => {
+  //     const dr = generateDataRequirement(retrieve);
+  //     GapsInCareHelpers.addFiltersToDataRequirement(retrieve, dr, withErrors);
+  //     addFhirQueryPatternToDataRequirements(dr);
+  //     return dr;
+  //   }),
+  //   JSON.stringify
+  // );
+
+  // return {
+  //   results: results,
+  //   debugOutput: {
+  //     cql: cqls,
+  //     elm: elmJSONs,
+  //     gaps: {
+  //       retrieves: allRetrieves
+  //     }
+  //   },
+  //   withErrors
+  // };
 }
 
 /**
@@ -610,7 +705,7 @@ export async function calculateQueryInfo(
   options: CalculationOptions = {}
 ): Promise<QICalculationOutput> {
   // Extract the library ELM, and the id of the root library, from the measure bundle
-  const { cqls, rootLibIdentifier, elmJSONs } = MeasureBundleHelpers.extractLibrariesFromBundle(measureBundle);
+  const { cqls, rootLibIdentifier, elmJSONs } = MeasureBundleHelpers.extractLibrariesFromMeasureBundle(measureBundle);
   const rootLib = elmJSONs.find(ej => ej.library.identifier == rootLibIdentifier);
   const { startCql, endCql } = Execution.getCQLIntervalEndpoints(options);
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -77,7 +77,7 @@ program
     '-o, --out-file [file-path]',
     'Path to a file that fqm-execution will write the calculation results to (default: output.json)'
   )
-  .option('--root-lib-ref <url>', 'Url for the root library', undefined)
+  .option('--root-lib-ref <root-lib-ref>', 'Reference to the root library', undefined)
   .parse(process.argv);
 
 function parseBundle(filePath: string): fhir4.Bundle {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -119,6 +119,7 @@ async function calc(
   } else if (program.outputType === 'dataRequirements') {
     result = calculateDataRequirements(measureBundle, calcOptions);
   } else if (program.outputType === 'libraryDataRequirements') {
+    // in this case, measureBundle should be a library bundle
     result = calculateLibraryDataRequirements(measureBundle, calcOptions);
   } else if (program.outputType === 'queryInfo') {
     // calculateQueryInfo doesn't make use of the calcOptions object at this point

--- a/src/helpers/DataRequirementHelpers.ts
+++ b/src/helpers/DataRequirementHelpers.ts
@@ -60,7 +60,7 @@ export async function getDataRequirements(
 
   // We need a root library to run dataRequirements properly. If we don't have one, error out.
   if (!rootLib?.library) {
-    throw new UnexpectedResource("root library doesn't contain a library object"); //unexpected resource
+    throw new UnexpectedResource("root library doesn't contain a library object");
   }
 
   const parameters = { 'Measurement Period': new Interval(startCql, endCql) };

--- a/src/helpers/DataRequirementHelpers.ts
+++ b/src/helpers/DataRequirementHelpers.ts
@@ -46,7 +46,7 @@ export function flattenFilters(filter: AnyFilter): AnyFilter[] {
 }
 
 /**
- * Returns a
+ * Returns a FHIR library containing data requirements, given a root library
  */
 export async function getDataRequirements(
   cqls: ExtractedLibrary[],

--- a/src/helpers/MeasureBundleHelpers.ts
+++ b/src/helpers/MeasureBundleHelpers.ts
@@ -225,7 +225,7 @@ export function extractLibrariesFromLibraryBundle(
   const { cqls, rootLibIdentifier, elmJSONs } = extractLibrariesFromBundle(libraryBundle, rootLibId);
 
   if (rootLibIdentifier.id === '') {
-    throw new UnexpectedResource('No Root Library could be identified in provided measure bundle');
+    throw new UnexpectedResource('No Root Library could be identified in provided library bundle');
   }
 
   return { cqls, rootLibIdentifier, elmJSONs };

--- a/src/helpers/MeasureBundleHelpers.ts
+++ b/src/helpers/MeasureBundleHelpers.ts
@@ -206,17 +206,43 @@ export function isValidLibraryURL(libraryName: string) {
   return r.test(libraryName);
 }
 
-export function extractLibrariesFromBundle(measureBundle: fhir4.Bundle): {
+/**
+ * Returns the cqls, rootLibIdentifier, and elmJSONs for a collection of libraries
+ * within a Library Bundle
+ */
+export function extractLibrariesFromLibraryBundle(
+  libraryBundle: fhir4.Bundle,
+  rootLibRef: string
+): {
   cqls: ExtractedLibrary[];
   rootLibIdentifier: ELMIdentifier;
   elmJSONs: ELM[];
 } {
-  const measure = extractMeasureFromBundle(measureBundle);
-  const rootLibRef = measure.library[0];
   let rootLibId: string;
   if (isValidLibraryURL(rootLibRef)) rootLibId = rootLibRef;
   else rootLibId = rootLibRef.substring(rootLibRef.indexOf('/') + 1);
 
+  const { cqls, rootLibIdentifier, elmJSONs } = extractLibrariesFromBundle(libraryBundle, rootLibId);
+
+  if (rootLibIdentifier.id === '') {
+    throw new UnexpectedResource('No Root Library could be identified in provided measure bundle');
+  }
+
+  return { cqls, rootLibIdentifier, elmJSONs };
+}
+
+/**
+ * Returns the cqls, rootLibIdentifier, and elmJSONs for a collection of libraries
+ * within a Bundle
+ */
+export function extractLibrariesFromBundle(
+  bundle: fhir4.Bundle,
+  rootLibId: string
+): {
+  cqls: ExtractedLibrary[];
+  rootLibIdentifier: ELMIdentifier;
+  elmJSONs: ELM[];
+} {
   const libraries: fhir4.Library[] = [];
   const elmJSONs: ELM[] = [];
   const cqls: { name: string; cql: string }[] = [];
@@ -224,7 +250,7 @@ export function extractLibrariesFromBundle(measureBundle: fhir4.Bundle): {
     id: '',
     version: ''
   };
-  measureBundle.entry?.forEach(e => {
+  bundle.entry?.forEach(e => {
     if (e.resource?.resourceType == 'Library') {
       const library = e.resource as fhir4.Library;
       libraries.push(library);
@@ -262,6 +288,25 @@ export function extractLibrariesFromBundle(measureBundle: fhir4.Bundle): {
       });
     }
   });
+  return { cqls, rootLibIdentifier, elmJSONs };
+}
+
+/**
+ * Returns the cqls, rootLibIdentifier, and elmJSONs for a collection of libraries
+ * within a Measure Bundle
+ */
+export function extractLibrariesFromMeasureBundle(measureBundle: fhir4.Bundle): {
+  cqls: ExtractedLibrary[];
+  rootLibIdentifier: ELMIdentifier;
+  elmJSONs: ELM[];
+} {
+  const measure = extractMeasureFromBundle(measureBundle);
+  const rootLibRef = measure.library[0];
+  let rootLibId: string;
+  if (isValidLibraryURL(rootLibRef)) rootLibId = rootLibRef;
+  else rootLibId = rootLibRef.substring(rootLibRef.indexOf('/') + 1);
+
+  const { cqls, rootLibIdentifier, elmJSONs } = extractLibrariesFromBundle(measureBundle, rootLibId);
 
   if (rootLibIdentifier.id === '') {
     throw new UnexpectedResource('No Root Library could be identified in provided measure bundle');

--- a/src/helpers/elm/ELMInfoCache.ts
+++ b/src/helpers/elm/ELMInfoCache.ts
@@ -45,7 +45,7 @@ export function retrieveELMInfo(
   if (!(ELMInfoCache.get(key) && cacheEntryIsValid(ELMInfoCache.get(key)?.lastAccessed))) {
     const vsMap = valueSetsForCodeService(valueSets);
 
-    const { cqls, rootLibIdentifier, elmJSONs } = MeasureBundleHelpers.extractLibrariesFromBundle(measureBundle);
+    const { cqls, rootLibIdentifier, elmJSONs } = MeasureBundleHelpers.extractLibrariesFromMeasureBundle(measureBundle);
 
     // add expressions for collecting for all measure observations
     measure.group?.forEach(group => {

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -42,6 +42,8 @@ export interface CalculationOptions {
   useElmJsonsCaching?: boolean;
   /** if true, clears ElmJsons cache before running calculation */
   clearElmJsonsCache?: boolean;
+  /** Root lib ref, to be used in calculateLibraryDataRequirements */
+  rootLibRef?: string;
 }
 
 /**

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -42,7 +42,7 @@ export interface CalculationOptions {
   useElmJsonsCaching?: boolean;
   /** if true, clears ElmJsons cache before running calculation */
   clearElmJsonsCache?: boolean;
-  /** Root lib ref, to be used in calculateLibraryDataRequirements */
+  /** Reference to root library (should be a canonical URL but resource ID will work if matching one exists in the bundle), to be used in calculateLibraryDataRequirements */
   rootLibRef?: string;
 }
 

--- a/test/unit/helpers/ELMInfoCache.test.ts
+++ b/test/unit/helpers/ELMInfoCache.test.ts
@@ -11,14 +11,14 @@ describe('ELMInfoCache tests', () => {
   });
   test('retrieves elm info when useElmJsonsCaching set to false', () => {
     const elfbSpy = jest
-      .spyOn(MeasureBundleHelpers, 'extractLibrariesFromBundle')
+      .spyOn(MeasureBundleHelpers, 'extractLibrariesFromMeasureBundle')
       .mockImplementation(() => TEST_ELFB_OUTPUT);
     retrieveELMInfo(MEASURE as fhir4.Measure, MEASURE_BUNDLE as fhir4.Bundle, [], false);
     expect(elfbSpy).toHaveBeenCalledTimes(1);
   });
   test('does not retrieve elm info on second call when useElmJsonsCaching set to true', () => {
     const elfbSpy = jest
-      .spyOn(MeasureBundleHelpers, 'extractLibrariesFromBundle')
+      .spyOn(MeasureBundleHelpers, 'extractLibrariesFromMeasureBundle')
       .mockImplementation(() => TEST_ELFB_OUTPUT);
     retrieveELMInfo(MEASURE as fhir4.Measure, MEASURE_BUNDLE as fhir4.Bundle, [], true);
     expect(elfbSpy).toHaveBeenCalledTimes(1);
@@ -27,7 +27,7 @@ describe('ELMInfoCache tests', () => {
   });
   test('retrieves elm info when useElmJsonsCaching set to true and last entry over 10 minutes ago', () => {
     const elfbSpy = jest
-      .spyOn(MeasureBundleHelpers, 'extractLibrariesFromBundle')
+      .spyOn(MeasureBundleHelpers, 'extractLibrariesFromMeasureBundle')
       .mockImplementation(() => TEST_ELFB_OUTPUT);
     jest.useFakeTimers('modern').setSystemTime(new Date('2020-01-01T00:00:00'));
     retrieveELMInfo(MEASURE as fhir4.Measure, MEASURE_BUNDLE as fhir4.Bundle, [], true);

--- a/test/unit/helpers/MeasureBundleHelpers.test.ts
+++ b/test/unit/helpers/MeasureBundleHelpers.test.ts
@@ -812,6 +812,39 @@ describe('MeasureBundleHelpers tests', () => {
       expect(cqls).toHaveLength(6);
       expect(elmJSONs).toHaveLength(6);
     });
+
+    it('throws an error if there is no root Library resource in the Library bundle', () => {
+      const libraryBundle: fhir4.Bundle = {
+        resourceType: 'Bundle',
+        entry: [
+          {
+            resource: {
+              resourceType: 'Library',
+              type: {
+                coding: [{ code: 'module-definition', system: 'http://terminology.hl7.org/CodeSystem/library-type' }]
+              },
+              url: 'http://example.com/library',
+              status: 'draft'
+            }
+          },
+          {
+            resource: {
+              resourceType: 'Library',
+              type: {
+                coding: [{ code: 'module-definition', system: 'http://terminology.hl7.org/CodeSystem/library-type' }]
+              },
+              url: 'http://example.com/other-library',
+              status: 'draft'
+            }
+          }
+        ],
+        type: 'transaction'
+      };
+
+      expect(() => extractLibrariesFromLibraryBundle(libraryBundle, 'http://example.com/root-library')).toThrow(
+        'No Root Library could be identified in provided library bundle'
+      );
+    });
   });
 
   describe('extractLibrariesFromMeasureBundle', () => {

--- a/test/unit/helpers/MeasureBundleHelpers.test.ts
+++ b/test/unit/helpers/MeasureBundleHelpers.test.ts
@@ -790,7 +790,7 @@ describe('MeasureBundleHelpers tests', () => {
   });
 
   describe('extractLibrariesFromLibraryBundle', () => {
-    it('properly gets libraries from EXM130 library bundle', () => {
+    it('properly gets libraries from EXM130 library bundle using resourceID for rootLibRef', () => {
       const measureBundle = getJSONFixture('EXM130-7.3.000-bundle-nocodes.json') as fhir4.Bundle;
       const libraryBundle: fhir4.Bundle = {
         resourceType: 'Bundle',
@@ -800,6 +800,29 @@ describe('MeasureBundleHelpers tests', () => {
       libraryBundle.entry = measureBundle.entry?.filter(e => e.resource?.resourceType === 'Library');
 
       const rootLibRef = 'Library/library-EXM130-7.3.000';
+      const { cqls, rootLibIdentifier, elmJSONs } = extractLibrariesFromLibraryBundle(libraryBundle, rootLibRef);
+
+      expect(rootLibIdentifier).toStrictEqual({
+        id: 'EXM130',
+        system: 'http://fhir.org/guides/dbcg/connectathon',
+        version: '7.3.000'
+      });
+      // The EXM130 test bundle has 7 libraries, including the root one
+      // BUT one of them is the FHIR model info file, which we ignore
+      expect(cqls).toHaveLength(6);
+      expect(elmJSONs).toHaveLength(6);
+    });
+
+    it('properly gets libraries from EXM130 library bundle using canonical URL for rootLibRef', () => {
+      const measureBundle = getJSONFixture('EXM130-7.3.000-bundle-nocodes.json') as fhir4.Bundle;
+      const libraryBundle: fhir4.Bundle = {
+        resourceType: 'Bundle',
+        id: 'EXM130-7.3.000-bundle',
+        type: 'transaction'
+      };
+      libraryBundle.entry = measureBundle.entry?.filter(e => e.resource?.resourceType === 'Library');
+
+      const rootLibRef = 'http://fhir.org/guides/dbcg/connectathon/Library/EXM130';
       const { cqls, rootLibIdentifier, elmJSONs } = extractLibrariesFromLibraryBundle(libraryBundle, rootLibRef);
 
       expect(rootLibIdentifier).toStrictEqual({


### PR DESCRIPTION
# Summary
Before, we had only the option to calculate dataRequirements on a measure bundle. Now, we can calculate dataRequirements on a collection of Library resources (library bundle). This will be helpful when we implement Library/$data-requirements in the measure-repository-service.

## New behavior
New function in `Calculator.ts` calculates library dataRequirements from a Library bundle. This is in addition to the calculateDataRequirements function that calculates the dataRequirements on a measure bundle.

## Code changes
- `src/calculation/Calculator.ts` - new function `calculateLibrarydataRequirements` gets data requirements for a collection of Library resources. A lot of this code was identical to that in `calculateDataRequirements` but we wanted them to be separate functions so I refactored the duplicate code into a function in `DataRequirementHelpers.ts`.
- `src/cli.ts` - new cli option to run `libraryDataRequirements` with a flag with the `rootLibRef`.
- `src/helpers/DataRequirementHelpers.ts` - refactored a lot of the identical code in `calculateDataRequirements` and `calculateLibraryDataRequirements` to the `getDataRequirements` function.
- `src/helpers/MeasureBundleHelpers.ts` - `extractLibrariesFromLibraryBundle` gets libraries from a library bundle and `extractLibrariesFromMeasureBundle` gets libraries from a measure bundle. They both use `extractLibrariesFromBundle` because a lot of the code was the same. The main difference is that `extractLibrariesFromLibraryBundle` has to take a reference to the root library as a parameter, since there is no measure on the bundle to indicate the root library like in `extractLibrariesFromMeasureBundle`.
- `src/helpers/elm/ELMInfoCache.ts` - changed `extractLibrariesFromBundle` to `extractLibrariesFromMeasureBundle`.
- `src/types/Calculator.ts` - added `rootLibRef` as an optional CalculationOption which we need in `libraryDataRequirements` in the cli.
- `test/unit/helpers/ELMInfoCache.test.ts` - changed `extractLibrariesFromBundle` to `extractLibrariesFromMeasureBundle`.
- `test/unit/helpers/MeasureBundleHelpers.test.ts` - added a test for `extractLibrariesFromLibraryBundle`. This uses the `ELM130-7.3.000-bundles-nocodes.json` fixture that we already have but filters is so that it is a bundle of only its library resources. 

# Testing guidance
- `npm run check`
- Try the new cli command! 
- My motivation behind this test is I want to take a measure bundle and run dataRequirements on it. Then, I want to take that same measure bundle, but remove all resources that are not of type Library. Finally, I run libraryDataRequirements on that library bundle and then compare the two outputs. They should be the same.
- With this approach, I used the `EXM130-7.3.000-bundle-nocodes.json` fixture because it is there. I suggest you do the same since I attached that file and the one with only the library resources below, but feel free to try other bundles!
- `npm run cli -- dataRequirements -m <path-to-EXM130-7.3.000-bundle-nocodes.json> -o` 
- Save that `output.json` file
- `npm run cli -- libraryDataRequirements -m <path-to-EXM130.7.3.000-library-nocodes.json --root-lib-ref "Library-library-EXM130-7.3.000 -o`
- Save that `output.json` file.
- Compare the two files and make sure they are the same!


[LibraryDataRequirementsTestFiles.zip](https://github.com/projecttacoma/fqm-execution/files/10362517/LibraryDataRequirementsTestFiles.zip)
