### PR TITLE
Independent numer/denom for ratio measures

### DIFF
--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -110,6 +110,10 @@ export async function calculate<T extends CalculationOptions>(
     // iterator to use for group ID if they are defined in the population groups
     let i = 1;
 
+    // use scoring code from measure as a fallback when building population group
+    // relevance map (if scoring code is not present at the group level)
+    const measureScoringCode = MeasureBundleHelpers.getScoringCodeFromMeasure(measure);
+
     // Iterate over measure population groups
     measure.group?.forEach(group => {
       // build initial results set with population values
@@ -123,6 +127,7 @@ export async function calculate<T extends CalculationOptions>(
       // get the relevance information for each population
       detailedGroupResult.populationRelevance = ResultsHelpers.buildPopulationGroupRelevanceMap(
         detailedGroupResult,
+        measureScoringCode,
         group
       );
 

--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -127,8 +127,8 @@ export async function calculate<T extends CalculationOptions>(
       // get the relevance information for each population
       detailedGroupResult.populationRelevance = ResultsHelpers.buildPopulationGroupRelevanceMap(
         detailedGroupResult,
-        measureScoringCode,
-        group
+        group,
+        measureScoringCode
       );
 
       // use relevance info to fill out statement relevance information and create initial statementResults structure

--- a/src/calculation/ClauseResultsBuilder.ts
+++ b/src/calculation/ClauseResultsBuilder.ts
@@ -589,15 +589,15 @@ export function doesResultPass(result: any | null): boolean {
  * together so that a patient level population relevance set can be made.
  *
  * @private
- * @param {fhir4.MeasureGroup} populationGroup population group from measure
  * @param {EpisodeResults[]} episodeResultsSet - Results for each episode
- * @param {string | null} measureScoringCode scoring code for measure (used if scoring code not provided at the group level)
+ * @param {fhir4.MeasureGroup} populationGroup population group from measure
+ * @param {string} measureScoringCode scoring code for measure (used if scoring code not provided at the group level)
  * @returns {PopulationResult[]} List denoting if population calculation was considered/relevant in any episode
  */
 export function buildPopulationRelevanceForAllEpisodes(
-  populationGroup: fhir4.MeasureGroup,
   episodeResultsSet: EpisodeResults[],
-  measureScoringCode: string | null
+  populationGroup: fhir4.MeasureGroup,
+  measureScoringCode?: string
 ): PopulationResult[] {
   const masterRelevanceResults: PopulationResult[] =
     populationGroup.population?.map(population => {
@@ -611,8 +611,8 @@ export function buildPopulationRelevanceForAllEpisodes(
   episodeResultsSet.forEach(episodeResults => {
     const episodeRelevance = buildPopulationRelevanceMap(
       episodeResults.populationResults,
-      measureScoringCode,
-      populationGroup
+      populationGroup,
+      measureScoringCode
     );
     masterRelevanceResults.forEach(masterPopResults => {
       // find relevance in episode and if true, make master relevance true, only if not already true
@@ -653,14 +653,14 @@ export function buildPopulationRelevanceForAllEpisodes(
  * was kept to make it more maintainable.
  *
  * @param {PopulationResult[]} results - The population results list for the population results.
- * @param {string | null} measureScoringCode scoring code for measure (used if scoring code not provided at the group level)
  * @param {fhir4.MeasureGroup} group - The full group of the Measure, which is useful for resolving references between different populations
+ * @param {string} measureScoringCode scoring code for measure (used if scoring code not provided at the group level)
  * @returns {PopulationResult[]} The population relevance set.
  */
 export function buildPopulationRelevanceMap(
   results: PopulationResult[],
-  measureScoringCode: string | null,
-  group?: fhir4.MeasureGroup
+  group?: fhir4.MeasureGroup,
+  measureScoringCode?: string
 ): PopulationResult[] {
   // Create initial results starting with all true to create the basis for relevance.
   const relevantResults: PopulationResult[] = results.map(result => {
@@ -810,16 +810,16 @@ export function buildPopulationRelevanceMap(
 
 export function buildPopulationGroupRelevanceMap(
   results: DetailedPopulationGroupResult,
-  measureScoringCode: string | null,
-  group: fhir4.MeasureGroup
+  group: fhir4.MeasureGroup,
+  measureScoringCode?: string
 ): PopulationResult[] {
   // Episode of care measure
   if (results.episodeResults) {
-    return buildPopulationRelevanceForAllEpisodes(group, results.episodeResults, measureScoringCode);
+    return buildPopulationRelevanceForAllEpisodes(results.episodeResults, group, measureScoringCode);
 
     // Normal patient based measure
   } else if (results.populationResults) {
-    return buildPopulationRelevanceMap(results.populationResults, measureScoringCode, group);
+    return buildPopulationRelevanceMap(results.populationResults, group, measureScoringCode);
   } else {
     // this shouldn't happen
     return [];

--- a/src/calculation/ClauseResultsBuilder.ts
+++ b/src/calculation/ClauseResultsBuilder.ts
@@ -6,7 +6,7 @@ import * as cql from '../types/CQLTypes';
 import { Interval, DateTime, Code, Quantity } from 'cql-execution';
 import moment from 'moment';
 
-import { FinalResult, MeasureScoreType, PopulationType, Relevance } from '../types/Enums';
+import { FinalResult, PopulationType, Relevance } from '../types/Enums';
 import {
   ClauseResult,
   DetailedPopulationGroupResult,
@@ -729,13 +729,7 @@ export function buildPopulationRelevanceMap(
   // If DENOM is false then DENEX, DENEXCEP, NUMER and NUMEX are not calculated
   if (hasResult(PopulationType.DENOM, results) && getResult(PopulationType.DENOM, results) === false) {
     // Do not apply this to ratio measures (numerator and denominator are independent from each other)
-    if (
-      !(
-        group &&
-        (MeasureBundleHelpers.getScoringCodeFromGroup(group) === MeasureScoreType.RATIO ||
-          measureScoringCode === MeasureScoreType.RATIO)
-      )
-    ) {
+    if (!MeasureBundleHelpers.isRatioMeasure(group, measureScoringCode)) {
       if (hasResult(PopulationType.NUMER, relevantResults)) {
         setResult(PopulationType.NUMER, false, relevantResults);
       }
@@ -754,13 +748,7 @@ export function buildPopulationRelevanceMap(
   // If DENEX is true then NUMER, NUMEX and DENEXCEP not calculated
   if (hasResult(PopulationType.DENEX, results) && getResult(PopulationType.DENEX, results) === true) {
     // Do not apply this to ratio measures (numerator and denominator are independent from each other)
-    if (
-      !(
-        group &&
-        (MeasureBundleHelpers.getScoringCodeFromGroup(group) === MeasureScoreType.RATIO ||
-          measureScoringCode === MeasureScoreType.RATIO)
-      )
-    ) {
+    if (!MeasureBundleHelpers.isRatioMeasure(group, measureScoringCode)) {
       if (hasResult(PopulationType.NUMER, relevantResults)) {
         setResult(PopulationType.NUMER, false, relevantResults);
       }

--- a/src/calculation/ClauseResultsBuilder.ts
+++ b/src/calculation/ClauseResultsBuilder.ts
@@ -769,6 +769,7 @@ export function buildPopulationRelevanceMap(
   }
 
   // If NUMER is true then DENEXCEP is not calculated
+  // Do not apply this to ratio measures (numerator and denominator are independent from each other)
   if (
     hasResult(PopulationType.NUMER, results) &&
     getResult(PopulationType.NUMER, results) === true &&

--- a/src/calculation/ClauseResultsBuilder.ts
+++ b/src/calculation/ClauseResultsBuilder.ts
@@ -769,7 +769,11 @@ export function buildPopulationRelevanceMap(
   }
 
   // If NUMER is true then DENEXCEP is not calculated
-  if (hasResult(PopulationType.NUMER, results) && getResult(PopulationType.NUMER, results) === true) {
+  if (
+    hasResult(PopulationType.NUMER, results) &&
+    getResult(PopulationType.NUMER, results) === true &&
+    !MeasureBundleHelpers.isRatioMeasure(group, measureScoringCode)
+  ) {
     if (hasResult(PopulationType.DENEXCEP, relevantResults)) {
       setResult(PopulationType.DENEXCEP, false, relevantResults);
     }

--- a/src/calculation/ClauseResultsBuilder.ts
+++ b/src/calculation/ClauseResultsBuilder.ts
@@ -590,8 +590,8 @@ export function doesResultPass(result: any | null): boolean {
  *
  * @private
  * @param {EpisodeResults[]} episodeResultsSet - Results for each episode
- * @param {fhir4.MeasureGroup} populationGroup population group from measure
- * @param {string} measureScoringCode scoring code for measure (used if scoring code not provided at the group level)
+ * @param {fhir4.MeasureGroup} populationGroup - The population group from the measure
+ * @param {string} measureScoringCode - The scoring code for the measure (used if scoring code not provided at the group level)
  * @returns {PopulationResult[]} List denoting if population calculation was considered/relevant in any episode
  */
 export function buildPopulationRelevanceForAllEpisodes(
@@ -654,7 +654,7 @@ export function buildPopulationRelevanceForAllEpisodes(
  *
  * @param {PopulationResult[]} results - The population results list for the population results.
  * @param {fhir4.MeasureGroup} group - The full group of the Measure, which is useful for resolving references between different populations
- * @param {string} measureScoringCode scoring code for measure (used if scoring code not provided at the group level)
+ * @param {string} measureScoringCode - The scoring code for measure (used if scoring code not provided at the group level)
  * @returns {PopulationResult[]} The population relevance set.
  */
 export function buildPopulationRelevanceMap(
@@ -796,6 +796,15 @@ export function buildPopulationRelevanceMap(
   return relevantResults;
 }
 
+/**
+ * Wrapper function that builds population relevance either for all episodes (if the measure is episode-based) or for each
+ * population (if patient-based).
+ * @param results - The detailed results (used to pull off episode results for episode of care measure, or population results for
+ * patient-based measure)
+ * @param group - The full group of the Measure
+ * @param measureScoringCode - The scoring code for measure (used if scoring code not provided at the group level)
+ * @returns The population relevance set.
+ */
 export function buildPopulationGroupRelevanceMap(
   results: DetailedPopulationGroupResult,
   group: fhir4.MeasureGroup,

--- a/src/calculation/DetailedResultsBuilder.ts
+++ b/src/calculation/DetailedResultsBuilder.ts
@@ -3,7 +3,7 @@ import * as MeasureBundleHelpers from '../helpers/MeasureBundleHelpers';
 import * as DetailedResultsHelpers from '../helpers/DetailedResultsHelpers';
 import { getResult, hasResult, setResult, createOrSetResult } from './ClauseResultsBuilder';
 import { ELM, ELMStatement } from '../types/ELMTypes';
-import { MeasureScoreType, PopulationType } from '../types/Enums';
+import { PopulationType } from '../types/Enums';
 import * as cql from '../types/CQLTypes';
 
 /**
@@ -187,12 +187,7 @@ export function handlePopulationValues(
     }
 
     // If the numer is influenced by the DENOM, false it out and its observations since we are not in the DENOM for this branch of logic
-    if (
-      !(
-        MeasureBundleHelpers.getScoringCodeFromGroup(group) === MeasureScoreType.RATIO ||
-        measureScoringCode === MeasureScoreType.RATIO
-      )
-    ) {
+    if (!MeasureBundleHelpers.isRatioMeasure(group, measureScoringCode)) {
       setResult(PopulationType.NUMER, false, populationResults);
       setResult(PopulationType.NUMEX, false, populationResults);
       // If there are not multiple IPPs, then NUMER depends on DENOM. We're not in the DENOM, so let's null out NUMER observations
@@ -203,12 +198,7 @@ export function handlePopulationValues(
 
     // Cannot be in the numerator if they are excluded from the denominator
   } else if (getResult(PopulationType.DENEX, populationResults)) {
-    if (
-      !(
-        MeasureBundleHelpers.getScoringCodeFromGroup(group) === MeasureScoreType.RATIO ||
-        measureScoringCode === MeasureScoreType.RATIO
-      )
-    ) {
+    if (!MeasureBundleHelpers.isRatioMeasure(group, measureScoringCode)) {
       setResult(PopulationType.NUMER, false, populationResults);
       setResult(PopulationType.NUMEX, false, populationResults);
       // Since we can't be in the numerator, null out numerator observations
@@ -233,10 +223,7 @@ export function handlePopulationValues(
 
     // Cannot be in the DENEXCEP if in the NUMER
   } else if (
-    !(
-      MeasureBundleHelpers.getScoringCodeFromGroup(group) === MeasureScoreType.RATIO ||
-      measureScoringCode === MeasureScoreType.RATIO
-    ) &&
+    !MeasureBundleHelpers.isRatioMeasure(group, measureScoringCode) &&
     getResult(PopulationType.NUMER, populationResults)
   ) {
     setResult(PopulationType.DENEXCEP, false, populationResults);

--- a/src/calculation/DetailedResultsBuilder.ts
+++ b/src/calculation/DetailedResultsBuilder.ts
@@ -114,13 +114,13 @@ export function createPopulationValues(
  * values that should not be considered calculated are zeroed out. ex. results NUMER is true but IPP is false.
  * @param {PopulationResult[]} populationResults - The list of population results.
  * @param {fhir4.MeasureGroup} group - Full Measure Group used to detect multiple IPPs and resolve any references between populations
- * @param measureScoringCode scoring code for measure (used if scoring code not provided at the group level)
+ * @param {string} measureScoringCode scoring code for measure (used if scoring code not provided at the group level)
  * @returns {PopulationResult[]} Population results in the list as passed in, but the appropriate values are zeroed out.
  */
 export function handlePopulationValues(
   populationResults: PopulationResult[],
   group: fhir4.MeasureGroup,
-  measureScoringCode: string | null
+  measureScoringCode?: string
 ): PopulationResult[] {
   /* Setting values of populations if the correct populations are not set based on the following logic guidelines
    * Initial Population (IPP): The set of patients or episodes of care to be evaluated by the measure.
@@ -135,7 +135,6 @@ export function handlePopulationValues(
    */
   const populationResultsHandled = populationResults;
   // Cannot be in all populations if not in IPP.
-
   if (MeasureBundleHelpers.hasMultipleIPPs(group)) {
     const numerRelevantIPP = MeasureBundleHelpers.getRelevantIPPFromPopulation(group, PopulationType.NUMER);
     if (numerRelevantIPP) {
@@ -349,14 +348,14 @@ function isStatementValueTruthy(value: any): boolean {
  * used only for the episode of care measures.
  * @param {fhir4.MeasureGroup} populationGroup - The population group we are getting the values for.
  * @param {cql.StatementResults} patientResults - The raw results object for the patient from the calculation engine.
- * @param measureScoringCode scoring code for measure (used if scoring code not provided at the group level)
+ * @param {string} measureScoringCode scoring code for measure (used if scoring code not provided at the group level)
  * @returns {EpisodeResults[]} The episode results list. Structure with episode id population results for each episode.
  *   If this is a continuous variable measure the observations are included.
  */
 export function createEpisodePopulationValues(
   populationGroup: fhir4.MeasureGroup,
   patientResults: cql.StatementResults,
-  measureScoringCode: string | null
+  measureScoringCode?: string
 ): EpisodeResults[] {
   const episodeResultsSet: EpisodeResults[] = [];
 

--- a/src/helpers/DataRequirementHelpers.ts
+++ b/src/helpers/DataRequirementHelpers.ts
@@ -277,7 +277,7 @@ export function addFhirQueryPatternToDataRequirements(dataRequirement: fhir4.Dat
         console.warn(`Unexpected result:  (${foundParams.length}) dateFilter path search parameters found`);
       } else if (foundParams.length == 0) {
         // (or no matches means we ignore this constraint and add nothing to the query)
-        console.warn(`Could not identify search paramaters using dateFiler path '${path}'`);
+        console.warn(`Could not identify search parameters using dateFiler path '${path}'`);
       }
     });
   }

--- a/src/helpers/MeasureBundleHelpers.ts
+++ b/src/helpers/MeasureBundleHelpers.ts
@@ -5,6 +5,7 @@ import { UnexpectedProperty, UnexpectedResource } from '../types/errors/CustomEr
 import { getMissingDependentValuesets } from '../execution/ValueSetHelper';
 import { ValueSetResolver } from '../execution/ValueSetResolver';
 import { ExtractedLibrary } from '../types/CQLTypes';
+import { MeasureBundleHelpers } from '..';
 
 /**
  * The extension that defines the population basis. This is used to determine if the measure is an episode of care or
@@ -13,7 +14,7 @@ import { ExtractedLibrary } from '../types/CQLTypes';
 const POPULATION_BASIS_EXT = 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis';
 const SCORING_CODE_EXT = 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-scoring';
 
-export function getScoringCodeFromGroup(group: fhir4.MeasureGroup): string | null {
+export function getScoringCodeFromGroup(group?: fhir4.MeasureGroup): string | null {
   return group?.extension?.find(ext => ext.url === SCORING_CODE_EXT)?.valueCodeableConcept?.coding?.[0].code ?? null;
 }
 
@@ -23,6 +24,19 @@ export function getScoringCodeFromMeasure(measure: fhir4.Measure): string | unde
       c.system === 'http://hl7.org/fhir/measure-scoring' ||
       c.system === 'http://terminology.hl7.org/CodeSystem/measure-scoring'
   )?.code;
+}
+
+/**
+ * Checks if a given measure/measure group has scoring code 'ratio.'
+ * @param group measure group (used to extract scoring code if present on the group)
+ * @param measureScoringCode scoring code for measure (used if scoring code not provided at the group level)
+ * @returns true if scoring code is 'ratio' for the group or at the measure root, false otherwise
+ */
+export function isRatioMeasure(group?: fhir4.MeasureGroup, measureScoringCode?: string): boolean {
+  return (
+    MeasureBundleHelpers.getScoringCodeFromGroup(group) === MeasureScoreType.RATIO ||
+    measureScoringCode === MeasureScoreType.RATIO
+  );
 }
 
 /**

--- a/src/helpers/MeasureBundleHelpers.ts
+++ b/src/helpers/MeasureBundleHelpers.ts
@@ -5,7 +5,6 @@ import { UnexpectedProperty, UnexpectedResource } from '../types/errors/CustomEr
 import { getMissingDependentValuesets } from '../execution/ValueSetHelper';
 import { ValueSetResolver } from '../execution/ValueSetResolver';
 import { ExtractedLibrary } from '../types/CQLTypes';
-import { MeasureBundleHelpers } from '..';
 
 /**
  * The extension that defines the population basis. This is used to determine if the measure is an episode of care or
@@ -33,10 +32,7 @@ export function getScoringCodeFromMeasure(measure: fhir4.Measure): string | unde
  * @returns true if scoring code is 'ratio' for the group or at the measure root, false otherwise
  */
 export function isRatioMeasure(group?: fhir4.MeasureGroup, measureScoringCode?: string): boolean {
-  return (
-    MeasureBundleHelpers.getScoringCodeFromGroup(group) === MeasureScoreType.RATIO ||
-    measureScoringCode === MeasureScoreType.RATIO
-  );
+  return getScoringCodeFromGroup(group) === MeasureScoreType.RATIO || measureScoringCode === MeasureScoreType.RATIO;
 }
 
 /**

--- a/src/helpers/MeasureBundleHelpers.ts
+++ b/src/helpers/MeasureBundleHelpers.ts
@@ -17,14 +17,12 @@ export function getScoringCodeFromGroup(group: fhir4.MeasureGroup): string | nul
   return group?.extension?.find(ext => ext.url === SCORING_CODE_EXT)?.valueCodeableConcept?.coding?.[0].code ?? null;
 }
 
-export function getScoringCodeFromMeasure(measure: fhir4.Measure): string | null {
-  return (
-    measure.scoring?.coding?.find(
-      c =>
-        c.system === 'http://hl7.org/fhir/measure-scoring' ||
-        c.system === 'http://terminology.hl7.org/CodeSystem/measure-scoring'
-    )?.code ?? null
-  );
+export function getScoringCodeFromMeasure(measure: fhir4.Measure): string | undefined {
+  return measure.scoring?.coding?.find(
+    c =>
+      c.system === 'http://hl7.org/fhir/measure-scoring' ||
+      c.system === 'http://terminology.hl7.org/CodeSystem/measure-scoring'
+  )?.code;
 }
 
 /**

--- a/test/unit/ClauseResultsBuilder.test.ts
+++ b/test/unit/ClauseResultsBuilder.test.ts
@@ -2,7 +2,7 @@ import * as ClauseResultsBuilder from '../../src/calculation/ClauseResultsBuilde
 import { getJSONFixture, getELMFixture } from './helpers/testHelpers';
 
 import { PopulationResult, StatementResult } from '../../src/types/Calculator';
-import { PopulationType, Relevance, FinalResult } from '../../src/types/Enums';
+import { PopulationType, Relevance, FinalResult, MeasureScoreType } from '../../src/types/Enums';
 import * as cql from '../../src/types/CQLTypes';
 
 type MeasureWithGroup = fhir4.Measure & {
@@ -254,7 +254,7 @@ describe('ClauseResultsBuilder', () => {
         }
       ];
 
-      const relevantPops = ClauseResultsBuilder.buildPopulationRelevanceMap(results);
+      const relevantPops = ClauseResultsBuilder.buildPopulationRelevanceMap(results, null);
 
       expect(relevantPops).toEqual(results);
     });
@@ -268,7 +268,7 @@ describe('ClauseResultsBuilder', () => {
         }
       ];
 
-      const relevantPops = ClauseResultsBuilder.buildPopulationRelevanceMap(results);
+      const relevantPops = ClauseResultsBuilder.buildPopulationRelevanceMap(results, null);
 
       expect(relevantPops).toEqual(results);
     });
@@ -300,10 +300,14 @@ describe('ClauseResultsBuilder', () => {
         { populationType: PopulationType.NUMEX, criteriaExpression: 'Numerator Exclusion', result: true }
       ];
 
-      const results = ClauseResultsBuilder.buildPopulationRelevanceForAllEpisodes(simpleMeasure.group[0], [
-        { episodeId: '1', populationResults: truePopulationResults },
-        { episodeId: '2', populationResults: falsePopulationResults }
-      ]);
+      const results = ClauseResultsBuilder.buildPopulationRelevanceForAllEpisodes(
+        simpleMeasure.group[0],
+        [
+          { episodeId: '1', populationResults: truePopulationResults },
+          { episodeId: '2', populationResults: falsePopulationResults }
+        ],
+        null
+      );
 
       expect(results.length).toEqual(expectedMasterResults.length);
       expect(results).toEqual(expect.arrayContaining(expectedMasterResults));
@@ -367,7 +371,7 @@ describe('ClauseResultsBuilder', () => {
         { populationType: PopulationType.NUMEX, criteriaExpression: 'Numerator Exclusion', result: false }
       ];
 
-      const relevanceMap = ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults);
+      const relevanceMap = ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults, null);
       expect(relevanceMap).toEqual(expectedRelevanceMap);
     });
 
@@ -389,7 +393,7 @@ describe('ClauseResultsBuilder', () => {
         { populationType: PopulationType.NUMEX, criteriaExpression: 'Numerator Exclusion', result: false }
       ];
 
-      const relevanceMap = ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults);
+      const relevanceMap = ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults, null);
       expect(relevanceMap).toEqual(expectedRelevanceMap);
     });
 
@@ -411,7 +415,7 @@ describe('ClauseResultsBuilder', () => {
         { populationType: PopulationType.NUMEX, criteriaExpression: 'Numerator Exclusion', result: false }
       ];
 
-      const relevanceMap = ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults);
+      const relevanceMap = ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults, null);
       expect(relevanceMap).toEqual(expectedRelevanceMap);
     });
 
@@ -433,7 +437,7 @@ describe('ClauseResultsBuilder', () => {
         { populationType: PopulationType.NUMEX, criteriaExpression: 'Numerator Exclusion', result: true }
       ];
 
-      const relevanceMap = ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults);
+      const relevanceMap = ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults, null);
       expect(relevanceMap).toEqual(expectedRelevanceMap);
     });
 
@@ -455,7 +459,7 @@ describe('ClauseResultsBuilder', () => {
         { populationType: PopulationType.NUMEX, criteriaExpression: 'Numerator Exclusion', result: false }
       ];
 
-      const relevanceMap = ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults);
+      const relevanceMap = ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults, null);
       expect(relevanceMap).toEqual(expectedRelevanceMap);
     });
 
@@ -471,7 +475,7 @@ describe('ClauseResultsBuilder', () => {
         { populationType: PopulationType.MSRPOPLEX, criteriaExpression: 'Measure Population Exclusions', result: false }
       ];
 
-      const relevanceMap = ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults);
+      const relevanceMap = ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults, null);
       expect(relevanceMap).toEqual(expectedRelevanceMap);
     });
 
@@ -487,7 +491,7 @@ describe('ClauseResultsBuilder', () => {
         { populationType: PopulationType.MSRPOPLEX, criteriaExpression: 'Measure Population Exclusions', result: false }
       ];
 
-      const relevanceMap = ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults);
+      const relevanceMap = ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults, null);
       expect(relevanceMap).toEqual(expectedRelevanceMap);
     });
 
@@ -623,9 +627,9 @@ describe('ClauseResultsBuilder', () => {
           { populationType: PopulationType.NUMER, criteriaExpression: 'numer', result: true }
         ];
 
-        expect(ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults, group)).toEqual(
-          expectedRelevanceMap
-        );
+        expect(
+          ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults, MeasureScoreType.RATIO, group)
+        ).toEqual(expectedRelevanceMap);
       });
 
       test('should mark numer/numex irrelevant when corresponding IPP is false', () => {
@@ -645,9 +649,9 @@ describe('ClauseResultsBuilder', () => {
           { populationType: PopulationType.NUMEX, criteriaExpression: 'numex', result: false }
         ];
 
-        expect(ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults, group)).toEqual(
-          expectedRelevanceMap
-        );
+        expect(
+          ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults, MeasureScoreType.RATIO, group)
+        ).toEqual(expectedRelevanceMap);
       });
 
       test('should mark denom/denex/denexcep irrelevant when corresponding IPP is false', () => {
@@ -667,9 +671,9 @@ describe('ClauseResultsBuilder', () => {
           { populationType: PopulationType.DENEXCEP, criteriaExpression: 'denexcep', result: false }
         ];
 
-        expect(ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults, group)).toEqual(
-          expectedRelevanceMap
-        );
+        expect(
+          ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults, MeasureScoreType.RATIO, group)
+        ).toEqual(expectedRelevanceMap);
       });
 
       test('should mark denom relevant independent of numer IPP', () => {
@@ -686,9 +690,9 @@ describe('ClauseResultsBuilder', () => {
           { populationType: PopulationType.NUMER, criteriaExpression: 'numer', result: false }
         ];
 
-        expect(ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults, group)).toEqual(
-          expectedRelevanceMap
-        );
+        expect(
+          ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults, MeasureScoreType.RATIO, group)
+        ).toEqual(expectedRelevanceMap);
       });
 
       test('should mark numer relevant independent of denom IPP', () => {
@@ -705,9 +709,9 @@ describe('ClauseResultsBuilder', () => {
           { populationType: PopulationType.NUMER, criteriaExpression: 'numer', result: true }
         ];
 
-        expect(ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults, group)).toEqual(
-          expectedRelevanceMap
-        );
+        expect(
+          ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults, MeasureScoreType.RATIO, group)
+        ).toEqual(expectedRelevanceMap);
       });
 
       test('should bypass denom-based numer/numex logic', () => {
@@ -726,9 +730,9 @@ describe('ClauseResultsBuilder', () => {
           { populationType: PopulationType.NUMEX, criteriaExpression: 'numex', result: true }
         ];
 
-        expect(ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults, group)).toEqual(
-          expectedRelevanceMap
-        );
+        expect(
+          ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults, MeasureScoreType.RATIO, group)
+        ).toEqual(expectedRelevanceMap);
       });
 
       test('should bypass denex-based numer/numex logic', () => {
@@ -749,9 +753,9 @@ describe('ClauseResultsBuilder', () => {
           { populationType: PopulationType.NUMEX, criteriaExpression: 'numex', result: true }
         ];
 
-        expect(ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults, group)).toEqual(
-          expectedRelevanceMap
-        );
+        expect(
+          ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults, MeasureScoreType.RATIO, group)
+        ).toEqual(expectedRelevanceMap);
       });
     });
   });

--- a/test/unit/ClauseResultsBuilder.test.ts
+++ b/test/unit/ClauseResultsBuilder.test.ts
@@ -254,7 +254,7 @@ describe('ClauseResultsBuilder', () => {
         }
       ];
 
-      const relevantPops = ClauseResultsBuilder.buildPopulationRelevanceMap(results, null);
+      const relevantPops = ClauseResultsBuilder.buildPopulationRelevanceMap(results);
 
       expect(relevantPops).toEqual(results);
     });
@@ -268,7 +268,7 @@ describe('ClauseResultsBuilder', () => {
         }
       ];
 
-      const relevantPops = ClauseResultsBuilder.buildPopulationRelevanceMap(results, null);
+      const relevantPops = ClauseResultsBuilder.buildPopulationRelevanceMap(results);
 
       expect(relevantPops).toEqual(results);
     });
@@ -301,12 +301,11 @@ describe('ClauseResultsBuilder', () => {
       ];
 
       const results = ClauseResultsBuilder.buildPopulationRelevanceForAllEpisodes(
-        simpleMeasure.group[0],
         [
           { episodeId: '1', populationResults: truePopulationResults },
           { episodeId: '2', populationResults: falsePopulationResults }
         ],
-        null
+        simpleMeasure.group[0]
       );
 
       expect(results.length).toEqual(expectedMasterResults.length);
@@ -371,7 +370,7 @@ describe('ClauseResultsBuilder', () => {
         { populationType: PopulationType.NUMEX, criteriaExpression: 'Numerator Exclusion', result: false }
       ];
 
-      const relevanceMap = ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults, null);
+      const relevanceMap = ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults);
       expect(relevanceMap).toEqual(expectedRelevanceMap);
     });
 
@@ -393,7 +392,7 @@ describe('ClauseResultsBuilder', () => {
         { populationType: PopulationType.NUMEX, criteriaExpression: 'Numerator Exclusion', result: false }
       ];
 
-      const relevanceMap = ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults, null);
+      const relevanceMap = ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults);
       expect(relevanceMap).toEqual(expectedRelevanceMap);
     });
 
@@ -415,7 +414,7 @@ describe('ClauseResultsBuilder', () => {
         { populationType: PopulationType.NUMEX, criteriaExpression: 'Numerator Exclusion', result: false }
       ];
 
-      const relevanceMap = ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults, null);
+      const relevanceMap = ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults);
       expect(relevanceMap).toEqual(expectedRelevanceMap);
     });
 
@@ -437,7 +436,7 @@ describe('ClauseResultsBuilder', () => {
         { populationType: PopulationType.NUMEX, criteriaExpression: 'Numerator Exclusion', result: true }
       ];
 
-      const relevanceMap = ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults, null);
+      const relevanceMap = ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults);
       expect(relevanceMap).toEqual(expectedRelevanceMap);
     });
 
@@ -459,7 +458,7 @@ describe('ClauseResultsBuilder', () => {
         { populationType: PopulationType.NUMEX, criteriaExpression: 'Numerator Exclusion', result: false }
       ];
 
-      const relevanceMap = ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults, null);
+      const relevanceMap = ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults);
       expect(relevanceMap).toEqual(expectedRelevanceMap);
     });
 
@@ -475,7 +474,7 @@ describe('ClauseResultsBuilder', () => {
         { populationType: PopulationType.MSRPOPLEX, criteriaExpression: 'Measure Population Exclusions', result: false }
       ];
 
-      const relevanceMap = ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults, null);
+      const relevanceMap = ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults);
       expect(relevanceMap).toEqual(expectedRelevanceMap);
     });
 
@@ -491,7 +490,7 @@ describe('ClauseResultsBuilder', () => {
         { populationType: PopulationType.MSRPOPLEX, criteriaExpression: 'Measure Population Exclusions', result: false }
       ];
 
-      const relevanceMap = ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults, null);
+      const relevanceMap = ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults);
       expect(relevanceMap).toEqual(expectedRelevanceMap);
     });
 
@@ -628,7 +627,7 @@ describe('ClauseResultsBuilder', () => {
         ];
 
         expect(
-          ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults, MeasureScoreType.RATIO, group)
+          ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults, group, MeasureScoreType.RATIO)
         ).toEqual(expectedRelevanceMap);
       });
 
@@ -650,7 +649,7 @@ describe('ClauseResultsBuilder', () => {
         ];
 
         expect(
-          ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults, MeasureScoreType.RATIO, group)
+          ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults, group, MeasureScoreType.RATIO)
         ).toEqual(expectedRelevanceMap);
       });
 
@@ -672,7 +671,7 @@ describe('ClauseResultsBuilder', () => {
         ];
 
         expect(
-          ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults, MeasureScoreType.RATIO, group)
+          ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults, group, MeasureScoreType.RATIO)
         ).toEqual(expectedRelevanceMap);
       });
 
@@ -691,7 +690,7 @@ describe('ClauseResultsBuilder', () => {
         ];
 
         expect(
-          ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults, MeasureScoreType.RATIO, group)
+          ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults, group, MeasureScoreType.RATIO)
         ).toEqual(expectedRelevanceMap);
       });
 
@@ -710,7 +709,7 @@ describe('ClauseResultsBuilder', () => {
         ];
 
         expect(
-          ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults, MeasureScoreType.RATIO, group)
+          ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults, group, MeasureScoreType.RATIO)
         ).toEqual(expectedRelevanceMap);
       });
 
@@ -731,7 +730,7 @@ describe('ClauseResultsBuilder', () => {
         ];
 
         expect(
-          ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults, MeasureScoreType.RATIO, group)
+          ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults, group, MeasureScoreType.RATIO)
         ).toEqual(expectedRelevanceMap);
       });
 
@@ -754,7 +753,7 @@ describe('ClauseResultsBuilder', () => {
         ];
 
         expect(
-          ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults, MeasureScoreType.RATIO, group)
+          ClauseResultsBuilder.buildPopulationRelevanceMap(populationResults, group, MeasureScoreType.RATIO)
         ).toEqual(expectedRelevanceMap);
       });
     });

--- a/test/unit/DetailedResultsBuilder.test.ts
+++ b/test/unit/DetailedResultsBuilder.test.ts
@@ -585,7 +585,7 @@ describe('DetailedResultsBuilder', () => {
       );
     });
 
-    describe('handlePopulationValues for group with observations and multiple IPPs', () => {
+    describe('handlePopulationValues for group with observations and multiple IPPs (relevant for ratio measures)', () => {
       const group: fhir4.MeasureGroup = {
         population: [
           {

--- a/test/unit/DetailedResultsBuilder.test.ts
+++ b/test/unit/DetailedResultsBuilder.test.ts
@@ -1,7 +1,7 @@
 import * as DetailedResultsBuilder from '../../src/calculation/DetailedResultsBuilder';
 
 import { getJSONFixture } from './helpers/testHelpers';
-import { PopulationType } from '../../src/types/Enums';
+import { MeasureScoreType, PopulationType } from '../../src/types/Enums';
 import { StatementResults } from '../../src/types/CQLTypes';
 import { PopulationResult, EpisodeResults } from '../../src/types/Calculator';
 import { ELMExpressionRef, ELMQuery, ELMTuple, ELMFunctionRef } from '../../src/types/ELMTypes';
@@ -12,8 +12,10 @@ type MeasureWithGroup = fhir4.Measure & {
 
 const simpleMeasure = getJSONFixture('measure/simple-measure.json') as MeasureWithGroup;
 const cvMeasure = getJSONFixture('measure/cv-measure.json') as MeasureWithGroup;
+const ratioMeasure = getJSONFixture('measure/ratio-measure.json') as MeasureWithGroup;
 const simpleMeasureGroup = simpleMeasure.group[0];
 const cvMeasureGroup = cvMeasure.group[0];
+const ratioMeasureGroup = ratioMeasure.group[0];
 const groupWithObs = getJSONFixture('measure/groups/groupNumerAndDenomCriteria.json');
 const measureWithMeasureObs = getJSONFixture('measure/measure-measure-obs.json') as MeasureWithGroup;
 const groupWithMeasureObs = (measureWithMeasureObs.group as [fhir4.MeasureGroup])[0];
@@ -583,7 +585,7 @@ describe('DetailedResultsBuilder', () => {
       );
     });
 
-    describe('multiple IPPs', () => {
+    describe('handlePopulationValues for group with observations and multiple IPPs', () => {
       const group: fhir4.MeasureGroup = {
         population: [
           {
@@ -758,7 +760,9 @@ describe('DetailedResultsBuilder', () => {
           { populationType: PopulationType.NUMEX, criteriaExpression: 'numex', result: false }
         ];
 
-        expect(DetailedResultsBuilder.handlePopulationValues(populationResults, group)).toEqual(expectedHandledResults);
+        expect(DetailedResultsBuilder.handlePopulationValues(populationResults, group, MeasureScoreType.RATIO)).toEqual(
+          expectedHandledResults
+        );
       });
 
       test('should false out DENOM/DENEX/DENEXCEP when relevant IPP is false', () => {
@@ -776,9 +780,59 @@ describe('DetailedResultsBuilder', () => {
           { populationType: PopulationType.DENEXCEP, criteriaExpression: 'denexcep', result: false }
         ];
 
-        expect(DetailedResultsBuilder.handlePopulationValues(populationResults, group)).toEqual(expectedHandledResults);
+        expect(DetailedResultsBuilder.handlePopulationValues(populationResults, group, MeasureScoreType.RATIO)).toEqual(
+          expectedHandledResults
+        );
       });
 
+      test('should null out NUMER observations when associated IPP is false for multiple IPP', () => {
+        const populationResults: PopulationResult[] = [
+          { populationType: PopulationType.IPP, criteriaExpression: 'ipp', result: true },
+          { populationType: PopulationType.IPP, criteriaExpression: 'ipp2', result: false },
+          { populationType: PopulationType.DENOM, criteriaExpression: 'denom', result: true },
+          { populationType: PopulationType.NUMER, criteriaExpression: 'numer', result: false },
+          { populationType: PopulationType.OBSERV, criteriaExpression: 'denomFunc', result: true },
+          { populationType: PopulationType.OBSERV, criteriaExpression: 'numerFunc', result: true }
+        ];
+        const expectedHandledResults: PopulationResult[] = [
+          { populationType: PopulationType.IPP, criteriaExpression: 'ipp', result: true },
+          { populationType: PopulationType.IPP, criteriaExpression: 'ipp2', result: false },
+          { populationType: PopulationType.DENOM, criteriaExpression: 'denom', result: true },
+          { populationType: PopulationType.NUMER, criteriaExpression: 'numer', result: false },
+          { populationType: PopulationType.OBSERV, criteriaExpression: 'denomFunc', result: true },
+          { populationType: PopulationType.OBSERV, criteriaExpression: 'numerFunc', result: false, observations: null }
+        ];
+
+        expect(DetailedResultsBuilder.handlePopulationValues(populationResults, group, MeasureScoreType.RATIO)).toEqual(
+          expectedHandledResults
+        );
+      });
+
+      test('should null out DENOM observations when associated IPP is false for multiple IPP', () => {
+        const populationResults: PopulationResult[] = [
+          { populationType: PopulationType.IPP, criteriaExpression: 'ipp', result: false },
+          { populationType: PopulationType.IPP, criteriaExpression: 'ipp2', result: true },
+          { populationType: PopulationType.DENOM, criteriaExpression: 'denom', result: true },
+          { populationType: PopulationType.NUMER, criteriaExpression: 'numer', result: true },
+          { populationType: PopulationType.OBSERV, criteriaExpression: 'denomFunc', result: true },
+          { populationType: PopulationType.OBSERV, criteriaExpression: 'numerFunc', result: true }
+        ];
+        const expectedHandledResults: PopulationResult[] = [
+          { populationType: PopulationType.IPP, criteriaExpression: 'ipp', result: false },
+          { populationType: PopulationType.IPP, criteriaExpression: 'ipp2', result: true },
+          { populationType: PopulationType.DENOM, criteriaExpression: 'denom', result: false },
+          { populationType: PopulationType.NUMER, criteriaExpression: 'numer', result: true },
+          { populationType: PopulationType.OBSERV, criteriaExpression: 'denomFunc', result: false, observations: null },
+          { populationType: PopulationType.OBSERV, criteriaExpression: 'numerFunc', result: true }
+        ];
+
+        expect(DetailedResultsBuilder.handlePopulationValues(populationResults, group, MeasureScoreType.RATIO)).toEqual(
+          expectedHandledResults
+        );
+      });
+    });
+
+    describe('handlePopulationValues for group with observations and single IPP (non-ratio measure)', () => {
       test('should null out NUMER and DENOM observations IPP for single IPP', () => {
         const populationResults: PopulationResult[] = [
           { populationType: PopulationType.IPP, criteriaExpression: 'ipp', result: false },
@@ -795,9 +849,9 @@ describe('DetailedResultsBuilder', () => {
           { populationType: PopulationType.OBSERV, criteriaExpression: 'denomFunc', result: false, observations: null }
         ];
 
-        expect(DetailedResultsBuilder.handlePopulationValues(populationResults, groupWithObs)).toEqual(
-          expectedHandledResults
-        );
+        expect(
+          DetailedResultsBuilder.handlePopulationValues(populationResults, groupWithObs, MeasureScoreType.PROP)
+        ).toEqual(expectedHandledResults);
       });
 
       test('should null out NUMER observations when not in DENOM for single IPP', () => {
@@ -814,9 +868,9 @@ describe('DetailedResultsBuilder', () => {
           { populationType: PopulationType.OBSERV, criteriaExpression: 'numerFunc', result: false, observations: null }
         ];
 
-        expect(DetailedResultsBuilder.handlePopulationValues(populationResults, groupWithObs)).toEqual(
-          expectedHandledResults
-        );
+        expect(
+          DetailedResultsBuilder.handlePopulationValues(populationResults, groupWithObs, MeasureScoreType.PROP)
+        ).toEqual(expectedHandledResults);
       });
 
       test('should null out both NUMER and DENOM observations when not in DENOM for single IPP', () => {
@@ -835,9 +889,9 @@ describe('DetailedResultsBuilder', () => {
           { populationType: PopulationType.OBSERV, criteriaExpression: 'numerFunc', result: false, observations: null }
         ];
 
-        expect(DetailedResultsBuilder.handlePopulationValues(populationResults, groupWithObs)).toEqual(
-          expectedHandledResults
-        );
+        expect(
+          DetailedResultsBuilder.handlePopulationValues(populationResults, groupWithObs, MeasureScoreType.PROP)
+        ).toEqual(expectedHandledResults);
       });
 
       test('should null out NUMER observations when in DENEX for single IPP', () => {
@@ -858,9 +912,9 @@ describe('DetailedResultsBuilder', () => {
           { populationType: PopulationType.OBSERV, criteriaExpression: 'numerFunc', result: false, observations: null }
         ];
 
-        expect(DetailedResultsBuilder.handlePopulationValues(populationResults, groupWithObs)).toEqual(
-          expectedHandledResults
-        );
+        expect(
+          DetailedResultsBuilder.handlePopulationValues(populationResults, groupWithObs, MeasureScoreType.PROP)
+        ).toEqual(expectedHandledResults);
       });
 
       test('should null out NUMER observations when not in NUMER for single IPP', () => {
@@ -879,9 +933,9 @@ describe('DetailedResultsBuilder', () => {
           { populationType: PopulationType.OBSERV, criteriaExpression: 'numerFunc', result: false, observations: null }
         ];
 
-        expect(DetailedResultsBuilder.handlePopulationValues(populationResults, groupWithObs)).toEqual(
-          expectedHandledResults
-        );
+        expect(
+          DetailedResultsBuilder.handlePopulationValues(populationResults, groupWithObs, MeasureScoreType.PROP)
+        ).toEqual(expectedHandledResults);
       });
 
       test('should null out observation when not in MSRPOPL', () => {
@@ -939,9 +993,13 @@ describe('DetailedResultsBuilder', () => {
           }
         ];
 
-        expect(DetailedResultsBuilder.handlePopulationValues(populationResults, groupWithMeasurePopulation)).toEqual(
-          expectedHandledResults
-        );
+        expect(
+          DetailedResultsBuilder.handlePopulationValues(
+            populationResults,
+            groupWithMeasurePopulation,
+            MeasureScoreType.PROP
+          )
+        ).toEqual(expectedHandledResults);
       });
 
       test('should null out observation when in MSRPOPLEX', () => {
@@ -1020,51 +1078,35 @@ describe('DetailedResultsBuilder', () => {
           }
         ];
 
-        expect(DetailedResultsBuilder.handlePopulationValues(populationResults, groupWithMeasurePopulation)).toEqual(
-          expectedHandledResults
-        );
+        expect(
+          DetailedResultsBuilder.handlePopulationValues(
+            populationResults,
+            groupWithMeasurePopulation,
+            MeasureScoreType.PROP
+          )
+        ).toEqual(expectedHandledResults);
       });
+    });
 
-      test('should null out NUMER observations when associated IPP is false for multiple IPP', () => {
+    describe('handlePopulationValues for group with single IPP - ratio measure', () => {
+      test('should not false out NUMER/NUMEX when DENOM is false for ratio measure', () => {
         const populationResults: PopulationResult[] = [
           { populationType: PopulationType.IPP, criteriaExpression: 'ipp', result: true },
-          { populationType: PopulationType.IPP, criteriaExpression: 'ipp2', result: false },
-          { populationType: PopulationType.DENOM, criteriaExpression: 'denom', result: true },
-          { populationType: PopulationType.NUMER, criteriaExpression: 'numer', result: false },
-          { populationType: PopulationType.OBSERV, criteriaExpression: 'denomFunc', result: true },
-          { populationType: PopulationType.OBSERV, criteriaExpression: 'numerFunc', result: true }
-        ];
-        const expectedHandledResults: PopulationResult[] = [
-          { populationType: PopulationType.IPP, criteriaExpression: 'ipp', result: true },
-          { populationType: PopulationType.IPP, criteriaExpression: 'ipp2', result: false },
-          { populationType: PopulationType.DENOM, criteriaExpression: 'denom', result: true },
-          { populationType: PopulationType.NUMER, criteriaExpression: 'numer', result: false },
-          { populationType: PopulationType.OBSERV, criteriaExpression: 'denomFunc', result: true },
-          { populationType: PopulationType.OBSERV, criteriaExpression: 'numerFunc', result: false, observations: null }
-        ];
-
-        expect(DetailedResultsBuilder.handlePopulationValues(populationResults, group)).toEqual(expectedHandledResults);
-      });
-
-      test('should null out DENOM observations when associated IPP is false for multiple IPP', () => {
-        const populationResults: PopulationResult[] = [
-          { populationType: PopulationType.IPP, criteriaExpression: 'ipp', result: false },
-          { populationType: PopulationType.IPP, criteriaExpression: 'ipp2', result: true },
-          { populationType: PopulationType.DENOM, criteriaExpression: 'denom', result: true },
-          { populationType: PopulationType.NUMER, criteriaExpression: 'numer', result: true },
-          { populationType: PopulationType.OBSERV, criteriaExpression: 'denomFunc', result: true },
-          { populationType: PopulationType.OBSERV, criteriaExpression: 'numerFunc', result: true }
-        ];
-        const expectedHandledResults: PopulationResult[] = [
-          { populationType: PopulationType.IPP, criteriaExpression: 'ipp', result: false },
-          { populationType: PopulationType.IPP, criteriaExpression: 'ipp2', result: true },
           { populationType: PopulationType.DENOM, criteriaExpression: 'denom', result: false },
           { populationType: PopulationType.NUMER, criteriaExpression: 'numer', result: true },
-          { populationType: PopulationType.OBSERV, criteriaExpression: 'denomFunc', result: false, observations: null },
-          { populationType: PopulationType.OBSERV, criteriaExpression: 'numerFunc', result: true }
+          { populationType: PopulationType.NUMEX, criteriaExpression: 'numex', result: true }
         ];
 
-        expect(DetailedResultsBuilder.handlePopulationValues(populationResults, group)).toEqual(expectedHandledResults);
+        const expectedHandledResults: PopulationResult[] = [
+          { populationType: PopulationType.IPP, criteriaExpression: 'ipp', result: true },
+          { populationType: PopulationType.DENOM, criteriaExpression: 'denom', result: false },
+          { populationType: PopulationType.NUMER, criteriaExpression: 'numer', result: true },
+          { populationType: PopulationType.NUMEX, criteriaExpression: 'numex', result: true }
+        ];
+
+        expect(
+          DetailedResultsBuilder.handlePopulationValues(populationResults, ratioMeasureGroup, MeasureScoreType.RATIO)
+        ).toEqual(expectedHandledResults);
       });
     });
   });


### PR DESCRIPTION
# Summary
Addresses https://github.com/projecttacoma/fqm-execution/issues/182 (single IPP ratio measure numerator/denominator populations should be treated independently in fqm-execution).

## New behavior
Fqm-execution currently does not align with HQMF in the fact that ratio measure calculation should always treat numerator and denominator as independent populations. In fqm-execution, this currently only happens when the measure has multiple IPPs.

Fqm-execution now handles the numerator and denominator populations as independent populations for all ratio measures (so, including single IPP).

For example, we should now be able to achieve the following `populationResults`, meaning the numer is not automatically set to be false if the denom is false:

```
 "populationResults": [
          {
            "populationType": "initial-population",
            "criteriaExpression": "ipp",
            "result": true,
            "populationId": “ipp-id”
          },
          {
            "populationType": "numerator",
            "criteriaExpression": "numer",
            "result": true,
            "populationId": “numer-id”
          },
          {
            "populationType": "denominator",
            "criteriaExpression": "denom",
            "result": false,
            "populationId": “denom-id”
          }
        ]
```

## Code changes
Overall change: in `ClauseResultsBuilder` and `DetailedResultsBuilder`, check that the measure is a ratio measure (rather than checking that it has multiple IPPs) in spots where there is an assumed dependence between the numer and denom populations.

Note that the scoring code can occur at both the group and measure root level, so we should check for the presence of a scoring code in both spots. The measure scoring code is passed in to these functions as a fallback in case the scoring code does not appear at the group level. Open to feedback on a better way to pass in the measure scoring code… the only spot that I could see was passing it in through `calculate()` since the ClauseResultsBuilder/DetailedResultsBuilder  take in the measure group as input rather than the entire measure.

Code changes to focus on:
* Update `buildPopulationRelevanceMap` to check if measure is a ratio measure when deciding whether to set NUMER/NUMEX to false if DENOM is false
* Update `buildPopulationRelevanceMap` to check if measure is a ratio measure when deciding whether to se NUMER/NUMEX to false if DENEX is true
* Update `handlePopulationValues` to do similar checks based on scoring code as those in `buildPopulationRelevanceMap`
* Add unit test in DetailedResultsBuilder for checking numer/denom independence for single IPP ratio measure (plus some rearranging of unit tests - sorry the code diff is really ugly)
* Update unit tests in ClauseResultsBuilder to take in the new argument for measure scoring code

# Testing guidance
* Run unit tests
* Run detailed results against patient/measure bundle in https://github.com/projecttacoma/fqm-execution/issues/182 - on the main branch the numerator should false out, but on this branch the numerator should stay as “true” in the `populationResults`
* Run detailed results against the same patient/measure bundle but change the scoring code to “proportion” instead of “ratio” - the numerator should false out since it is dependent with the denominator (since this only applies to ratio measures)
