### PR TITLE
Proportion episode-based measure highlighting fix

### DIFF
--- a/src/calculation/ClauseResultsBuilder.ts
+++ b/src/calculation/ClauseResultsBuilder.ts
@@ -46,8 +46,8 @@ import {
  * @param {string} mainLibraryId - The identifier of the main library.
  * @param {ELM[]} elmLibraries - All ELM libraries for the measure.
  * @param {fhir4.MeasureGroup} populationGroup - The population group being calculated.
- * @param {boolean} calculateSDEs - Wether or not to treat SDEs as calculed/relevant or not.
- * @returns {StatementResult[]} The StatementResults list for each statement with it its relevance status populated.
+ * @param {boolean} calculateSDEs - Whether or not to treat SDEs as calculated/relevant or not.
+ * @returns {StatementResult[]} The StatementResults list for each statement with its relevance status populated.
  */
 export function buildStatementRelevanceMap(
   measure: fhir4.Measure,
@@ -132,7 +132,7 @@ export function buildStatementRelevanceMap(
 /**
  * Recursive helper function for the buildStatementRelevanceMap function. This marks a statement as relevant (or not
  * relevant but applicable) in the StatementResults list. It recurses and marks dependent statements also relevant
- * unless they have already been marked as 'TRUE' for their relevance statue. This function will never be called on
+ * unless they have already been marked as 'TRUE' for their relevance status. This function will never be called on
  * statements that are 'NA'.
  *
  * @private
@@ -816,7 +816,7 @@ export function buildPopulationGroupRelevanceMap(
   measureScoringCode?: string
 ): PopulationResult[] {
   // Episode of care measure
-  if (results.episodeResults) {
+  if (results.episodeResults && results.episodeResults.length > 0) {
     return buildPopulationRelevanceForAllEpisodes(results.episodeResults, group, measureScoringCode);
 
     // Normal patient based measure


### PR DESCRIPTION
# Summary
Fixes #211 

## New behavior
Before, `buildPopulationRelevanceForAllEpisodes()` was being called in scenarios where `episodeResults` is defined, but is an empty array. This caused the highlighting to be incorrect because `buildPopulationRelevanceForAllEpisodes` had no episode array to work with and therefore returned a `masterRelevanceResults` array where every entry had a result of false. Now, in `ClauseResultsBuilder.ts`, we check if `results.episodeResults` is defined AND has a length greater than 0. As a result, the correct highlighting is shown because it is treated as a normal patient based measure when calculating relevance. We set the precedent of using patient-level logic for this in `DetailedResultsBuilder.ts` (line 43) so I thought this fix was okay.

## Code changes
- `ClauseResultsBuilder.ts` - bug fix and some small grammar fixes

# Testing guidance
- In the issue, Matt attached a patient and measure bundle for this issue. 
- Add valuesets to the measure bundle.
- `npm cli -- detailed -m <path-to-measure-bundle> -b <path-to-patient-bundle> --debug`
- `cd debug/html`
- Open the clauses HTML and make sure the highlighting is what it is supposed to be (shown in the issue).
- Change the patient encounter in the patient bundle to have a status of `"finished"` rather than `"in-progress"`.
- Open the detailed results command again and make sure that highlighting appears, but that it is all green.