### PR TITLE
DataRequirements flattened relatedArtifact list

### DIFF
--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -570,7 +570,15 @@ export async function calculateDataRequirements(
     measureBundle,
     measure
   );
-  return DataRequirementHelpers.getDataRequirements(cqls, rootLibIdentifier, elmJSONs, options, effectivePeriod);
+  const dataRequirements = await DataRequirementHelpers.getDataRequirements(
+    cqls,
+    rootLibIdentifier,
+    elmJSONs,
+    options,
+    effectivePeriod
+  );
+  dataRequirements.results.relatedArtifact = DataRequirementHelpers.getFlattenedRelatedArtifacts(measureBundle);
+  return dataRequirements;
 }
 
 /**

--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -548,7 +548,12 @@ export async function calculateLibraryDataRequirements(
     options.rootLibRef
   );
 
-  return DataRequirementHelpers.getDataRequirements(cqls, rootLibIdentifier, elmJSONs, options);
+  const dataRequirements = await DataRequirementHelpers.getDataRequirements(cqls, rootLibIdentifier, elmJSONs, options);
+  dataRequirements.results.relatedArtifact = DataRequirementHelpers.getFlattenedRelatedArtifacts(
+    libraryBundle,
+    options.rootLibRef
+  );
+  return dataRequirements;
 }
 
 /**

--- a/src/helpers/DataRequirementHelpers.ts
+++ b/src/helpers/DataRequirementHelpers.ts
@@ -23,8 +23,9 @@ import * as GapsInCareHelpers from '../gaps/GapsReportBuilder';
 import { parseQueryInfo } from '../gaps/QueryFilterParser';
 import * as RetrievesHelper from '../gaps/RetrievesFinder';
 import { uniqBy } from 'lodash';
-import { DateTime, Interval } from 'cql-execution';
+import { DateTime, Interval, Library } from 'cql-execution';
 import { parseTimeStringAsUTC } from '../execution/ValueSetHelper';
+import * as MeasureBundleHelpers from './MeasureBundleHelpers';
 const FHIR_QUERY_PATTERN_URL = 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-fhirQueryPattern';
 
 /**
@@ -444,4 +445,41 @@ function hasMeasurementPeriodInfo(options: CalculationOptions, effectivePeriod?:
   return Boolean(
     options.measurementPeriodStart || options.measurementPeriodEnd || effectivePeriod?.start || effectivePeriod?.end
   );
+}
+
+/**
+ * Get a flattened list of all related artifacts in the measure bundle.
+ *
+ * @param measureBundle The measure bundle to fetch all RelatedArtifacts from
+ * @returns List of flattened related artifacts.
+ */
+export function getFlattenedRelatedArtifacts(measureBundle: fhir4.Bundle): fhir4.RelatedArtifact[] {
+  const measure = MeasureBundleHelpers.extractMeasureFromBundle(measureBundle);
+  // add the measure itself
+  const relatedArtifacts: fhir4.RelatedArtifact[] = [
+    {
+      type: 'depends-on',
+      display: 'Measure',
+      resource: measure.url ?? `Measure/${measure.id}`
+    }
+  ];
+
+  // copy over related artifacts from measure
+  if (measure.relatedArtifact) {
+    relatedArtifacts.push(...measure.relatedArtifact);
+  }
+
+  // copy over all related artifacts from all libraries
+  const libraries = measureBundle.entry?.filter(entry => entry.resource?.resourceType === 'Library');
+  if (libraries) {
+    libraries.forEach(libraryEntry => {
+      const library = libraryEntry.resource as fhir4.Library;
+      if (library.relatedArtifact) {
+        relatedArtifacts.push(...library.relatedArtifact);
+      }
+    });
+  }
+
+  // unique the relatedArtifacts
+  return uniqBy(relatedArtifacts, JSON.stringify);
 }

--- a/src/helpers/DataRequirementHelpers.ts
+++ b/src/helpers/DataRequirementHelpers.ts
@@ -453,20 +453,47 @@ function hasMeasurementPeriodInfo(options: CalculationOptions, effectivePeriod?:
  * @param measureBundle The measure bundle to fetch all RelatedArtifacts from
  * @returns List of flattened related artifacts.
  */
-export function getFlattenedRelatedArtifacts(measureBundle: fhir4.Bundle): fhir4.RelatedArtifact[] {
-  const measure = MeasureBundleHelpers.extractMeasureFromBundle(measureBundle);
-  // add the measure itself
-  const relatedArtifacts: fhir4.RelatedArtifact[] = [
-    {
+export function getFlattenedRelatedArtifacts(
+  measureBundle: fhir4.Bundle,
+  rootLibRef?: string
+): fhir4.RelatedArtifact[] {
+  const relatedArtifacts: fhir4.RelatedArtifact[] = [];
+
+  if (rootLibRef) {
+    // if a rootLibIdentifier is defined we should be excluding the measure info
+    const { libId: rootLibId, libVersion: rootLibVersion } = MeasureBundleHelpers.parseLibRef(rootLibRef);
+    // find the root library resource
+    const libraryEntry = measureBundle.entry?.find(entry => {
+      if (entry.resource?.resourceType === 'Library') {
+        const library = entry.resource as fhir4.Library;
+        return (
+          (library.url === rootLibId && (!rootLibVersion || library.version === rootLibVersion)) ||
+          library.id === rootLibId
+        );
+      }
+    });
+    if (libraryEntry?.resource) {
+      const library = libraryEntry.resource as fhir4.Library;
+      // add the root library itself
+      relatedArtifacts.push({
+        type: 'depends-on',
+        display: library.name ? `Library ${library.name}` : 'Library',
+        resource: library.url ?? `Library/${library.id}`
+      });
+    }
+  } else {
+    const measure = MeasureBundleHelpers.extractMeasureFromBundle(measureBundle);
+    // add the measure itself
+    relatedArtifacts.push({
       type: 'depends-on',
       display: measure.name ? `Measure ${measure.name}` : 'Measure',
       resource: measure.url ?? `Measure/${measure.id}`
-    }
-  ];
+    });
 
-  // copy over related artifacts from measure
-  if (measure.relatedArtifact) {
-    relatedArtifacts.push(...measure.relatedArtifact);
+    // copy over related artifacts from measure
+    if (measure.relatedArtifact) {
+      relatedArtifacts.push(...measure.relatedArtifact);
+    }
   }
 
   // copy over all related artifacts from all libraries

--- a/src/helpers/DataRequirementHelpers.ts
+++ b/src/helpers/DataRequirementHelpers.ts
@@ -23,7 +23,7 @@ import * as GapsInCareHelpers from '../gaps/GapsReportBuilder';
 import { parseQueryInfo } from '../gaps/QueryFilterParser';
 import * as RetrievesHelper from '../gaps/RetrievesFinder';
 import { uniqBy } from 'lodash';
-import { DateTime, Interval, Library } from 'cql-execution';
+import { DateTime, Interval } from 'cql-execution';
 import { parseTimeStringAsUTC } from '../execution/ValueSetHelper';
 import * as MeasureBundleHelpers from './MeasureBundleHelpers';
 const FHIR_QUERY_PATTERN_URL = 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-fhirQueryPattern';
@@ -459,7 +459,7 @@ export function getFlattenedRelatedArtifacts(measureBundle: fhir4.Bundle): fhir4
   const relatedArtifacts: fhir4.RelatedArtifact[] = [
     {
       type: 'depends-on',
-      display: 'Measure',
+      display: measure.name ? `Measure ${measure.name}` : 'Measure',
       resource: measure.url ?? `Measure/${measure.id}`
     }
   ];

--- a/src/helpers/MeasureBundleHelpers.ts
+++ b/src/helpers/MeasureBundleHelpers.ts
@@ -225,17 +225,7 @@ export function extractLibrariesFromLibraryBundle(
   rootLibIdentifier: ELMIdentifier;
   elmJSONs: ELM[];
 } {
-  let rootLibId: string;
-  let rootLibVersion: string | undefined;
-  if (isValidLibraryURL(rootLibRef)) {
-    if (rootLibRef.includes('|')) {
-      const splitRootLibRef = rootLibRef.split('|');
-      rootLibId = splitRootLibRef[0];
-      rootLibVersion = splitRootLibRef[1];
-    } else {
-      rootLibId = rootLibRef;
-    }
-  } else rootLibId = rootLibRef.substring(rootLibRef.indexOf('/') + 1);
+  const { libId: rootLibId, libVersion: rootLibVersion } = parseLibRef(rootLibRef);
 
   const { cqls, rootLibIdentifier, elmJSONs } = extractLibrariesFromBundle(libraryBundle, rootLibId, rootLibVersion);
 
@@ -244,6 +234,28 @@ export function extractLibrariesFromLibraryBundle(
   }
 
   return { cqls, rootLibIdentifier, elmJSONs };
+}
+
+/**
+ * Parses a library reference as canonical url or Library/id to an id and version.
+ *
+ * @param rootLibRef
+ * @returns Library id and version
+ */
+export function parseLibRef(libRef: string): { libId: string; libVersion: string | undefined } {
+  let libId: string;
+  let libVersion: string | undefined;
+  if (isValidLibraryURL(libRef)) {
+    if (libRef.includes('|')) {
+      const splitLibRef = libRef.split('|');
+      libId = splitLibRef[0];
+      libVersion = splitLibRef[1];
+    } else {
+      libId = libRef;
+    }
+  } else libId = libRef.substring(libRef.indexOf('/') + 1);
+
+  return { libId, libVersion };
 }
 
 /**

--- a/test/unit/DataRequirementHelpers.getFlattenedRelatedArtifacts.test.ts
+++ b/test/unit/DataRequirementHelpers.getFlattenedRelatedArtifacts.test.ts
@@ -1,6 +1,79 @@
 import { RelatedArtifact } from 'fhir/r4';
 import * as DataRequirementHelpers from '../../src/helpers/DataRequirementHelpers';
 
+const TEST_MEASURE: fhir4.BundleEntry = {
+  resource: {
+    resourceType: 'Measure',
+    status: 'draft',
+    id: 'TestMeasure',
+    url: 'http://example.org/Measure/TestMeasure',
+    library: ['http://example.org/Library/TestMainLibrary'],
+    relatedArtifact: [
+      {
+        type: 'depends-on',
+        display: 'Main Library',
+        resource: 'http://example.org/Library/TestMainLibrary'
+      }
+    ]
+  }
+};
+
+const TEST_MAIN_LIBRARY: fhir4.BundleEntry = {
+  resource: {
+    resourceType: 'Library',
+    status: 'draft',
+    type: {},
+    id: 'TestMainLibrary',
+    url: 'http://example.org/Library/TestMainLibrary',
+    relatedArtifact: [
+      {
+        type: 'depends-on',
+        display: 'FHIR model information',
+        resource: 'http://fhir.org/guides/cqf/common/Library/FHIR-ModelInfo|4.0.1'
+      }
+    ]
+  }
+};
+
+const TEST_MAIN_LIBRARY_USING_SUPPORTING: fhir4.BundleEntry = {
+  resource: {
+    resourceType: 'Library',
+    status: 'draft',
+    type: {},
+    id: 'TestMainLibrary',
+    url: 'http://example.org/Library/TestMainLibrary',
+    relatedArtifact: [
+      {
+        type: 'depends-on',
+        display: 'FHIR model information',
+        resource: 'http://fhir.org/guides/cqf/common/Library/FHIR-ModelInfo|4.0.1'
+      },
+      {
+        type: 'depends-on',
+        display: 'Supporting Library',
+        resource: 'http://example.org/Library/SupportingLibrary'
+      }
+    ]
+  }
+};
+
+const TEST_SUPPORTING_LIBRARY: fhir4.BundleEntry = {
+  resource: {
+    resourceType: 'Library',
+    status: 'draft',
+    type: {},
+    id: 'SupportingLibrary',
+    url: 'http://example.org/Library/SupportingLibrary',
+    relatedArtifact: [
+      {
+        type: 'depends-on',
+        display: 'FHIR model information',
+        resource: 'http://fhir.org/guides/cqf/common/Library/FHIR-ModelInfo|4.0.1'
+      }
+    ]
+  }
+};
+
 describe('DataRequirementHelpers', () => {
   describe('getFlattenedRelatedArtifacts', () => {
     test('throws error if bundle with no measure is passed in', () => {
@@ -16,39 +89,18 @@ describe('DataRequirementHelpers', () => {
       const result = DataRequirementHelpers.getFlattenedRelatedArtifacts({
         resourceType: 'Bundle',
         type: 'transaction',
-        entry: [
-          {
-            resource: {
-              resourceType: 'Measure',
-              status: 'draft',
-              id: 'TestMeasure',
-              url: 'http://example.org/Measure/TestMeasure',
-              library: ['http://example.org/Library/TestMainLibrary']
-            }
-          },
-          {
-            resource: {
-              resourceType: 'Library',
-              status: 'draft',
-              type: {},
-              id: 'TestMainLibrary',
-              url: 'http://example.org/Library/TestMainLibrary',
-              relatedArtifact: [
-                {
-                  type: 'depends-on',
-                  display: 'FHIR model information',
-                  resource: 'http://fhir.org/guides/cqf/common/Library/FHIR-ModelInfo|4.0.1'
-                }
-              ]
-            }
-          }
-        ]
+        entry: [TEST_MEASURE, TEST_MAIN_LIBRARY]
       });
       const expectedResult: RelatedArtifact[] = [
         {
           type: 'depends-on',
           display: 'Measure',
           resource: 'http://example.org/Measure/TestMeasure'
+        },
+        {
+          type: 'depends-on',
+          display: 'Main Library',
+          resource: 'http://example.org/Library/TestMainLibrary'
         },
         {
           type: 'depends-on',
@@ -76,22 +128,7 @@ describe('DataRequirementHelpers', () => {
               library: ['http://example.org/Library/TestMainLibrary']
             }
           },
-          {
-            resource: {
-              resourceType: 'Library',
-              status: 'draft',
-              type: {},
-              id: 'TestMainLibrary',
-              url: 'http://example.org/Library/TestMainLibrary',
-              relatedArtifact: [
-                {
-                  type: 'depends-on',
-                  display: 'FHIR model information',
-                  resource: 'http://fhir.org/guides/cqf/common/Library/FHIR-ModelInfo|4.0.1'
-                }
-              ]
-            }
-          }
+          TEST_MAIN_LIBRARY
         ]
       });
       const expectedResult: RelatedArtifact[] = [
@@ -115,61 +152,7 @@ describe('DataRequirementHelpers', () => {
       const result = DataRequirementHelpers.getFlattenedRelatedArtifacts({
         resourceType: 'Bundle',
         type: 'transaction',
-        entry: [
-          {
-            resource: {
-              resourceType: 'Measure',
-              status: 'draft',
-              id: 'TestMeasure',
-              url: 'http://example.org/Measure/TestMeasure',
-              library: ['http://example.org/Library/TestMainLibrary'],
-              relatedArtifact: [
-                {
-                  type: 'depends-on',
-                  display: 'Main Library',
-                  resource: 'http://example.org/Library/TestMainLibrary'
-                }
-              ]
-            }
-          },
-          {
-            resource: {
-              resourceType: 'Library',
-              status: 'draft',
-              type: {},
-              id: 'TestMainLibrary',
-              url: 'http://example.org/Library/TestMainLibrary',
-              relatedArtifact: [
-                {
-                  type: 'depends-on',
-                  display: 'FHIR model information',
-                  resource: 'http://fhir.org/guides/cqf/common/Library/FHIR-ModelInfo|4.0.1'
-                },
-                {
-                  type: 'depends-on',
-                  display: 'Supporting Library',
-                  resource: 'http://example.org/Library/SupportingLibrary'
-                }
-              ]
-            }
-          },
-          {
-            resource: {
-              resourceType: 'Library',
-              status: 'draft',
-              type: {},
-              id: 'SupportingLibrary',
-              url: 'http://example.org/Library/SupportingLibrary',
-              relatedArtifact: [
-                {
-                  type: 'depends-on',
-                  display: 'FHIR model information',
-                  resource: 'http://fhir.org/guides/cqf/common/Library/FHIR-ModelInfo|4.0.1'
-                }
-              ]
-            }
-          }
-        ]
+        entry: [TEST_MEASURE, TEST_MAIN_LIBRARY_USING_SUPPORTING, TEST_SUPPORTING_LIBRARY]
       });
       const expectedResult: RelatedArtifact[] = [
         {
@@ -203,61 +186,7 @@ describe('DataRequirementHelpers', () => {
         {
           resourceType: 'Bundle',
           type: 'transaction',
-          entry: [
-            {
-              resource: {
-                resourceType: 'Measure',
-                status: 'draft',
-                id: 'TestMeasure',
-                url: 'http://example.org/Measure/TestMeasure',
-                library: ['http://example.org/Library/TestMainLibrary'],
-                relatedArtifact: [
-                  {
-                    type: 'depends-on',
-                    display: 'Main Library',
-                    resource: 'http://example.org/Library/TestMainLibrary'
-                  }
-                ]
-              }
-            },
-            {
-              resource: {
-                resourceType: 'Library',
-                status: 'draft',
-                type: {},
-                id: 'TestMainLibrary',
-                url: 'http://example.org/Library/TestMainLibrary',
-                relatedArtifact: [
-                  {
-                    type: 'depends-on',
-                    display: 'FHIR model information',
-                    resource: 'http://fhir.org/guides/cqf/common/Library/FHIR-ModelInfo|4.0.1'
-                  },
-                  {
-                    type: 'depends-on',
-                    display: 'Supporting Library',
-                    resource: 'http://example.org/Library/SupportingLibrary'
-                  }
-                ]
-              }
-            },
-            {
-              resource: {
-                resourceType: 'Library',
-                status: 'draft',
-                type: {},
-                id: 'SupportingLibrary',
-                url: 'http://example.org/Library/SupportingLibrary',
-                relatedArtifact: [
-                  {
-                    type: 'depends-on',
-                    display: 'FHIR model information',
-                    resource: 'http://fhir.org/guides/cqf/common/Library/FHIR-ModelInfo|4.0.1'
-                  }
-                ]
-              }
-            }
-          ]
+          entry: [TEST_MEASURE, TEST_MAIN_LIBRARY_USING_SUPPORTING, TEST_SUPPORTING_LIBRARY]
         },
         'http://example.org/Library/TestMainLibrary'
       );

--- a/test/unit/DataRequirementHelpers.getFlattenedRelatedArtifacts.test.ts
+++ b/test/unit/DataRequirementHelpers.getFlattenedRelatedArtifacts.test.ts
@@ -197,5 +197,90 @@ describe('DataRequirementHelpers', () => {
       expect(result).toHaveLength(expectedResult.length);
       expect(result).toEqual(expect.arrayContaining(expectedResult));
     });
+
+    test('can return library only related artifacts from nested and redundant relatedArtifact entries with deduplication', () => {
+      const result = DataRequirementHelpers.getFlattenedRelatedArtifacts(
+        {
+          resourceType: 'Bundle',
+          type: 'transaction',
+          entry: [
+            {
+              resource: {
+                resourceType: 'Measure',
+                status: 'draft',
+                id: 'TestMeasure',
+                url: 'http://example.org/Measure/TestMeasure',
+                library: ['http://example.org/Library/TestMainLibrary'],
+                relatedArtifact: [
+                  {
+                    type: 'depends-on',
+                    display: 'Main Library',
+                    resource: 'http://example.org/Library/TestMainLibrary'
+                  }
+                ]
+              }
+            },
+            {
+              resource: {
+                resourceType: 'Library',
+                status: 'draft',
+                type: {},
+                id: 'TestMainLibrary',
+                url: 'http://example.org/Library/TestMainLibrary',
+                relatedArtifact: [
+                  {
+                    type: 'depends-on',
+                    display: 'FHIR model information',
+                    resource: 'http://fhir.org/guides/cqf/common/Library/FHIR-ModelInfo|4.0.1'
+                  },
+                  {
+                    type: 'depends-on',
+                    display: 'Supporting Library',
+                    resource: 'http://example.org/Library/SupportingLibrary'
+                  }
+                ]
+              }
+            },
+            {
+              resource: {
+                resourceType: 'Library',
+                status: 'draft',
+                type: {},
+                id: 'SupportingLibrary',
+                url: 'http://example.org/Library/SupportingLibrary',
+                relatedArtifact: [
+                  {
+                    type: 'depends-on',
+                    display: 'FHIR model information',
+                    resource: 'http://fhir.org/guides/cqf/common/Library/FHIR-ModelInfo|4.0.1'
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        'http://example.org/Library/TestMainLibrary'
+      );
+      const expectedResult: RelatedArtifact[] = [
+        {
+          type: 'depends-on',
+          display: 'Library',
+          resource: 'http://example.org/Library/TestMainLibrary'
+        },
+        {
+          type: 'depends-on',
+          display: 'Supporting Library',
+          resource: 'http://example.org/Library/SupportingLibrary'
+        },
+        {
+          type: 'depends-on',
+          display: 'FHIR model information',
+          resource: 'http://fhir.org/guides/cqf/common/Library/FHIR-ModelInfo|4.0.1'
+        }
+      ];
+
+      expect(result).toHaveLength(expectedResult.length);
+      expect(result).toEqual(expect.arrayContaining(expectedResult));
+    });
   });
 });

--- a/test/unit/DataRequirementHelpers.getFlattenedRelatedArtifacts.test.ts
+++ b/test/unit/DataRequirementHelpers.getFlattenedRelatedArtifacts.test.ts
@@ -61,6 +61,56 @@ describe('DataRequirementHelpers', () => {
       expect(result).toEqual(expect.arrayContaining(expectedResult));
     });
 
+    test('can return related artifacts from simple bundle with measure with name and main library', () => {
+      const result = DataRequirementHelpers.getFlattenedRelatedArtifacts({
+        resourceType: 'Bundle',
+        type: 'transaction',
+        entry: [
+          {
+            resource: {
+              resourceType: 'Measure',
+              status: 'draft',
+              id: 'TestMeasure',
+              name: 'Test Measure',
+              url: 'http://example.org/Measure/TestMeasure',
+              library: ['http://example.org/Library/TestMainLibrary']
+            }
+          },
+          {
+            resource: {
+              resourceType: 'Library',
+              status: 'draft',
+              type: {},
+              id: 'TestMainLibrary',
+              url: 'http://example.org/Library/TestMainLibrary',
+              relatedArtifact: [
+                {
+                  type: 'depends-on',
+                  display: 'FHIR model information',
+                  resource: 'http://fhir.org/guides/cqf/common/Library/FHIR-ModelInfo|4.0.1'
+                }
+              ]
+            }
+          }
+        ]
+      });
+      const expectedResult: RelatedArtifact[] = [
+        {
+          type: 'depends-on',
+          display: 'Measure Test Measure',
+          resource: 'http://example.org/Measure/TestMeasure'
+        },
+        {
+          type: 'depends-on',
+          display: 'FHIR model information',
+          resource: 'http://fhir.org/guides/cqf/common/Library/FHIR-ModelInfo|4.0.1'
+        }
+      ];
+
+      expect(result).toHaveLength(expectedResult.length);
+      expect(result).toEqual(expect.arrayContaining(expectedResult));
+    });
+
     test('can return related artifacts from nested and redundant relatedArtifact entries with deduplication', () => {
       const result = DataRequirementHelpers.getFlattenedRelatedArtifacts({
         resourceType: 'Bundle',

--- a/test/unit/DataRequirementHelpers.getFlattenedRelatedArtifacts.test.ts
+++ b/test/unit/DataRequirementHelpers.getFlattenedRelatedArtifacts.test.ts
@@ -1,0 +1,151 @@
+import { RelatedArtifact } from 'fhir/r4';
+import * as DataRequirementHelpers from '../../src/helpers/DataRequirementHelpers';
+
+describe('DataRequirementHelpers', () => {
+  describe('getFlattenedRelatedArtifacts', () => {
+    test('throws error if bundle with no measure is passed in empty measure bundle is passed in', () => {
+      expect(() => {
+        DataRequirementHelpers.getFlattenedRelatedArtifacts({
+          resourceType: 'Bundle',
+          type: 'transaction'
+        });
+      }).toThrowError('Measure resource does not exist in provided measure bundle');
+    });
+
+    test('can return related artifacts from simple bundle with measure and main library', () => {
+      const result = DataRequirementHelpers.getFlattenedRelatedArtifacts({
+        resourceType: 'Bundle',
+        type: 'transaction',
+        entry: [
+          {
+            resource: {
+              resourceType: 'Measure',
+              status: 'draft',
+              id: 'TestMeasure',
+              url: 'http://example.org/Measure/TestMeasure',
+              library: ['http://example.org/Library/TestMainLibrary']
+            }
+          },
+          {
+            resource: {
+              resourceType: 'Library',
+              status: 'draft',
+              type: {},
+              id: 'TestMainLibrary',
+              url: 'http://example.org/Library/TestMainLibrary',
+              relatedArtifact: [
+                {
+                  type: 'depends-on',
+                  display: 'FHIR model information',
+                  resource: 'http://fhir.org/guides/cqf/common/Library/FHIR-ModelInfo|4.0.1'
+                }
+              ]
+            }
+          }
+        ]
+      });
+      const expectedResult: RelatedArtifact[] = [
+        {
+          type: 'depends-on',
+          display: 'Measure',
+          resource: 'http://example.org/Measure/TestMeasure'
+        },
+        {
+          type: 'depends-on',
+          display: 'FHIR model information',
+          resource: 'http://fhir.org/guides/cqf/common/Library/FHIR-ModelInfo|4.0.1'
+        }
+      ];
+
+      expect(result).toHaveLength(expectedResult.length);
+      expect(result).toEqual(expect.arrayContaining(expectedResult));
+    });
+
+    test('can return related artifacts from nested and redundant relatedArtifact entries with deduplication', () => {
+      const result = DataRequirementHelpers.getFlattenedRelatedArtifacts({
+        resourceType: 'Bundle',
+        type: 'transaction',
+        entry: [
+          {
+            resource: {
+              resourceType: 'Measure',
+              status: 'draft',
+              id: 'TestMeasure',
+              url: 'http://example.org/Measure/TestMeasure',
+              library: ['http://example.org/Library/TestMainLibrary'],
+              relatedArtifact: [
+                {
+                  type: 'depends-on',
+                  display: 'Main Library',
+                  resource: 'http://example.org/Library/TestMainLibrary'
+                }
+              ]
+            }
+          },
+          {
+            resource: {
+              resourceType: 'Library',
+              status: 'draft',
+              type: {},
+              id: 'TestMainLibrary',
+              url: 'http://example.org/Library/TestMainLibrary',
+              relatedArtifact: [
+                {
+                  type: 'depends-on',
+                  display: 'FHIR model information',
+                  resource: 'http://fhir.org/guides/cqf/common/Library/FHIR-ModelInfo|4.0.1'
+                },
+                {
+                  type: 'depends-on',
+                  display: 'Supporting Library',
+                  resource: 'http://example.org/Library/SupportingLibrary'
+                }
+              ]
+            }
+          },
+          {
+            resource: {
+              resourceType: 'Library',
+              status: 'draft',
+              type: {},
+              id: 'SupportingLibrary',
+              url: 'http://example.org/Library/SupportingLibrary',
+              relatedArtifact: [
+                {
+                  type: 'depends-on',
+                  display: 'FHIR model information',
+                  resource: 'http://fhir.org/guides/cqf/common/Library/FHIR-ModelInfo|4.0.1'
+                }
+              ]
+            }
+          }
+        ]
+      });
+      const expectedResult: RelatedArtifact[] = [
+        {
+          type: 'depends-on',
+          display: 'Measure',
+          resource: 'http://example.org/Measure/TestMeasure'
+        },
+        {
+          type: 'depends-on',
+          display: 'Main Library',
+          resource: 'http://example.org/Library/TestMainLibrary'
+        },
+        {
+          type: 'depends-on',
+          display: 'Supporting Library',
+          resource: 'http://example.org/Library/SupportingLibrary'
+        },
+        {
+          type: 'depends-on',
+          display: 'FHIR model information',
+          resource: 'http://fhir.org/guides/cqf/common/Library/FHIR-ModelInfo|4.0.1'
+        }
+      ];
+
+      expect(result).toHaveLength(expectedResult.length);
+      expect(result).toEqual(expect.arrayContaining(expectedResult));
+    });
+  });
+});

--- a/test/unit/DataRequirementHelpers.getFlattenedRelatedArtifacts.test.ts
+++ b/test/unit/DataRequirementHelpers.getFlattenedRelatedArtifacts.test.ts
@@ -3,7 +3,7 @@ import * as DataRequirementHelpers from '../../src/helpers/DataRequirementHelper
 
 describe('DataRequirementHelpers', () => {
   describe('getFlattenedRelatedArtifacts', () => {
-    test('throws error if bundle with no measure is passed in empty measure bundle is passed in', () => {
+    test('throws error if bundle with no measure is passed in', () => {
       expect(() => {
         DataRequirementHelpers.getFlattenedRelatedArtifacts({
           resourceType: 'Bundle',

--- a/test/unit/helpers/MeasureBundleHelpers.test.ts
+++ b/test/unit/helpers/MeasureBundleHelpers.test.ts
@@ -13,7 +13,8 @@ import {
   getObservationResultForPopulation,
   extractLibrariesFromMeasureBundle,
   extractLibrariesFromLibraryBundle,
-  isRatioMeasure
+  isRatioMeasure,
+  parseLibRef
 } from '../../../src/helpers/MeasureBundleHelpers';
 import { PopulationType } from '../../../src/types/Enums';
 import { ValueSetResolver } from '../../../src/execution/ValueSetResolver';
@@ -1133,6 +1134,27 @@ describe('MeasureBundleHelpers tests', () => {
         populationType: PopulationType.OBSERV,
         criteriaExpression: 'numerFunc',
         result: false
+      });
+    });
+  });
+
+  describe('parseLibRef', () => {
+    it('handles canonical with version', () => {
+      expect(parseLibRef('http://example.org/TestLibrary|1.0.1')).toEqual({
+        libId: 'http://example.org/TestLibrary',
+        libVersion: '1.0.1'
+      });
+    });
+
+    it('handles canonical without version', () => {
+      expect(parseLibRef('http://example.org/TestLibrary')).toEqual({
+        libId: 'http://example.org/TestLibrary'
+      });
+    });
+
+    it('handles Library/id reference', () => {
+      expect(parseLibRef('Library/TestLibrary')).toEqual({
+        libId: 'TestLibrary'
       });
     });
   });


### PR DESCRIPTION
# Summary
Adds a combined/flattened version of all `relatedArtifact` lists in a measure bundle to the measure data-requirements output.

## New behavior
Combines all `relatedArtifact` objects in a measure bundle's Measure and Library resources into one list, makes the list unique and puts the resulting list on the `relatedArtifact` property of the the data-requirements output.

## Code changes
`src/helpers/DataRequirementHelpers.ts` - New helper function `getFlattenedRelatedArtifacts` that compiles the flat list of `relatedArtifact`s.
`src/calculation/Calculator.ts` - Calls new helper function to get the list assembled and adds it to the dataRequirements output.

# Testing guidance
Run unit tests. Run data-requirements on a measure bundle and spot check that elements in the `relatedArtifacts` attributes on Measure and Library resources are ending up in the `relatedArtifacts` attribute in the resulting data-requirements output.