### PR TITLE
DRY extraction of measure for calculation

### DIFF
--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -564,9 +564,12 @@ export async function calculateDataRequirements(
   options: CalculationOptions = {}
 ): Promise<DRCalculationOutput> {
   // Extract the library ELM, and the id of the root library, from the measure bundle
-  const { cqls, rootLibIdentifier, elmJSONs } = MeasureBundleHelpers.extractLibrariesFromMeasureBundle(measureBundle);
   const measure = MeasureBundleHelpers.extractMeasureFromBundle(measureBundle);
   const effectivePeriod = measure.effectivePeriod;
+  const { cqls, rootLibIdentifier, elmJSONs } = MeasureBundleHelpers.extractLibrariesFromMeasureBundle(
+    measureBundle,
+    measure
+  );
   return DataRequirementHelpers.getDataRequirements(cqls, rootLibIdentifier, elmJSONs, options, effectivePeriod);
 }
 

--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -565,7 +565,8 @@ export async function calculateDataRequirements(
 ): Promise<DRCalculationOutput> {
   // Extract the library ELM, and the id of the root library, from the measure bundle
   const { cqls, rootLibIdentifier, elmJSONs } = MeasureBundleHelpers.extractLibrariesFromMeasureBundle(measureBundle);
-  const effectivePeriod = MeasureBundleHelpers.extractMeasureFromBundle(measureBundle).effectivePeriod;
+  const measure = MeasureBundleHelpers.extractMeasureFromBundle(measureBundle);
+  const effectivePeriod = measure.effectivePeriod;
   return DataRequirementHelpers.getDataRequirements(cqls, rootLibIdentifier, elmJSONs, options, effectivePeriod);
 }
 

--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -71,12 +71,12 @@ export async function calculate<T extends CalculationOptions>(
   options.calculateSDEs = options.calculateSDEs ?? true;
   options.calculateClauseCoverage = options.calculateClauseCoverage ?? true;
   // Get the default measurement period out of the Measure object
-  const measurementPeriod = MeasureBundleHelpers.extractMeasurementPeriod(measureBundle);
+  const measure = MeasureBundleHelpers.extractMeasureFromBundle(measureBundle);
+  const measurementPeriod = MeasureBundleHelpers.extractMeasurementPeriod(measure);
   // Set the measurement period start/end, but only if the caller didn't specify one
   options.measurementPeriodStart = options.measurementPeriodStart ?? measurementPeriod.measurementPeriodStart;
   options.measurementPeriodEnd = options.measurementPeriodEnd ?? measurementPeriod.measurementPeriodEnd;
 
-  const measure = MeasureBundleHelpers.extractMeasureFromBundle(measureBundle);
   const executionResults: ExecutionResult<DetailedPopulationGroupResult>[] = [];
 
   const results = await Execution.execute(measureBundle, patientSource, options, valueSetCache, debugObject);

--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -43,7 +43,7 @@ import { omit } from 'lodash';
 /**
  * Calculate measure against a set of patients. Returning detailed results for each patient and population group.
  *
- * @param measureBundle Bundle with a MeasureResource and all necessary data for execution.
+ * @param measureBundle Bundle with a Measure Resource and all necessary data for execution.
  * @param patientBundles List of bundles of patients to be executed.
  * @param options Options for calculation.
  * @param valueSetCache Cache of existing valuesets
@@ -70,8 +70,9 @@ export async function calculate<T extends CalculationOptions>(
   options.calculateHTML = options.calculateHTML ?? true;
   options.calculateSDEs = options.calculateSDEs ?? true;
   options.calculateClauseCoverage = options.calculateClauseCoverage ?? true;
-  // Get the default measurement period out of the Measure object
+
   const measure = MeasureBundleHelpers.extractMeasureFromBundle(measureBundle);
+  // Get the default measurement period out of the Measure object
   const measurementPeriod = MeasureBundleHelpers.extractMeasurementPeriod(measure);
   // Set the measurement period start/end, but only if the caller didn't specify one
   options.measurementPeriodStart = options.measurementPeriodStart ?? measurementPeriod.measurementPeriodStart;
@@ -79,7 +80,7 @@ export async function calculate<T extends CalculationOptions>(
 
   const executionResults: ExecutionResult<DetailedPopulationGroupResult>[] = [];
 
-  const results = await Execution.execute(measureBundle, patientSource, options, valueSetCache, debugObject);
+  const results = await Execution.execute(measure, measureBundle, patientSource, options, valueSetCache, debugObject);
   if (!results.rawResults) {
     throw new Error(results.errorMessage ?? 'something happened with no error message');
   }
@@ -339,7 +340,7 @@ export async function calculateAggregateMeasureReport(
 /**
  * Get raw results from cql-execution
  *
- * @param measureBundle Bundle with a MeasureResource and all necessary data for execution.
+ * @param measureBundle Bundle with a Measure Resource and all necessary data for execution.
  * @param patientBundles List of bundles of patients to be executed.
  * @param options Options for calculation.
  * @param valueSetCache Cache of existing valuesets
@@ -354,7 +355,8 @@ export async function calculateRaw(
   const debugObject: DebugOutput | undefined = options.enableDebugOutput ? <DebugOutput>{} : undefined;
   // Get the PatientSource to use for calculation.
   const patientSource = resolvePatientSource(patientBundles, options);
-  const results = await Execution.execute(measureBundle, patientSource, options, valueSetCache, debugObject);
+  const measure = MeasureBundleHelpers.extractMeasureFromBundle(measureBundle);
+  const results = await Execution.execute(measure, measureBundle, patientSource, options, valueSetCache, debugObject);
   if (results.rawResults) {
     return { results: results.rawResults, debugOutput: debugObject, valueSetCache: results.valueSetCache };
   } else {

--- a/src/execution/Execution.ts
+++ b/src/execution/Execution.ts
@@ -4,9 +4,10 @@ import { parseTimeStringAsUTC, getMissingDependentValuesets } from './ValueSetHe
 import { ValueSetResolver } from './ValueSetResolver';
 import { UnexpectedResource } from '../types/errors/CustomErrors';
 import { retrieveELMInfo } from '../helpers/elm/ELMInfoCache';
+import { MeasureWithLibrary } from '../helpers/MeasureBundleHelpers';
 
 export async function execute(
-  measure: fhir4.Measure,
+  measure: MeasureWithLibrary,
   measureBundle: fhir4.Bundle,
   patientSource: DataProvider,
   options: CalculationOptions,

--- a/src/execution/Execution.ts
+++ b/src/execution/Execution.ts
@@ -1,12 +1,12 @@
 import { CalculationOptions, RawExecutionData, DebugOutput } from '../types/Calculator';
 import { DataProvider, DateTime, Interval, Executor, Results } from 'cql-execution';
 import { parseTimeStringAsUTC, getMissingDependentValuesets } from './ValueSetHelper';
-import * as MeasureBundleHelpers from '../helpers/MeasureBundleHelpers';
 import { ValueSetResolver } from './ValueSetResolver';
 import { UnexpectedResource } from '../types/errors/CustomErrors';
 import { retrieveELMInfo } from '../helpers/elm/ELMInfoCache';
 
 export async function execute(
+  measure: fhir4.Measure,
   measureBundle: fhir4.Bundle,
   patientSource: DataProvider,
   options: CalculationOptions,
@@ -14,8 +14,6 @@ export async function execute(
   debugObject?: DebugOutput
 ): Promise<RawExecutionData> {
   // Determine "root" library by looking at which lib is referenced by populations, and pull out the ELM
-
-  const measure = MeasureBundleHelpers.extractMeasureFromBundle(measureBundle);
 
   // check for any missing valuesets
   const valueSets: fhir4.ValueSet[] = [];

--- a/src/helpers/MeasureBundleHelpers.ts
+++ b/src/helpers/MeasureBundleHelpers.ts
@@ -312,13 +312,15 @@ export function extractLibrariesFromBundle(
  * Returns the cqls, rootLibIdentifier, and elmJSONs for a collection of libraries
  * within a Measure Bundle
  */
-export function extractLibrariesFromMeasureBundle(measureBundle: fhir4.Bundle): {
+export function extractLibrariesFromMeasureBundle(
+  measureBundle: fhir4.Bundle,
+  measure?: MeasureWithLibrary
+): {
   cqls: ExtractedLibrary[];
   rootLibIdentifier: ELMIdentifier;
   elmJSONs: ELM[];
 } {
-  const measure = extractMeasureFromBundle(measureBundle);
-  const rootLibRef = measure.library[0];
+  const rootLibRef = measure ? measure.library[0] : extractMeasureFromBundle(measureBundle).library[0];
   let rootLibId: string;
   if (isValidLibraryURL(rootLibRef)) rootLibId = rootLibRef;
   else rootLibId = rootLibRef.substring(rootLibRef.indexOf('/') + 1);

--- a/src/helpers/MeasureBundleHelpers.ts
+++ b/src/helpers/MeasureBundleHelpers.ts
@@ -186,20 +186,15 @@ export function codeableConceptToPopulationType(concept: fhir4.CodeableConcept |
 }
 
 /**
- * Pulls the measurement period out of the Measure resource in the provided bundle, assuming one is set.
+ * Pulls the measurement period out of the provided FHIR Measure resource, assuming one is set.
  * NOTE: the default start/end values are also set in Execution.ts
  * so if this date is changed from 2019 it must also be changed there
  *
- * @param {fhir4.Bundle} measureBundle the FHIR Bundle object containing the Measure resource.
+ * @param measure FHIR Measure resource
  * @returns {CalculationOptions} object with only the measurement period start/end fields filled out,
  * or the year 2019 set as the calculation period if not set in the Measure.
  */
-export function extractMeasurementPeriod(measureBundle: fhir4.Bundle): CalculationOptions {
-  const measureEntry = measureBundle.entry?.find(e => e.resource?.resourceType === 'Measure');
-  if (!measureEntry || !measureEntry.resource) {
-    throw new UnexpectedResource('Measure resource was not found in provided measure bundle');
-  }
-  const measure = measureEntry.resource as fhir4.Measure;
+export function extractMeasurementPeriod(measure: fhir4.Measure): CalculationOptions {
   return {
     measurementPeriodStart: measure.effectivePeriod?.start || '2019-01-01',
     measurementPeriodEnd: measure.effectivePeriod?.end || '2019-12-31'

--- a/test/unit/helpers/ELMInfoCache.test.ts
+++ b/test/unit/helpers/ELMInfoCache.test.ts
@@ -3,7 +3,8 @@ import { retrieveELMInfo, clearElmInfoCache } from '../../../src/helpers/elm/ELM
 import { getJSONFixture } from './testHelpers';
 
 const measureBundle: fhir4.Bundle = getJSONFixture('bundle/measure-with-library-dependencies.json');
-const measure = measureBundle.entry?.find(e => e.resource?.resourceType === 'Measure')?.resource as fhir4.Measure;
+const measure = measureBundle.entry?.find(e => e.resource?.resourceType === 'Measure')
+  ?.resource as MeasureBundleHelpers.MeasureWithLibrary;
 const TEST_ELFB_OUTPUT = { cqls: [], rootLibIdentifier: { id: 'test-id', version: 'test-version' }, elmJSONs: [] };
 
 describe('ELMInfoCache tests', () => {

--- a/test/unit/helpers/MeasureBundleHelpers.test.ts
+++ b/test/unit/helpers/MeasureBundleHelpers.test.ts
@@ -683,94 +683,62 @@ describe('MeasureBundleHelpers tests', () => {
 
   describe('extractMeasurementPeriod', () => {
     it('Measurement period start set on measure', () => {
-      const measureBundleFixture: fhir4.Bundle = {
-        resourceType: 'Bundle',
-        entry: [
-          {
-            resource: {
-              resourceType: 'Measure',
-              effectivePeriod: {
-                start: '2000-01-01'
-              },
-              status: 'draft'
-            }
-          }
-        ],
-        type: 'transaction'
+      const measureFixture: fhir4.Measure = {
+        resourceType: 'Measure',
+        effectivePeriod: {
+          start: '2000-01-01'
+        },
+        status: 'draft'
       };
 
-      const mpConfig = extractMeasurementPeriod(measureBundleFixture);
+      const mpConfig = extractMeasurementPeriod(measureFixture);
 
       expect(mpConfig.measurementPeriodStart).toBe('2000-01-01');
       expect(mpConfig.measurementPeriodEnd).toBe('2019-12-31');
     });
 
     it('Measurement period end set on measure', () => {
-      const measureBundleFixture: fhir4.Bundle = {
-        resourceType: 'Bundle',
-        entry: [
-          {
-            resource: {
-              resourceType: 'Measure',
-              effectivePeriod: {
-                end: '2000-12-31'
-              },
-              status: 'draft'
-            }
-          }
-        ],
-        type: 'transaction'
+      const measureFixture: fhir4.Measure = {
+        resourceType: 'Measure',
+        effectivePeriod: {
+          end: '2000-12-31'
+        },
+        status: 'draft'
       };
 
-      const mpConfig = extractMeasurementPeriod(measureBundleFixture);
+      const mpConfig = extractMeasurementPeriod(measureFixture);
 
       expect(mpConfig.measurementPeriodStart).toBe('2019-01-01');
       expect(mpConfig.measurementPeriodEnd).toBe('2000-12-31');
     });
 
     it('Measurement period start and end set on measure', () => {
-      const measureBundleFixture: fhir4.Bundle = {
-        resourceType: 'Bundle',
-        entry: [
-          {
-            resource: {
-              resourceType: 'Measure',
-              effectivePeriod: {
-                start: '2000-01-01',
-                end: '2000-12-31'
-              },
-              status: 'draft'
-            }
-          }
-        ],
-        type: 'transaction'
+      const measureFixture: fhir4.Measure = {
+        resourceType: 'Measure',
+        effectivePeriod: {
+          start: '2000-01-01',
+          end: '2000-12-31'
+        },
+        status: 'draft'
       };
 
-      const mpConfig = extractMeasurementPeriod(measureBundleFixture);
+      const mpConfig = extractMeasurementPeriod(measureFixture);
 
       expect(mpConfig.measurementPeriodStart).toBe('2000-01-01');
       expect(mpConfig.measurementPeriodEnd).toBe('2000-12-31');
     });
 
     it('Neither set on measure', () => {
-      const measureBundleFixture: fhir4.Bundle = {
-        resourceType: 'Bundle',
-        entry: [
-          {
-            resource: {
-              resourceType: 'Measure',
-              effectivePeriod: {
-                start: '',
-                end: ''
-              },
-              status: 'draft'
-            }
-          }
-        ],
-        type: 'transaction'
+      const measureFixture: fhir4.Measure = {
+        resourceType: 'Measure',
+        effectivePeriod: {
+          start: '',
+          end: ''
+        },
+        status: 'draft'
       };
 
-      const mpConfig = extractMeasurementPeriod(measureBundleFixture);
+      const mpConfig = extractMeasurementPeriod(measureFixture);
 
       expect(mpConfig.measurementPeriodStart).toBe('2019-01-01');
       expect(mpConfig.measurementPeriodEnd).toBe('2019-12-31');


### PR DESCRIPTION
# Summary
Code refactors related to measure extraction for the `calculate` function and its helpers.

## New behavior
**Main motivation**: Future work related to composite measure calculation will require looping over component measures and calling various helpers on each component measure. Therefore, we want to limit the amount of code duplication related to measure extraction since we will want to specify the measure outside the helper functions when looping over the components rather than doing a `.find()` for the first measure in the given bundle every time.

No new behavior should be introduced. 

## Code changes
- Update `extractMeasurementPeriod` to take in a measure rather than a bundle
- Update `execute` to take in a measure *in addition to* a bundle
- Update `extractLibrariesFromMeasureBundle` to take in an *optional* measure *in addition to* a bundle
- Various unit test updates to reflect changes to function inputs

Some context behind these changes:

- The change to `extractMeasurementPeriod` is pretty self-explanatory - there's no reason to duplicate the measure extraction within `calculate` and within `extractMeasurementPeriod`
- The change to `execute` comes from the overarching motivation for composite measure calculation. We still need to pass in the entire measure bundle in order to resolve ValueSets. However, we want to specify the measure being passed in rather than extracting it from the bundle once we are in the `execute` function. This will allow us to call `execute` on each component (or on the single measure in the non-composite case).
- The change to `extractLibrariesFromMeasureBundle` is a little more nuanced. We call this function from `retrieveELMInfo`, which itself is called from `execute`. Therefore, when calculating detailed results, we will want to specify the measure that we are extracting the libraries from (following the same idea of looping over components), and this measure is already passed in to `retrieveELMInfo`. However, the `extractLibrariesFromMeasureBundle` function is also used for `calculateDataRequirements` and `calculateQueryInfo`, where we don't really need to specify the measure beforehand (at least not within the scope of this task since we are only focusing on composite measure calculation for detailed results). Therefore, `measure` is an optional input and will be extracted from the passed-in bundle if it is not supplied as a separate input (open to thoughts on this)
- While the `extractMeasureFromBundle` functionality is not necessarily what we will want to use with composite measures (since it does a `.find()` to get the first measure), I kept the existing functionality for now - figured it was out of scope to change this logic without adding full support for composite measures

# Testing guidance

- Run unit tests and basic `detailedResults` CLI commands to check that calculation behavior has not changed
- Inspect `calculate` to see if there are any other useful refactors we can make now to allow for more flexibility with measure calculation
