### PR TITLE
Readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <h1 align="center">fqm-execution</h1>
 <div align="center">
 
-Library for calculating HL7® FHIR® standard<sup id="fn-1">[\[1\]](#fnref-1)</sup>-based Electronic Clinical Quality Measures (eCQMs) written in Clinical Quality Language (CQL)
+Library for calculating Electronic Clinical Quality Measures (eCQMs) written in Clinical Quality Language (CQL) using the HL7® FHIR® standard<sup id="fn-1">[\[1\]](#fnref-1)</sup>
 
 </div>
 </p>

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 <p align="center">
   <h1 align="center">fqm-execution</h1>
-<center>
+<div align="center">
 
 Library for calculating HL7® FHIR® standard<sup id="fn-1">[\[1\]](#fnref-1)</sup>-based Electronic Clinical Quality Measures (eCQMs) written in Clinical Quality Language (CQL)
 
-</center>
+</div>
 </p>
 <div align="center">
   <a href="https://projecttacoma.github.io/fqm-execution">docs</a>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <h1 align="center">fqm-execution</h1>
   <p align="center">
-    Library for calculating HL7® FHIR® standard<a href="#footnote-1"><sup>1</sup></a>-based Electronic Clinical Quality Measures (eCQMs) written in Clinical Quality Language (CQL)
+    Library for calculating HL7® FHIR® standard<a href="#/?id=footnote-1"><sup>1</sup></a>-based Electronic Clinical Quality Measures (eCQMs) written in Clinical Quality Language (CQL)
     <br/>
   </p>
 </p>
@@ -1009,4 +1009,6 @@ Unless required by applicable law or agreed to in writing, software distributed 
 
 ---
 
-<a id="footnote-1">[1] FHIR® is the registered trademark of Health Level Seven International (HL7).</a>
+<p id="footnote-1">
+<a href="#/?id=footnote-1">[1] FHIR® is the registered trademark of Health Level Seven International (HL7).</a>
+</p>

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 <p align="center">
   <h1 align="center">fqm-execution</h1>
-  <p align="center">
-    Library for calculating HL7® FHIR® standard<a href="#/?id=footnote-1"><sup>1</sup></a>-based Electronic Clinical Quality Measures (eCQMs) written in Clinical Quality Language (CQL)
-    <br/>
-  </p>
+<center>
+
+Library for calculating HL7® FHIR® standard<sup id="fn-1">[\[1\]](#fnref-1)</sup>-based Electronic Clinical Quality Measures (eCQMs) written in Clinical Quality Language (CQL)
+
+</center>
 </p>
 <div align="center">
   <a href="https://projecttacoma.github.io/fqm-execution">docs</a>
@@ -1009,6 +1010,4 @@ Unless required by applicable law or agreed to in writing, software distributed 
 
 ---
 
-<p id="footnote-1">
-<a href="#/?id=footnote-1">[1] FHIR® is the registered trademark of Health Level Seven International (HL7).</a>
-</p>
+<strong id="fnref-1">[\[1\]](#fn-1) FHIR® is the registered trademark of Health Level Seven International (HL7). </strong>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 <p align="center">
   <h1 align="center">fqm-execution</h1>
   <p align="center">
-    Library for calculating HL7® FHIR® standard<a href="#footnote-1">[1]</a>-based Electronic Clinical Quality Measures (eCQMs) written in Clinical Quality Language (CQL)
+    Library for calculating HL7® FHIR® standard<a href="#footnote-1"><sup>1</sup></a>-based Electronic Clinical Quality Measures (eCQMs) written in Clinical Quality Language (CQL)
+    <br/>
   </p>
 </p>
 <div align="center">
@@ -51,7 +52,7 @@
 
 # Introduction
 
-`fqm-execution` is a library[^fn] for calculating FHIR-based Electronic Clinical Quality Measures (eCQMs) written in Clinical Quality Language (CQL). It wraps the [cql-execution](https://github.com/cqframework/cql-execution) and [cql-exec-fhir](https://github.com/cqframework/cql-exec-fhir/)
+`fqm-execution` is a library for calculating FHIR-based Electronic Clinical Quality Measures (eCQMs) written in Clinical Quality Language (CQL). It wraps the [cql-execution](https://github.com/cqframework/cql-execution) and [cql-exec-fhir](https://github.com/cqframework/cql-exec-fhir/)
 libraries in order to provide eCQM-specific output/interpretation of the raw results returned from executing the CQL/ELM on provided patient data.
 
 More information about FHIR eCQMs can be found in the [FHIR Quality Measure Implementation Guide](https://build.fhir.org/ig/HL7/cqf-measures/index.html), which informs the majority of how `fqm-execution` calculation behaves.
@@ -1008,4 +1009,4 @@ Unless required by applicable law or agreed to in writing, software distributed 
 
 ---
 
-<p id="footnote-1">[1] FHIR® is the registered trademark of Health Level Seven International (HL7).</p>
+<a id="footnote-1">[1] FHIR® is the registered trademark of Health Level Seven International (HL7).</a>

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 <p align="center">
   <h1 align="center">fqm-execution</h1>
   <p align="center">
-    Library for calculating FHIR-based Electronic Clinical Quality Measures (eCQMs) written in Clinical Quality Language (CQL)
-    <br/>
+    Library for calculating HL7® FHIR® standard<a href="#footnote-1">[1]</a>-based Electronic Clinical Quality Measures (eCQMs) written in Clinical Quality Language (CQL)
   </p>
 </p>
 <div align="center">
@@ -52,7 +51,7 @@
 
 # Introduction
 
-`fqm-execution` is a library for calculating FHIR-based Electronic Clinical Quality Measures (eCQMs) written in Clinical Quality Language (CQL). It wraps the [cql-execution](https://github.com/cqframework/cql-execution) and [cql-exec-fhir](https://github.com/cqframework/cql-exec-fhir/)
+`fqm-execution` is a library[^fn] for calculating FHIR-based Electronic Clinical Quality Measures (eCQMs) written in Clinical Quality Language (CQL). It wraps the [cql-execution](https://github.com/cqframework/cql-execution) and [cql-exec-fhir](https://github.com/cqframework/cql-exec-fhir/)
 libraries in order to provide eCQM-specific output/interpretation of the raw results returned from executing the CQL/ELM on provided patient data.
 
 More information about FHIR eCQMs can be found in the [FHIR Quality Measure Implementation Guide](https://build.fhir.org/ig/HL7/cqf-measures/index.html), which informs the majority of how `fqm-execution` calculation behaves.
@@ -1006,3 +1005,7 @@ http://www.apache.org/licenses/LICENSE-2.0
 ```
 
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+---
+
+<p id="footnote-1">[1] FHIR® is the registered trademark of Health Level Seven International (HL7).</p>


### PR DESCRIPTION
# Summary
Correct use of HL7® FHIR® standard registered trademark.

## New behavior
None

## Code changes
- Change first instance of FHIR to HL7® FHIR® standard. Subsequent uses should be fine as is. Also added a footnote.

# Testing guidance
- Look at the trademark section in the spec [here](https://build.fhir.org/license.html#trademark) and make sure I didn't miss anything. Also check the slack thread.
- `npm run docs` should show what the docs page looks like. Make sure the link works there!