### PR TITLE
Add regression script for comparing previous calculation results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ test/fixtures/elm/queries/.start-translator
 coverage
 cache
 test/integration/.start-translator
+regression/output/*-*
+regression/connectathon
+regression/ecqm-content-r4-2021
+regression/ecqm-content-qicore-2022

--- a/contributing.md
+++ b/contributing.md
@@ -158,6 +158,29 @@ When contributing new code, ensure that all tests, lint, and prettier checks pas
 npm run check
 ```
 
+`fqm-execution` also comes with a "regression" script, which is useful for ensuring that any changes made on a given branch did not change the calculation results for past known-good measures. To run the regression script:
+
+```bash
+./regression/run-regression.sh [-b|--base-branch <branch-name>] [-v|--verbose]
+```
+
+The above command will:
+
+1. Download all known `ecqm-content` repositories that have previously been a source of input for `fqm-execution`
+2. Run every measure bundle in those repositories through calculation for every test patient provided in that repository
+3. Run the same calculations on the "base" branch to compare the results with (default is the `master` branch, but this can be customized with `-b/--base-branch`
+4. Compare the contents of the calculation results across the two branches. If any calculation results differ, the offending files will be reported as failures in the console
+
+Full command options:
+
+```
+Usage: ./regression/run-regression.sh [-b|--base-branch <branch-name>] [-v|--verbose]
+
+Options:
+    -b/--base-branch:   Base branch to compare results with (default: master)
+    -v/--verbose:       Use verbose regression. Will print out diffs of failing JSON files with spacing (default: false)
+```
+
 # License
 
 Copyright 2020-2023 The MITRE Corporation

--- a/contributing.md
+++ b/contributing.md
@@ -166,7 +166,12 @@ npm run check
 
 The above command will:
 
-1. Download all known `ecqm-content` repositories that have previously been a source of input for `fqm-execution`
+1. Download all known [ecqm-content repositories](https://github.com/cqframework/ecqm-content) that have previously been a source of input for `fqm-execution`, which is currently:
+
+- [connectathon](https://github.com/DBCG/connectathon/)
+- [ecqm-content-r4-2021](https://github.com/cqframework/ecqm-content-r4-2021)
+- [ecqm-content-qicore-2022](https://github.com/cqframework/ecqm-content-qicore-2022)
+
 2. Run every measure bundle in those repositories through calculation for every test patient provided in that repository
 3. Run the same calculations on the "base" branch to compare the results with (default is the `master` branch, but this can be customized with `-b/--base-branch`
 4. Compare the contents of the calculation results across the two branches. If any calculation results differ, the offending files will be reported as failures in the console

--- a/regression/regression.ts
+++ b/regression/regression.ts
@@ -39,14 +39,17 @@ async function main() {
     // where the `*-files` directory contains the patient
     const filesPath = path.join(basePath, `${dir.shortName}-files`);
 
-    // Skip measures with no test patients provided
+    // Skip measures with no `*-files` directory
     if (!fs.existsSync(filesPath)) continue;
+
+    const testFilePaths = fs.readdirSync(filesPath).filter(p => p.startsWith('tests-'));
+
+    // Skip measures with no test patients in the `*-files` directory
+    if (testFilePaths.length === 0) continue;
 
     const regressionResultsPath = path.join(REGRESSION_OUTPUT_DIR, dir.shortName);
 
     fs.mkdirSync(regressionResultsPath);
-
-    const testFilePaths = fs.readdirSync(filesPath).filter(p => p.startsWith('tests-'));
 
     // It is assumed that the bundle lives under the base directory with `-bundle.json` added to the extension
     const measureBundle = JSON.parse(

--- a/regression/regression.ts
+++ b/regression/regression.ts
@@ -70,15 +70,17 @@ async function main() {
         fs.writeFileSync(testResultsPath, JSON.stringify(results, undefined, verbose ? 2 : undefined), 'utf8');
         console.log(`${FG_GREEN}%s${RESET}: Results written to ${testResultsPath}`, 'SUCCESS');
       } catch (e) {
-        // Errors will not halt regression. For the purposes of these tests, what matters is that there aren't any new errors that weren't there before
-        // or that the behavior related to the error differs from the base branch to the branch in question.
-        // Errors that occur will be diffed just like normal calculation results
-        fs.writeFileSync(
-          testResultsPath,
-          JSON.stringify({ error: e.message }, undefined, verbose ? 2 : undefined),
-          'utf8'
-        );
-        console.log(`${FG_YELLOW}%s${RESET}: Results written to ${testResultsPath}`, 'EXECUTION ERROR');
+        if (e instanceof Error) {
+          // Errors will not halt regression. For the purposes of these tests, what matters is that there aren't any new errors that weren't there before
+          // or that the behavior related to the error differs from the base branch to the branch in question.
+          // Errors that occur will be diffed just like normal calculation results
+          fs.writeFileSync(
+            testResultsPath,
+            JSON.stringify({ error: e.message }, undefined, verbose ? 2 : undefined),
+            'utf8'
+          );
+          console.log(`${FG_YELLOW}%s${RESET}: Results written to ${testResultsPath}`, 'EXECUTION ERROR');
+        }
       }
     }
   }

--- a/regression/regression.ts
+++ b/regression/regression.ts
@@ -1,0 +1,84 @@
+import fs from 'fs';
+import path from 'path';
+import { Calculator } from '../src';
+
+const regressionBaseName = process.argv[2] ?? 'regression-output';
+const verbose = process.argv[3] === 'true';
+
+const REGRESSION_OUTPUT_DIR = path.join(__dirname, `./output/${regressionBaseName}`);
+const CTHON_BASE_PATH = path.join(__dirname, './connectathon/fhir401/bundles/measure');
+const ECQM_CONTENT_BASE_PATH = path.join(__dirname, './ecqm-content-r4-2021/bundles/measure');
+const ECQM_CONTENT_QICORE_BASE_PATH = path.join(__dirname, './ecqm-content-qicore-2022/bundles/measure');
+
+const RESET = '\x1b[0m';
+const FG_YELLOW = '\x1b[33m';
+const FG_GREEN = '\x1b[32m';
+
+async function main() {
+  if (fs.existsSync(REGRESSION_OUTPUT_DIR)) {
+    fs.rmSync(REGRESSION_OUTPUT_DIR, { recursive: true });
+  }
+
+  fs.mkdirSync(REGRESSION_OUTPUT_DIR);
+
+  const measureDirBasePaths = [CTHON_BASE_PATH, ECQM_CONTENT_BASE_PATH, ECQM_CONTENT_QICORE_BASE_PATH];
+
+  const allDirs = measureDirBasePaths
+    .map(d =>
+      fs.readdirSync(d).map(f => ({
+        shortName: f,
+        fullPath: path.join(d, f)
+      }))
+    )
+    .flat();
+
+  for (const dir of allDirs) {
+    const basePath = dir.fullPath;
+
+    // Regression relies on the `*-files` approach used in ecqm content repositories
+    // where the `*-files` directory contains the patient
+    const filesPath = path.join(basePath, `${dir.shortName}-files`);
+
+    // Skip measures with no test patients provided
+    if (!fs.existsSync(filesPath)) continue;
+
+    const regressionResultsPath = path.join(REGRESSION_OUTPUT_DIR, dir.shortName);
+
+    fs.mkdirSync(regressionResultsPath);
+
+    const testFilePaths = fs.readdirSync(filesPath).filter(p => p.startsWith('tests-'));
+
+    // It is assumed that the bundle lives under the base directory with `-bundle.json` added to the extension
+    const measureBundle = JSON.parse(
+      fs.readFileSync(path.join(basePath, `${dir.shortName}-bundle.json`), 'utf8')
+    ) as fhir4.Bundle;
+
+    for (const tfp of testFilePaths) {
+      const fullTestFilePath = path.join(filesPath, tfp);
+      const patientBundle = JSON.parse(fs.readFileSync(fullTestFilePath, 'utf8')) as fhir4.Bundle;
+
+      const testResultsPath = path.join(regressionResultsPath, `results-${tfp}`);
+
+      try {
+        const { results } = await Calculator.calculate(measureBundle, [patientBundle], {
+          verboseCalculationResults: false
+        });
+
+        fs.writeFileSync(testResultsPath, JSON.stringify(results, undefined, verbose ? 2 : undefined), 'utf8');
+        console.log(`${FG_GREEN}%s${RESET}: Results written to ${testResultsPath}`, 'SUCCESS');
+      } catch (e) {
+        // Errors will not halt regression. For the purposes of these tests, what matters is that there aren't any new errors that weren't there before
+        // or that the behavior related to the error differs from the main branch to the branch in question.
+        // Errors that occur will be diffed just like normal calculation results
+        fs.writeFileSync(
+          testResultsPath,
+          JSON.stringify({ error: e.message }, undefined, verbose ? 2 : undefined),
+          'utf8'
+        );
+        console.log(`${FG_YELLOW}%s${RESET}: Results written to ${testResultsPath}`, 'EXECUTION ERROR');
+      }
+    }
+  }
+}
+
+main().then(() => console.log('done'));

--- a/regression/regression.ts
+++ b/regression/regression.ts
@@ -68,7 +68,7 @@ async function main() {
         console.log(`${FG_GREEN}%s${RESET}: Results written to ${testResultsPath}`, 'SUCCESS');
       } catch (e) {
         // Errors will not halt regression. For the purposes of these tests, what matters is that there aren't any new errors that weren't there before
-        // or that the behavior related to the error differs from the main branch to the branch in question.
+        // or that the behavior related to the error differs from the base branch to the branch in question.
         // Errors that occur will be diffed just like normal calculation results
         fs.writeFileSync(
           testResultsPath,

--- a/regression/run-regression.sh
+++ b/regression/run-regression.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+
+if [ ! -z "$(git status --untracked-files=no --porcelain)" ]; then 
+  echo "Changes detected in working directory. Either stash or commit them before running regression"
+  exit 1
+fi
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+VERBOSE=false
+BASE_BRANCH="master"
+
+function usage() {
+    cat <<USAGE
+
+    Usage: $0 [-b|--base-branch <branch-name>] [-v|--verbose]
+
+    Options:
+        -b/--base-branch:   Base branch to compare results with (default: master)
+        -v/--verbose:       Use verbose regression. Will print out diffs of failing JSON files with spacing (default: false)
+USAGE
+    exit 1
+}
+
+while test $# != 0
+do
+    case "$1" in
+    -v | --verbose) VERBOSE=true ;;
+    -b | --base-branch)
+      shift
+      BASE_BRANCH=$1
+      ;;
+    *)  usage ;;
+    esac
+    shift
+done
+
+if [ ! -d "regression/connectathon" ]; then
+  git clone https://github.com/dbcg/connectathon.git regression/connectathon
+fi
+
+if [ ! -d "regression/ecqm-content-r4-2021" ]; then
+  git clone https://github.com/cqframework/ecqm-content-r4-2021.git regression/ecqm-content-r4-2021
+fi
+
+if [ ! -d "regression/ecqm-content-qicore-2022" ]; then
+  git clone https://github.com/cqframework/ecqm-content-qicore-2022.git regression/ecqm-content-qicore-2022
+fi
+
+git fetch --all
+
+CURRENT_BRANCH=$(git symbolic-ref --short -q HEAD)
+
+if [ "$CURRENT_BRANCH" = "$BASE_BRANCH" ]; then
+  echo "Cannot run regression while on the base branch, ensure current branch is different from base"
+  exit 1
+fi
+
+TIMESTAMP=$(date +%s)
+
+echo "Gathering results on current branch '$CURRENT_BRANCH'"
+
+npx ts-node --files ./regression/regression.ts "$CURRENT_BRANCH-$TIMESTAMP" $VERBOSE
+
+echo "Gathering results on base branch '$BASE_BRANCH'"
+git checkout $BASE_BRANCH
+
+npx ts-node --files ./regression/regression.ts "$BASE_BRANCH-$TIMESTAMP" $VERBOSE
+
+FAILURES=()
+MASTER_BASE="regression/output/$BASE_BRANCH-$TIMESTAMP"
+BRANCH_BASE="regression/output/$CURRENT_BRANCH-$TIMESTAMP"
+for fname in $BRANCH_BASE/**/*.json; do
+  # Gets the name of the test file itself ignoring the base path
+  END_PATH=${fname#*/*/*/}
+  P1="$BRANCH_BASE/$END_PATH"
+  P2="$MASTER_BASE/$END_PATH"
+
+  if ! test -f "$P1"; then
+    echo -e "${RED}FAIL${NC}: $P1 does not exist"
+    FAILURES+=("$P1")
+  fi
+
+  if ! test -f "$P2"; then
+    echo -e "${RED}FAIL${NC}: $P2 does not exist"
+    FAILURES+=("$P2")
+  fi
+
+  if cmp --silent $P1 $P2 ; then
+    echo -e "${GREEN}PASS${NC}: $END_PATH"
+  else
+    echo -e "${RED}FAIL${NC}: $P1 and $P2 are different"
+    FAILURES+=("$END_PATH")
+
+    if [ $VERBOSE = "true" ]; then
+      diff $P1 $P2
+    fi
+  fi
+done
+
+if [ ${#FAILURES[@]} -gt 0 ]; then
+  printf "\n\nSummary of All Failures:\n\n"
+
+  for s in "${FAILURES[@]}"; do
+    echo -e "${RED}FAIL${NC}: $s"
+  done
+
+  printf "\n\n"
+  git checkout $CURRENT_BRANCH
+  exit 1
+else
+  printf "\n\nRegression Passed\n\n"
+  git checkout $CURRENT_BRANCH
+fi
+

--- a/regression/run-regression.sh
+++ b/regression/run-regression.sh
@@ -70,13 +70,13 @@ git checkout $BASE_BRANCH
 npx ts-node --files ./regression/regression.ts "$BASE_BRANCH-$TIMESTAMP" $VERBOSE
 
 FAILURES=()
-MASTER_BASE="regression/output/$BASE_BRANCH-$TIMESTAMP"
-BRANCH_BASE="regression/output/$CURRENT_BRANCH-$TIMESTAMP"
-for fname in $BRANCH_BASE/**/*.json; do
+BASE_BRANCH_BASE_PATH="regression/output/$BASE_BRANCH-$TIMESTAMP"
+CURRENT_BRANCH_BASE_PATH="regression/output/$CURRENT_BRANCH-$TIMESTAMP"
+for fname in $CURRENT_BRANCH_BASE_PATH/**/*.json; do
   # Gets the name of the test file itself ignoring the base path
   END_PATH=${fname#*/*/*/}
-  P1="$BRANCH_BASE/$END_PATH"
-  P2="$MASTER_BASE/$END_PATH"
+  P1="$CURRENT_BRANCH_BASE_PATH/$END_PATH"
+  P2="$BASE_BRANCH_BASE_PATH/$END_PATH"
 
   if ! test -f "$P1"; then
     echo -e "${RED}FAIL${NC}: $P1 does not exist"


### PR DESCRIPTION
# Summary

Adds scripts for comparing calculation results across `ecqm-content` repos. See additions to `contributing.md` for details on what exactly is happening.

## New behavior

None in source code, new script exists.

## Code changes

Le script. Update docs

# Testing guidance

I've simulated an error on the `simulated-regression-error` branch, where for a given calculation, there is a 25% chance that it will incorrectly set numer/denom to true when IPP is false. If you run the script and get no failures at all, go buy a lottery ticket! To test:

1) `git checkout simulated-regression-error`
2) Run the following:

```bash
./regression/run-regression.sh -b add-regression-script
```

This will run regression with this PR's branch as the base, and the error branch as the "one under test." Conceptually this is simulating a scenario where you might be reviewing the code on `simulated-regression-error` and want to make sure that it didn't change any functionality from its base branch (in this case `add-regression-script`). In general the base branch will be master, but right now it won't work against `master` since the regression script isn't checked in there yet.

You should get some errors (this won't be idempotent since errors are random):

* There will be errors reported during comparison that says that the calculation results for two test cases for a measure are different: 
![image](https://user-images.githubusercontent.com/16297930/230419365-fb44ed1d-5f71-4c2a-82f5-cb6721fb38ed.png)
* There will be a summary of all of the offending test cases at the end: 
![image](https://user-images.githubusercontent.com/16297930/230419412-3734a561-94fe-44b7-bb20-6fdb8dd78aee.png)

This indicates that calculation results differ across the branches

3. To get more info, use `-v` during the regression run which will print the diffs of the actual results (NOTE: the errors you get will be different than step 2 since it's random):

```bash
./regression/run-regression.sh -b add-regression-script -v
```

Diffs will be printed to the terminal in realtime:

![image](https://user-images.githubusercontent.com/16297930/230420163-0817fa01-8fcc-42e2-b6cf-bb19ff7fc46d.png)
