### PR TITLE
Specify errors that come from cql-execution

### DIFF
--- a/src/execution/Execution.ts
+++ b/src/execution/Execution.ts
@@ -74,7 +74,7 @@ export async function execute(
   } catch (e) {
     if (e instanceof Error) {
       e.message = `The following error occurred in the cql-execution engine: ${e.message}`;
-      
+
       if (e instanceof TypeError) {
         e.message +=
           '\n\n\t- Inspect the content of the ELM and ensure the data types in the expressions are correct\n\n';

--- a/src/execution/Execution.ts
+++ b/src/execution/Execution.ts
@@ -74,6 +74,11 @@ export async function execute(
   } catch (e) {
     if (e instanceof Error) {
       e.message = `The following error occurred in the cql-execution engine: ${e.message}`;
+      
+      if (e instanceof TypeError) {
+        e.message +=
+          '\n\n\t- Inspect the content of the ELM and ensure the data types in the expressions are correct\n\n';
+      }
     }
     throw e;
   }

--- a/src/execution/Execution.ts
+++ b/src/execution/Execution.ts
@@ -68,7 +68,6 @@ export async function execute(
   const lib = rep.resolve(rootLibIdentifier.id, rootLibIdentifier.version);
 
   const executor = new Executor(lib, codeService, parameters);
-
   let results: Results;
   try {
     results = await executor.exec(patientSource, executionDateTime);


### PR DESCRIPTION
# Summary
Adds more detailed error throwing in `Execution.ts` in the sense that it is more clear when the error came from the underlying `cql-execution` engine.

## New behavior
When the user encounters an issue from `cql-execution`, the error message and stack from `cql-execution` will be thrown (as was the case before) and the error message will explicitly state that the error came from `cql-execution`.

## Code changes
All changes occur in `Execution.ts`. If an error is thrown from the `executor`, it will be caught and the error message will be amended to include a blurb about the error occurring in `cql-execution`. That original error is thrown (throwing a whole new error results in the `fqm-execution` stack trace being included instead of the `cql-execution` stack trace).

# Testing Guidance
No unit tests exist for `Execution.ts`, so testing should be done via the CLI. 
1. Test with patient/measure bundles that we expect to successfully calculate. Check that no errors are thrown and that we get the expected behavior.
2. Test with patient/measure bundles that should result in a `cql-execution` issue and check that the resulting error message includes “The following error occurred in the cql-execution engine” and that the error stack points to where the issue occurred in `cql-execution`. 

	Example test case: Test with the `HospitalHarmHyperglycemiainHospitalizedPatientsFHIR` measure and patient bundles in the `ecqm-content-r4-2021` repository. These bundles have issues with date formatting, and so you should get an error from `interval.ts` (“List of intervals contains mismatched types”).
