### PR TITLE
Upgrade to cql-execution v3.0.0-beta.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "axios": "^0.21.1",
         "commander": "^6.1.0",
         "cql-exec-fhir": "^2.1.3",
-        "cql-execution": "^3.0.0-beta.3",
+        "cql-execution": "^3.0.0-beta.4",
         "handlebars": "^4.7.7",
         "lodash": "^4.17.21",
         "moment": "^2.29.4",
@@ -2383,9 +2383,9 @@
       }
     },
     "node_modules/cql-execution": {
-      "version": "3.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.0-beta.3.tgz",
-      "integrity": "sha512-Mcr3vUilXfnz2qooyKzKZT3lexWTo/U7ktwt3DXnAFfsKfCYBe4zHyGv9ThRwW7OFMM/mr5LmM4szbm2StSfZw==",
+      "version": "3.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.0-beta.4.tgz",
+      "integrity": "sha512-TWAVtdZEr0h/P7CXRV+DBdPRdougBkG30AgXg/N8Xz4upbmc4zNTg2cfAAvMbJrsYl5sqZbJFcUvxaGcTZGjqw==",
       "dependencies": {
         "@lhncbc/ucum-lhc": "^4.1.3",
         "immutable": "^4.1.0",
@@ -10197,9 +10197,9 @@
       }
     },
     "cql-execution": {
-      "version": "3.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.0-beta.3.tgz",
-      "integrity": "sha512-Mcr3vUilXfnz2qooyKzKZT3lexWTo/U7ktwt3DXnAFfsKfCYBe4zHyGv9ThRwW7OFMM/mr5LmM4szbm2StSfZw==",
+      "version": "3.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.0-beta.4.tgz",
+      "integrity": "sha512-TWAVtdZEr0h/P7CXRV+DBdPRdougBkG30AgXg/N8Xz4upbmc4zNTg2cfAAvMbJrsYl5sqZbJFcUvxaGcTZGjqw==",
       "requires": {
         "@lhncbc/ucum-lhc": "^4.1.3",
         "immutable": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "axios": "^0.21.1",
     "commander": "^6.1.0",
     "cql-exec-fhir": "^2.1.3",
-    "cql-execution": "^3.0.0-beta.3",
+    "cql-execution": "^3.0.0-beta.4",
     "handlebars": "^4.7.7",
     "lodash": "^4.17.21",
     "moment": "^2.29.4",


### PR DESCRIPTION
# Summary
## New behavior
## Code changes
# Testing guidance

We should now have detailed execution error reporting just from this upgrade. Test with a bundle that throws an error and it should log the full annotated error