### PR TITLE
Upgrade cql-execution; Fix VSAC and ts-node config

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ Optionally, you can install the `ts-node` utility globally to execute the TypeSc
 
 ```bash
 npm install -g ts-node
-ts-node --files src/cli.ts [command] [options]
+ts-node src/cli.ts [command] [options]
 ```
 
 ### Debug Option

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "axios": "^0.21.1",
         "commander": "^6.1.0",
         "cql-exec-fhir": "^2.1.3",
-        "cql-execution": "^3.0.0-beta.2",
+        "cql-execution": "^3.0.0-beta.3",
         "handlebars": "^4.7.7",
         "lodash": "^4.17.21",
         "moment": "^2.29.4",
@@ -2382,12 +2382,13 @@
       }
     },
     "node_modules/cql-execution": {
-      "version": "3.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.0-beta.2.tgz",
-      "integrity": "sha512-rpBUkUotVAUfz73HGF+Vs1UItULuZcEGmAwHkPxCpWEUXXVKWL7Dc9vPbRu5lCteMovKSJDSZsK+jHqDd+iYhQ==",
+      "version": "3.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.0-beta.3.tgz",
+      "integrity": "sha512-Mcr3vUilXfnz2qooyKzKZT3lexWTo/U7ktwt3DXnAFfsKfCYBe4zHyGv9ThRwW7OFMM/mr5LmM4szbm2StSfZw==",
       "dependencies": {
         "@lhncbc/ucum-lhc": "^4.1.3",
-        "luxon": "^1.25.0"
+        "immutable": "^4.1.0",
+        "luxon": "^1.28.1"
       }
     },
     "node_modules/cql-translation-service-client": {
@@ -3856,6 +3857,11 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immutable": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.2.2.tgz",
+      "integrity": "sha512-fTMKDwtbvO5tldky9QZ2fMX7slR0mYpY5nbnFWYp0fOzDhHqhgIw9KoYgxLWsoNTS9ZHGauHj18DTyEw6BK3Og=="
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -5236,9 +5242,9 @@
       }
     },
     "node_modules/luxon": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.0.tgz",
-      "integrity": "sha512-TfTiyvZhwBYM/7QdAVDh+7dBTBA29v4ik0Ce9zda3Mnf8on1S5KJI8P2jKFZ8+5C0jhmr0KwJEO/Wdpm0VeWJQ==",
+      "version": "1.28.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.1.tgz",
+      "integrity": "sha512-gYHAa180mKrNIUJCbwpmD0aTu9kV0dREDrwNnuyFAsO1Wt0EVYSZelPnJlbj9HplzXX/YWXHFTL45kvZ53M0pw==",
       "engines": {
         "node": "*"
       }
@@ -10102,12 +10108,13 @@
       }
     },
     "cql-execution": {
-      "version": "3.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.0-beta.2.tgz",
-      "integrity": "sha512-rpBUkUotVAUfz73HGF+Vs1UItULuZcEGmAwHkPxCpWEUXXVKWL7Dc9vPbRu5lCteMovKSJDSZsK+jHqDd+iYhQ==",
+      "version": "3.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.0-beta.3.tgz",
+      "integrity": "sha512-Mcr3vUilXfnz2qooyKzKZT3lexWTo/U7ktwt3DXnAFfsKfCYBe4zHyGv9ThRwW7OFMM/mr5LmM4szbm2StSfZw==",
       "requires": {
         "@lhncbc/ucum-lhc": "^4.1.3",
-        "luxon": "^1.25.0"
+        "immutable": "^4.1.0",
+        "luxon": "^1.28.1"
       }
     },
     "cql-translation-service-client": {
@@ -11231,6 +11238,11 @@
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
       "dev": true
     },
+    "immutable": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.2.2.tgz",
+      "integrity": "sha512-fTMKDwtbvO5tldky9QZ2fMX7slR0mYpY5nbnFWYp0fOzDhHqhgIw9KoYgxLWsoNTS9ZHGauHj18DTyEw6BK3Og=="
+    },
     "import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -12261,9 +12273,9 @@
       }
     },
     "luxon": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.0.tgz",
-      "integrity": "sha512-TfTiyvZhwBYM/7QdAVDh+7dBTBA29v4ik0Ce9zda3Mnf8on1S5KJI8P2jKFZ8+5C0jhmr0KwJEO/Wdpm0VeWJQ=="
+      "version": "1.28.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.1.tgz",
+      "integrity": "sha512-gYHAa180mKrNIUJCbwpmD0aTu9kV0dREDrwNnuyFAsO1Wt0EVYSZelPnJlbj9HplzXX/YWXHFTL45kvZ53M0pw=="
     },
     "make-dir": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "axios": "^0.21.1",
     "commander": "^6.1.0",
     "cql-exec-fhir": "^2.1.3",
-    "cql-execution": "^3.0.0-beta.2",
+    "cql-execution": "^3.0.0-beta.3",
     "handlebars": "^4.7.7",
     "lodash": "^4.17.21",
     "moment": "^2.29.4",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "build": "tsc",
     "build:watch": "tsc -w",
     "build:test-data": "cd test/integration && make",
-    "cli": "ts-node --files src/cli.ts",
+    "cli": "ts-node src/cli.ts",
     "coverage": "opener coverage/lcov-report/index.html",
     "lint": "tsc && eslint \"**/*.{js,ts}\"",
     "lint:fix": "tsc --noEmit && eslint \"**/*.{js,ts}\" --quiet --fix",

--- a/src/execution/VSACHelper.ts
+++ b/src/execution/VSACHelper.ts
@@ -1,7 +1,8 @@
 const VSAC_REGEX = /http:\/\/cts\.nlm\.nih\.gov.*ValueSet/;
 const OID_REGEX = /([0-9]+\.)+[0-9]+/;
 
-export const VSAC_BASE = 'http://cts.nlm.nih.gov/fhir/r4/ValueSet';
+// Base URL for current version can be found at https://www.nlm.nih.gov/vsac/support/usingvsac/vsacfhirapi.html
+export const VSAC_BASE = 'http://cts.nlm.nih.gov/fhir/ValueSet';
 
 export function isVSACUrl(url: string): boolean {
   return VSAC_REGEX.test(url);

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,4 +4,5 @@ export * as ELMHelpers from './helpers/elm/ELMHelpers';
 export * as ELMDependencyHelpers from './helpers/elm/ELMDependencyHelpers';
 export * as MeasureBundleHelpers from './helpers/MeasureBundleHelpers';
 export * as RetrievesFinder from './gaps/RetrievesFinder';
+export { ValueSetResolver } from './execution/ValueSetResolver';
 export * from './types';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,8 @@
     "declaration": true,
     "sourceMap": true,
     "moduleResolution": "node"
+  },
+  "ts-node": {
+    "files": true
   }
 }


### PR DESCRIPTION
# Summary

Fixes #172 

This PR exposes the ValueSetResolver class that we use as an export from `fqm-execution` so it can be used in other libraries (main use case was use of it within a FHIR server). VSAC also changed their base URL recently for the FHIR API so I updated that too. I also updated the ts-node config to no longer require the use of `--files` option when testing the CLI

## New behavior

* Fixes issue brought up in #172 by upgrading the version of cql-execution (actual bug was fixed in https://github.com/cqframework/cql-execution/pull/306 thanks to @cmoesel)

## Code changes

* Upgrade cql-execution dependency
* Export ValueSetResolver from index.ts
* Fix canonical URL used for all VSAC requests, and included a link to where that URL is specified in case it breaks again in the future
* Move the `ts-node --files` option to `tsconfig` and update docs

# Testing guidance

Mainly just make sure the `npm run cli` command or using `ts-node` directly works without passing in the `--files` option. You can test valueset resolution if you want.
