### PR TITLE
Log full error in CLI

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -259,8 +259,7 @@ populatePatientBundles().then(async patientBundles => {
     }
   } catch (error) {
     if (error instanceof Error) {
-      console.error(error.message);
-      console.error(error.stack);
+      console.error(error);
     }
   }
 });


### PR DESCRIPTION
Examples using new error reporting from https://github.com/cqframework/cql-execution/pull/308:

Before:

![image](https://user-images.githubusercontent.com/16297930/224825047-d109a35b-b05f-4f8b-b745-454ce4bc58e5.png)

After:

![image](https://user-images.githubusercontent.com/16297930/224825120-ae062784-bfea-419f-892a-7493ac810b4b.png)

No need to limit ourselves to just logging the message and the stack in the CLI 