### PR TITLE
Allow more criteria language for SDE expression detection

### DIFF
--- a/src/calculation/ClauseResultsHelpers.ts
+++ b/src/calculation/ClauseResultsHelpers.ts
@@ -360,7 +360,13 @@ export function isSupplementalDataElementStatement(
 ): boolean {
   if (supplementalDataElements != undefined) {
     for (const supplementalData of supplementalDataElements) {
-      if (supplementalData.criteria.language === 'text/cql' && supplementalData.criteria.expression === statementName) {
+      // text/cql-identifier if correct, but text/cql.identifier used to be correct so for backwards compatibility we want to support both
+      if (
+        (supplementalData.criteria.language === 'text/cql' ||
+          supplementalData.criteria.language === 'text/cql.identifier' ||
+          supplementalData.criteria.language === 'text/cql-identifier') &&
+        supplementalData.criteria.expression === statementName
+      ) {
         return true;
       }
     }

--- a/src/calculation/ClauseResultsHelpers.ts
+++ b/src/calculation/ClauseResultsHelpers.ts
@@ -360,7 +360,8 @@ export function isSupplementalDataElementStatement(
 ): boolean {
   if (supplementalDataElements != undefined) {
     for (const supplementalData of supplementalDataElements) {
-      // text/cql-identifier if correct, but text/cql.identifier used to be correct so for backwards compatibility we want to support both
+      // text/cql-identifier is correct (https://build.fhir.org/ig/HL7/cqf-measures/measure-conformance.html#conformance-requirement-3-7),
+      // but text/cql.identifier used to be correct so for backwards compatibility we want to support both
       if (
         (supplementalData.criteria.language === 'text/cql' ||
           supplementalData.criteria.language === 'text/cql.identifier' ||

--- a/test/unit/ClauseResultsHelper.test.ts
+++ b/test/unit/ClauseResultsHelper.test.ts
@@ -164,32 +164,63 @@ describe('ClauseResultsHelpers', () => {
   });
 
   describe('isSupplementalDataElementStatement', () => {
-    let supplementalDataElements: any;
-    beforeEach(() => {
-      // Use the supplementalData from this measure for these tests.
-      const measure: fhir4.Measure = getJSONFixture('measure/simple-measure.json');
-      supplementalDataElements = measure.supplementalData;
-    });
-
     test('returns true if the statement is in a Supplemental Data Element given the statement name and the criteria.language is text/cql', () => {
-      const result = ClauseResultsHelpers.isSupplementalDataElementStatement(supplementalDataElements, 'SDE');
+      const result = ClauseResultsHelpers.isSupplementalDataElementStatement(
+        [
+          {
+            criteria: {
+              language: 'text/cql',
+              expression: 'SDE'
+            }
+          }
+        ],
+        'SDE'
+      );
       expect(result).toEqual(true);
     });
 
     test('returns true if the statement is in a Supplemental Data Element given the statement name and the criteria.language is text/cql.identifier', () => {
-      supplementalDataElements[0].criteria.language = 'text/cql.identifier';
-      const result = ClauseResultsHelpers.isSupplementalDataElementStatement(supplementalDataElements, 'SDE');
+      const result = ClauseResultsHelpers.isSupplementalDataElementStatement(
+        [
+          {
+            criteria: {
+              language: 'text/cql.identifier',
+              expression: 'SDE'
+            }
+          }
+        ],
+        'SDE'
+      );
       expect(result).toEqual(true);
     });
 
     test('returns true if the statement is in a Supplemental Data Element given the statement name and the criteria.language is text/cql-identifier', () => {
-      supplementalDataElements[0].criteria.language = 'text/cql-identifier';
-      const result = ClauseResultsHelpers.isSupplementalDataElementStatement(supplementalDataElements, 'SDE');
+      const result = ClauseResultsHelpers.isSupplementalDataElementStatement(
+        [
+          {
+            criteria: {
+              language: 'text/cql-identifier',
+              expression: 'SDE'
+            }
+          }
+        ],
+        'SDE'
+      );
       expect(result).toEqual(true);
     });
 
     test('returns false if the statement is not in the a Supplemental Data Element given the statement name', () => {
-      const result = ClauseResultsHelpers.isSupplementalDataElementStatement(supplementalDataElements, 'invalid');
+      const result = ClauseResultsHelpers.isSupplementalDataElementStatement(
+        [
+          {
+            criteria: {
+              language: 'text/cql-identifier',
+              expression: 'invalid'
+            }
+          }
+        ],
+        'SDE'
+      );
       expect(result).toEqual(false);
     });
 

--- a/test/unit/ClauseResultsHelper.test.ts
+++ b/test/unit/ClauseResultsHelper.test.ts
@@ -162,4 +162,40 @@ describe('ClauseResultsHelpers', () => {
       expect(ret).toBeNull();
     });
   });
+
+  describe('isSupplementalDataElementStatement', () => {
+    let supplementalDataElements: any;
+    beforeEach(() => {
+      // Use the supplementalData from this measure for these tests.
+      const measure: fhir4.Measure = getJSONFixture('measure/simple-measure.json');
+      supplementalDataElements = measure.supplementalData;
+    });
+
+    test('returns true if the statement is in a Supplemental Data Element given the statement name and the criteria.language is text/cql', () => {
+      const result = ClauseResultsHelpers.isSupplementalDataElementStatement(supplementalDataElements, 'SDE');
+      expect(result).toEqual(true);
+    });
+
+    test('returns true if the statement is in a Supplemental Data Element given the statement name and the criteria.language is text/cql.identifier', () => {
+      supplementalDataElements[0].criteria.language = 'text/cql.identifier';
+      const result = ClauseResultsHelpers.isSupplementalDataElementStatement(supplementalDataElements, 'SDE');
+      expect(result).toEqual(true);
+    });
+
+    test('returns true if the statement is in a Supplemental Data Element given the statement name and the criteria.language is text/cql-identifier', () => {
+      supplementalDataElements[0].criteria.language = 'text/cql-identifier';
+      const result = ClauseResultsHelpers.isSupplementalDataElementStatement(supplementalDataElements, 'SDE');
+      expect(result).toEqual(true);
+    });
+
+    test('returns false if the statement is not in the a Supplemental Data Element given the statement name', () => {
+      const result = ClauseResultsHelpers.isSupplementalDataElementStatement(supplementalDataElements, 'invalid');
+      expect(result).toEqual(false);
+    });
+
+    test('returns false if the Supplemental Data Element array is undefined', () => {
+      const result = ClauseResultsHelpers.isSupplementalDataElementStatement(undefined, 'SDE');
+      expect(result).toEqual(false);
+    });
+  });
 });


### PR DESCRIPTION
# Summary
According to [Conformance Requirement 3.7](https://build.fhir.org/ig/HL7/cqf-measures/measure-conformance.html#conformance-requirement-3-7), "references to expressions SHALL use the `text/cql-identifier` media type defined in the [CQL Specification](https://cql.hl7.org/2020May/07-physicalrepresentation.html#media-types-and-namespaces). This PR ensures that the function we have to detect supplemental data element expressions allows for the `criteria.language` to be either `text/cql` (what we are keeping), `text/cql.identifier` (for backwards compatibility because this is what it used to be), or `text/cql-identifier` (what it should be).
NOTE: We don't currently use the function being modified (it is commented out in `ClauseResultsBuilder.ts`), but we will likely use it in the future.

## New behavior
`isSupplementalDataElementStatement` now checks if the criteria.language is any of the three above variations. Unit tests for this function were also added to `ClauseResultsHelper.test.ts`.

## Code changes
- `src/calculation/ClauseResultsHelpers.ts` - changes to the `isSupplementalDataElementStatement` function.
- `test/unit/ClauseResultsHelper.test.ts` - new unit tests for these changes.

# Testing guidance
- `npm run check`
- Make sure all tests pass! 