### PR TITLE
Patched canonical url with version not supported for libraryDataRequirements

### DIFF
--- a/test/unit/helpers/MeasureBundleHelpers.test.ts
+++ b/test/unit/helpers/MeasureBundleHelpers.test.ts
@@ -896,6 +896,27 @@ describe('MeasureBundleHelpers tests', () => {
       expect(elmJSONs).toHaveLength(3);
     });
 
+    it('properly gets libraries from test library bundle using canonical URL with version for rootLibRef', () => {
+      const measureBundle = getJSONFixture('bundle/measure-with-library-dependencies.json') as fhir4.Bundle;
+      const libraryBundle: fhir4.Bundle = {
+        resourceType: 'Bundle',
+        id: 'test-bundle',
+        type: 'transaction'
+      };
+      libraryBundle.entry = measureBundle.entry?.filter(e => e.resource?.resourceType === 'Library');
+
+      const rootLibRef = 'http://example.com/Library/library-TestRootLib|0.0.1';
+      const { cqls, rootLibIdentifier, elmJSONs } = extractLibrariesFromLibraryBundle(libraryBundle, rootLibRef);
+
+      expect(rootLibIdentifier).toStrictEqual({
+        id: 'TestRootLib',
+        version: '0.0.1'
+      });
+      // The test Bundle has 3 libraries, including the root one
+      expect(cqls).toHaveLength(3);
+      expect(elmJSONs).toHaveLength(3);
+    });
+
     it('throws an error if there is no root Library resource in the Library bundle', () => {
       const libraryBundle: fhir4.Bundle = {
         resourceType: 'Bundle',


### PR DESCRIPTION
# Summary
Passing in a canonical url of format `url|version` is now supported for libraryDataRequirements operations.

## New behavior
Previously, passing in a canonical url of format `url|version` for `--root-lib-ref` would throw an error since it tried to match the full canonical to the `url` field for each library in the bundle. Now the canonical is parsed correctly and matches url and version when appropriate

## Code changes
 - updated `extractLibrariesFromLibraryBundle` to parse canonical url of format `url|version` and pass through url and version to extractLibrariesFromBundle` when appropriate
 - updated `extractLibrariesFromBundle` to take optional `rootLibVersion` param and matches it to Library.version when present
 - testing
# Testing guidance
 - `npm run check`
 - `npm run build`
 - `node build/cli.js libraryDataRequirements -m "ecqm-content-r4-2021/bundles/measure/ColorectalCancerScreeningsFHIR/ColorectalCancerScreeningsFHIR-bundle.json" --root-lib-ref "http://ecqi.healthit.gov/ecqms/Library/ColorectalCancerScreeningsFHIR|0.0.003"` make sure an error is not thrown and resulting dataRequirements are as expected.