### PR TITLE
Library data requirements should bypass query filter parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,7 @@ Get data requirements for a given Library bundle with a root Library reference.
 
 - `libraryBundle` <[fhir4.Bundle](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/5f88f0c7a11e86a19fc2356d0e11dfa7f472e3c9/types/fhir/r4.d.ts#L4325)>
 - `[options]` <[CalculatorTypes.CalculationOptions](https://github.com/projecttacoma/fqm-execution/blob/7c43b94521963703bdb43932bad60e5be3e7eeaa/src/types/Calculator.ts#L12)>
+  - Note: `measurementPeriodStart`/`measurementPeriodEnd` are omitted from library data requirements calculation if provided.
 
 **Returns**:
 

--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -38,6 +38,7 @@ import { Interval, DataProvider } from 'cql-execution';
 import { PatientSource } from 'cql-exec-fhir';
 import { pruneDetailedResults } from '../helpers/DetailedResultsHelpers';
 import { clearElmInfoCache } from '../helpers/elm/ELMInfoCache';
+import { omit } from 'lodash';
 
 /**
  * Calculate measure against a set of patients. Returning detailed results for each patient and population group.
@@ -532,6 +533,9 @@ export async function calculateLibraryDataRequirements(
   libraryBundle: fhir4.Bundle,
   options: CalculationOptions = {}
 ): Promise<DRCalculationOutput> {
+  // omit measurementPeriodStart/measurementPeriodEnd since there is no measure
+  options = omit(options, 'measurementPeriodStart', 'measurementPeriodEnd');
+
   if (options.rootLibRef === undefined) {
     throw new UnexpectedProperty('Root lib ref must be provided in order to calculate library dataRequirements');
   }

--- a/src/helpers/DataRequirementHelpers.ts
+++ b/src/helpers/DataRequirementHelpers.ts
@@ -79,9 +79,9 @@ export async function getDataRequirements(
   const allRetrievesPromises = allRetrieves.map(async retrieve => {
     // If the retrieves have a localId for the query and a known library name, we can get more info
     // on how the query filters the sources.
-    if (retrieve.queryLocalId && retrieve.queryLibraryName) {
+    if (retrieve.queryLocalId && retrieve.queryLibraryName && parameters['Measurement Period']) {
       const library = elmJSONs.find(lib => lib.library.identifier.id === retrieve.queryLibraryName);
-      if (library && parameters['Measurement Period']) {
+      if (library) {
         retrieve.queryInfo = await parseQueryInfo(
           library,
           elmJSONs,

--- a/src/helpers/DataRequirementHelpers.ts
+++ b/src/helpers/DataRequirementHelpers.ts
@@ -81,7 +81,7 @@ export async function getDataRequirements(
     // on how the query filters the sources.
     if (retrieve.queryLocalId && retrieve.queryLibraryName) {
       const library = elmJSONs.find(lib => lib.library.identifier.id === retrieve.queryLibraryName);
-      if (library) {
+      if (library && parameters['Measurement Period']) {
         retrieve.queryInfo = await parseQueryInfo(
           library,
           elmJSONs,


### PR DESCRIPTION
# Summary
Ensures query filter parsing is only performed on measure data requirements and not library data requirements.

## New Behavior
When running library data requirements, the detailed query filter parsing will no longer be performed. Library data requirements does not make use of a measurement period because there is no measure, and so it does not make sense to do detailed query filter parsing since a lot of the logic relies on constructing intervals for the (non-existent) measurement period.

## Code Changes
* Add check in the conditional of`getDataRequirements` for whether a measurement period is passed in (since it should only be passed in from `dataRequirements` and not `libraryDataRequirements`)
* `calculateLibraryDataRequirements` now omits `measurementPeriodStart`/`measurementPeriodEnd` if they are passed in as CLI options (we could change this to throw an error if that is more appropriate)

# Testing Guidance
* Run unit tests
* Run library data requirements on the master branch and compare the output to the results on this branch to see the effects of not performing detailed query filter parsing for library data requirements.
    * See the testing guidance in  https://github.com/projecttacoma/fqm-execution/pull/181 for an example library bundle and CLI command that can used for running library data requirements.
    * A good way to go about this is to save the output from the master branch to a file, then save the output from this branch to a file, and then use VSCode’s “Select for Compare”/“Compare with Selected” to see the code diff
