### PR TITLE
Removed default measurement period for dataRequirements

### DIFF
--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -554,8 +554,8 @@ export async function calculateDataRequirements(
 ): Promise<DRCalculationOutput> {
   // Extract the library ELM, and the id of the root library, from the measure bundle
   const { cqls, rootLibIdentifier, elmJSONs } = MeasureBundleHelpers.extractLibrariesFromMeasureBundle(measureBundle);
-
-  return DataRequirementHelpers.getDataRequirements(cqls, rootLibIdentifier, elmJSONs, options);
+  const effectivePeriod = MeasureBundleHelpers.extractMeasureFromBundle(measureBundle).effectivePeriod;
+  return DataRequirementHelpers.getDataRequirements(cqls, rootLibIdentifier, elmJSONs, options, effectivePeriod);
 }
 
 /**

--- a/src/gaps/QueryFilterParser.ts
+++ b/src/gaps/QueryFilterParser.ts
@@ -51,7 +51,8 @@ import {
   UnknownFilter,
   ValueFilter,
   ValueFilterComparator,
-  IsNullFilter
+  IsNullFilter,
+  QueryParserParams
 } from '../types/QueryFilterTypes';
 import { findLibraryReference, findLibraryReferenceId } from '../helpers/elm/ELMDependencyHelpers';
 import { findClauseInLibrary } from '../helpers/elm/ELMHelpers';
@@ -79,7 +80,7 @@ export async function parseQueryInfo(
   allELM: ELM[],
   queryLocalId?: string,
   valueComparisonLocalId?: string,
-  parameters: Record<string, any> = {},
+  parameters: QueryParserParams = {},
   patient?: CQLPatient
 ): Promise<QueryInfo> {
   if (!queryLocalId) {

--- a/src/gaps/QueryFilterParser.ts
+++ b/src/gaps/QueryFilterParser.ts
@@ -79,7 +79,7 @@ export async function parseQueryInfo(
   allELM: ELM[],
   queryLocalId?: string,
   valueComparisonLocalId?: string,
-  parameters: { [key: string]: any } = {},
+  parameters: Record<string, any> = {},
   patient?: CQLPatient
 ): Promise<QueryInfo> {
   if (!queryLocalId) {

--- a/src/helpers/DataRequirementHelpers.ts
+++ b/src/helpers/DataRequirementHelpers.ts
@@ -441,7 +441,7 @@ export function createIntervalFromEndpoints(start?: string, end?: string) {
 }
 
 function hasMeasurementPeriodInfo(options: CalculationOptions, effectivePeriod?: fhir4.Period) {
-  return (
+  return Boolean(
     options.measurementPeriodStart || options.measurementPeriodEnd || effectivePeriod?.start || effectivePeriod?.end
   );
 }

--- a/src/types/QueryFilterTypes.ts
+++ b/src/types/QueryFilterTypes.ts
@@ -29,6 +29,13 @@ export interface QueryInfo {
 }
 
 /**
+ * Parameters passed in to parseQueryInfo providing measurement period info
+ */
+export interface QueryParserParams {
+  'Measurement Period'?: Interval;
+}
+
+/**
  * Information about a single source in a query.
  */
 export interface SourceInfo {

--- a/test/unit/DataRequirementHelpers.test.ts
+++ b/test/unit/DataRequirementHelpers.test.ts
@@ -640,6 +640,7 @@ describe('DataRequirementHelpers', () => {
       const endCql = DateTime.fromJSDate(moment.utc(end, 'YYYYMDDHHmm').toDate(), 0);
       const options: CalculationOptions = { measurementPeriodStart: start, measurementPeriodEnd: end };
       const mp: fhir4.Period = { start: '2000-01-01', end: '2001-01-01' };
+
       expect(DataRequirementHelpers.extractDataRequirementsMeasurementPeriod(options, mp)).toEqual({
         'Measurement Period': new Interval(startCql, endCql)
       });
@@ -668,16 +669,18 @@ describe('DataRequirementHelpers', () => {
       expect(DataRequirementHelpers.createIntervalFromEndpoints(start, end)).toEqual(new Interval(startCql, endCql));
     });
 
-    test('returns interval from start with duration 1 year if end not provided provided', () => {
+    test('returns interval from start with duration 1 year if end not provided', () => {
       const start = '2019-01-01';
       const expectedEnd = '2020-01-01';
       const startCql = DateTime.fromJSDate(moment.utc(start, 'YYYYMDDHHmm').toDate(), 0);
       const endCql = DateTime.fromJSDate(moment.utc(expectedEnd, 'YYYYMDDHHmm').toDate(), 0);
 
-      expect(DataRequirementHelpers.createIntervalFromEndpoints(start)).toEqual(new Interval(startCql, endCql));
+      expect(DataRequirementHelpers.createIntervalFromEndpoints(start, undefined)).toEqual(
+        new Interval(startCql, endCql)
+      );
     });
 
-    test('returns interval up to end with duration 1 year if end not provided provided', () => {
+    test('returns interval up to end with duration 1 year if start not provided', () => {
       const expectedStart = '2019-01-01';
       const end = '2020-01-01';
       const startCql = DateTime.fromJSDate(moment.utc(expectedStart, 'YYYYMDDHHmm').toDate(), 0);

--- a/test/unit/queryFilters/parseQueryInfo.test.ts
+++ b/test/unit/queryFilters/parseQueryInfo.test.ts
@@ -460,7 +460,7 @@ describe('Parse Query Info', () => {
 
   test('simple valueset with id check with no parameters passed in', async () => {
     const queryLocalId = simpleQueryELM.library.statements.def[2].expression.localId; // expression with aliased query
-    const queryInfo = await parseQueryInfo(simpleQueryELM, allELM, queryLocalId, undefined, PATIENT);
+    const queryInfo = await parseQueryInfo(simpleQueryELM, allELM, queryLocalId, undefined, {}, PATIENT);
     expect(queryInfo).toEqual(EXPECTED_VS_WITH_ID_CHECK_QUERY);
   });
 
@@ -549,13 +549,13 @@ describe('Parse Query Info', () => {
 
   test('simple - query references query in another library, combines filters', async () => {
     const queryLocalId = simpleQueryELM.library.statements.def[10].expression.localId; // In simple queries "Nested Query From Another Library"
-    const queryInfo = await parseQueryInfo(simpleQueryELM, allELM, queryLocalId, undefined, PATIENT);
+    const queryInfo = await parseQueryInfo(simpleQueryELM, allELM, queryLocalId, undefined, {}, PATIENT);
     expect(queryInfo).toEqual(EXPECTED_QUERY_REFERENCES_QUERY_IN_ANOTHER_LIBRARY);
   });
 
   test('simple - query references query in another library, combines filters', async () => {
     const queryLocalId = simpleQueryELM.library.statements.def[10].expression.localId; // In simple queries "Nested Query From Another Library"
-    const queryInfo = await parseQueryInfo(simpleQueryELM, allELM, queryLocalId, undefined, PATIENT);
+    const queryInfo = await parseQueryInfo(simpleQueryELM, allELM, queryLocalId, undefined, {}, PATIENT);
     expect(queryInfo).toEqual(EXPECTED_QUERY_REFERENCES_QUERY_IN_ANOTHER_LIBRARY);
   });
 
@@ -567,6 +567,7 @@ describe('Parse Query Info', () => {
       [valueComparatorELM],
       queryLocalId,
       valueComparisonLocalId,
+      {},
       PATIENT
     );
     expect(queryInfo).toEqual(EXPECTED_EXTERNAL_VALUE_COMPARISON_QUERY);
@@ -574,7 +575,14 @@ describe('Parse Query Info', () => {
 
   test('Value Comparison queries produces value filter with tracked valueComparisonLocalId when comparison is done inside of a query', async () => {
     const queryLocalId = (valueComparatorELM.library.statements.def[3].expression as ELMLast).source.localId;
-    const queryInfo = await parseQueryInfo(valueComparatorELM, [valueComparatorELM], queryLocalId, undefined, PATIENT);
+    const queryInfo = await parseQueryInfo(
+      valueComparatorELM,
+      [valueComparatorELM],
+      queryLocalId,
+      undefined,
+      {},
+      PATIENT
+    );
     expect(queryInfo).toEqual(EXPECTED_INTERNAL_VALUE_COMPARISON_QUERY);
   });
 });


### PR DESCRIPTION
# Summary
We've been using 2019-01-01 -> 2019-12-31 as our default interval if one is not passed-in as a calculation option. Now, when one is not provided, we use the effectivePeriod of the Measure, or, when absent, simply pass in no measurement period.

## New behavior
data-requirements operations will no longer default to a 2019 measurement period when one is not provided. Instead, the following will happen: 
 - If a measurement period start and end calculation option are provided, this period will be used
 - If a measurement period start calculation option is provided with no end, a period with duration 1 year beginning at the provided start will be used
 - If a measurement period end calculation option is provided with no start, a period with duration 1 year ending at the provided end will be used
 - If no measurement period start or end calculation option is provided, the measurement period will be determined by the effective period of the FHIR Measure, using the same logic as above to handle missing start and end dates
 - If no measurement period start or end calculation option is provided and no effectivePeriod is found on the measure, no measurement period will be used, and all dateFilters will be excluded

## Code changes
 - updated `getDataRequirements` function to take an additional `effectivePeriod` argument
 - created `extractDataRequirementsMeasurementPeriod` function
 - created `createIntervalFromEndpoints` function
 - created `hasMeasurementPeriodInfo` function
 - added testing

# Testing guidance
 - `npm run check`
 - download the included .zip file
 - unzip the file and copy the contents into the root level of `fqm-execution`
 - `sh run.sh`
 - now inspect each output file in `test-outputs` and ensure that the `dateFilters` all line up with the logic outlined in the new behavior section
 - Please reach out with questions!

[test-data.zip](https://github.com/projecttacoma/fqm-execution/files/10503813/test-data.zip)

