### PR TITLE
Sde properties

### DIFF
--- a/src/calculation/ClauseResultsBuilder.ts
+++ b/src/calculation/ClauseResultsBuilder.ts
@@ -14,7 +14,8 @@ import {
   PopulationResult,
   SDEResult,
   StatementResult,
-  SupplementalDataUsage
+  SupplementalDataUsage,
+  isSupplementalDataUsage
 } from '../types/Calculator';
 import { UnexpectedProperty } from '../types/errors/CustomErrors';
 
@@ -883,8 +884,7 @@ export function getSDEValues(measure: fhir4.Measure, statementResults: cql.State
             sde.usage.length > 0 &&
             sde.usage[0].coding &&
             sde.usage[0].coding.length > 0 &&
-            sde.usage[0].coding[0].code &&
-            ['supplemental-data', 'risk-adjustment-factor'].includes(sde.usage[0].coding[0].code)
+            isSupplementalDataUsage(sde.usage[0].coding[0].code)
           )
         ) {
           throw new UnexpectedProperty(

--- a/src/calculation/ClauseResultsBuilder.ts
+++ b/src/calculation/ClauseResultsBuilder.ts
@@ -878,20 +878,12 @@ export function getSDEValues(measure: fhir4.Measure, statementResults: cql.State
       if (sde.criteria?.expression) {
         const expression = sde.criteria.expression;
         const result = statementResults[expression];
-        if (
-          !(
-            sde.usage &&
-            sde.usage.length > 0 &&
-            sde.usage[0].coding &&
-            sde.usage[0].coding.length > 0 &&
-            isSupplementalDataUsage(sde.usage[0].coding[0].code)
-          )
-        ) {
+        const usage = sde.usage?.[0]?.coding?.[0].code;
+        if (!isSupplementalDataUsage(usage)) {
           throw new UnexpectedProperty(
             'Expected sde usage code from the MeasureDataUsage valueset: https://terminology.hl7.org/3.1.0/ValueSet-measure-data-usage.html'
           );
         }
-        const usage = sde.usage[0].coding[0].code;
         results.push({
           name: sde.code?.text || expression,
           rawResult: result,

--- a/src/calculation/ClauseResultsBuilder.ts
+++ b/src/calculation/ClauseResultsBuilder.ts
@@ -13,8 +13,10 @@ import {
   EpisodeResults,
   PopulationResult,
   SDEResult,
-  StatementResult
+  StatementResult,
+  SupplementalDataUsage
 } from '../types/Calculator';
+import { UnexpectedProperty } from '../types/errors/CustomErrors';
 
 /**
  * Contains helpers that generate useful data for coverage and highlighting.
@@ -875,10 +877,28 @@ export function getSDEValues(measure: fhir4.Measure, statementResults: cql.State
       if (sde.criteria?.expression) {
         const expression = sde.criteria.expression;
         const result = statementResults[expression];
+        if (
+          !(
+            sde.usage &&
+            sde.usage.length > 0 &&
+            sde.usage[0].coding &&
+            sde.usage[0].coding.length > 0 &&
+            (sde.usage[0].coding[0].code === 'supplemental-data' ||
+              sde.usage[0].coding[0].code === 'risk-adjustment-factor')
+          )
+        ) {
+          throw new UnexpectedProperty(
+            'Expected sde usage code from the MeasureDataUsage valueset: https://terminology.hl7.org/3.1.0/ValueSet-measure-data-usage.html'
+          );
+        }
+        const usage = sde.usage[0].coding[0].code;
         results.push({
           name: sde.code?.text || expression,
           rawResult: result,
-          pretty: prettyResult(result)
+          pretty: prettyResult(result),
+          id: sde.id,
+          criteriaExpression: expression,
+          usage: usage as SupplementalDataUsage
         });
       }
     });

--- a/src/calculation/ClauseResultsBuilder.ts
+++ b/src/calculation/ClauseResultsBuilder.ts
@@ -14,7 +14,6 @@ import {
   PopulationResult,
   SDEResult,
   StatementResult,
-  SupplementalDataUsage,
   isSupplementalDataUsage
 } from '../types/Calculator';
 import { UnexpectedProperty } from '../types/errors/CustomErrors';
@@ -881,7 +880,7 @@ export function getSDEValues(measure: fhir4.Measure, statementResults: cql.State
         const usage = sde.usage?.[0]?.coding?.[0].code;
         if (!isSupplementalDataUsage(usage)) {
           throw new UnexpectedProperty(
-            'Expected sde usage code from the MeasureDataUsage valueset: https://terminology.hl7.org/3.1.0/ValueSet-measure-data-usage.html'
+            `Received usage: ${usage}. Expected sde usage code from the MeasureDataUsage valueset: https://terminology.hl7.org/3.1.0/ValueSet-measure-data-usage.html`
           );
         }
         results.push({
@@ -890,7 +889,7 @@ export function getSDEValues(measure: fhir4.Measure, statementResults: cql.State
           pretty: prettyResult(result),
           id: sde.id,
           criteriaExpression: expression,
-          usage: usage as SupplementalDataUsage
+          usage: usage
         });
       }
     });

--- a/src/calculation/ClauseResultsBuilder.ts
+++ b/src/calculation/ClauseResultsBuilder.ts
@@ -883,8 +883,8 @@ export function getSDEValues(measure: fhir4.Measure, statementResults: cql.State
             sde.usage.length > 0 &&
             sde.usage[0].coding &&
             sde.usage[0].coding.length > 0 &&
-            (sde.usage[0].coding[0].code === 'supplemental-data' ||
-              sde.usage[0].coding[0].code === 'risk-adjustment-factor')
+            sde.usage[0].coding[0].code &&
+            ['supplemental-data', 'risk-adjustment-factor'].includes(sde.usage[0].coding[0].code)
           )
         ) {
           throw new UnexpectedProperty(

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -97,12 +97,20 @@ export interface ExecutionResult<T extends PopulationGroupResult> {
  */
 export interface SDEResult {
   /** Name of the SDE */
-  name: string;
+  name?: string;
   /** Raw result of SDE clause */
   rawResult?: any;
   /** Pretty result for this SDE. */
   pretty?: string;
+  /** The id of the SDE as defined in the measure. */
+  id?: string;
+  /** Criteria expression for this SDE. */
+  criteriaExpression?: string;
+  /** Measure data usage for this SDE. */
+  usage?: SupplementalDataUsage;
 }
+
+export type SupplementalDataUsage = 'supplemental-data' | 'risk-adjustment-factor';
 
 /**
  * Stripped-down version of verbose detailed results

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -109,6 +109,7 @@ export interface SDEResult {
   /** Measure data usage for this SDE. */
   usage: SupplementalDataUsage;
 }
+
 /**
  * Allowed usages according to valueSet https://terminology.hl7.org/3.1.0/ValueSet-measure-data-usage.html.
  * Using typeof with allowed usages lets us both define a type (using SupplementalDataUsage) and determine

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -107,10 +107,18 @@ export interface SDEResult {
   /** Criteria expression for this SDE. */
   criteriaExpression?: string;
   /** Measure data usage for this SDE. */
-  usage?: SupplementalDataUsage;
+  usage: SupplementalDataUsage;
 }
-
-export type SupplementalDataUsage = 'supplemental-data' | 'risk-adjustment-factor';
+/**
+ * Allowed usages according to valueSet https://terminology.hl7.org/3.1.0/ValueSet-measure-data-usage.html.
+ * Using typeof with allowed usages lets us both define a type (using SupplementalDataUsage) and determine
+ * whether a value is validly typed (using usageValues const).
+ */
+export const usageValues = ['supplemental-data', 'risk-adjustment-factor'] as const;
+export type SupplementalDataUsage = typeof usageValues[number];
+export function isSupplementalDataUsage(u: unknown): u is SupplementalDataUsage {
+  return usageValues.includes(u as SupplementalDataUsage);
+}
 
 /**
  * Stripped-down version of verbose detailed results

--- a/test/unit/ClauseResultsBuilder.test.ts
+++ b/test/unit/ClauseResultsBuilder.test.ts
@@ -758,4 +758,22 @@ describe('ClauseResultsBuilder', () => {
       });
     });
   });
+
+  describe('getSDEValues', () => {
+    test('should create proper SDE results', () => {
+      const sdeStatementResults: cql.StatementResults = { SDE: [] };
+      const result = ClauseResultsBuilder.getSDEValues(simpleMeasure, sdeStatementResults);
+      const expectedResult = [
+        {
+          name: 'sde-code',
+          rawResult: [],
+          pretty: '[]',
+          id: 'sde-id',
+          criteriaExpression: 'SDE',
+          usage: 'supplemental-data'
+        }
+      ];
+      expect(result).toEqual(expectedResult);
+    });
+  });
 });

--- a/test/unit/ClauseResultsBuilder.test.ts
+++ b/test/unit/ClauseResultsBuilder.test.ts
@@ -775,5 +775,18 @@ describe('ClauseResultsBuilder', () => {
       ];
       expect(result).toEqual(expectedResult);
     });
+
+    test('should throw error when SDE usage is invalid', () => {
+      const invalidMeasure = getJSONFixture('measure/simple-measure.json') as MeasureWithGroup;
+      if (invalidMeasure.supplementalData?.[0]?.usage?.[0]?.coding?.[0].code) {
+        invalidMeasure.supplementalData[0].usage[0].coding[0].code = 'invalid';
+      }
+      const sdeStatementResults: cql.StatementResults = { SDE: [] };
+      expect(() => {
+        ClauseResultsBuilder.getSDEValues(invalidMeasure, sdeStatementResults);
+      }).toThrowError(
+        'Received usage: invalid. Expected sde usage code from the MeasureDataUsage valueset: https://terminology.hl7.org/3.1.0/ValueSet-measure-data-usage.html'
+      );
+    });
   });
 });

--- a/test/unit/MeasureReportBuilder.addSDE.test.ts
+++ b/test/unit/MeasureReportBuilder.addSDE.test.ts
@@ -65,7 +65,10 @@ const executionResultsTemplate: ExecutionResult<DetailedPopulationGroupResult>[]
           code: 'example',
           system: 'http://example.com',
           display: 'Example'
-        }
+        },
+        id: 'sde-id',
+        criteriaExpression: 'SDE',
+        usage: 'supplemental-data'
       }
     ]
   }
@@ -92,7 +95,10 @@ describe('MeasureReportBuilder Class', () => {
             code: 'example',
             system: 'http://example.com',
             display: 'Example'
-          }
+          },
+          id: 'sde-id',
+          criteriaExpression: 'SDE',
+          usage: 'supplemental-data'
         }
       ];
       builder.addPatientResults(executionResult);
@@ -124,7 +130,10 @@ describe('MeasureReportBuilder Class', () => {
               system: 'http://example.com',
               display: 'Example'
             }
-          ]
+          ],
+          id: 'sde-id',
+          criteriaExpression: 'SDE',
+          usage: 'supplemental-data'
         }
       ];
       builder.addPatientResults(executionResult);
@@ -161,7 +170,10 @@ describe('MeasureReportBuilder Class', () => {
                 value: 'Asian'
               }
             }
-          ]
+          ],
+          id: 'sde-id',
+          criteriaExpression: 'SDE',
+          usage: 'supplemental-data'
         }
       ];
       builder.addPatientResults(executionResult);
@@ -186,7 +198,10 @@ describe('MeasureReportBuilder Class', () => {
       executionResult.supplementalData = [
         {
           name: 'sde-code',
-          rawResult: undefined
+          rawResult: undefined,
+          id: 'sde-id',
+          criteriaExpression: 'SDE',
+          usage: 'supplemental-data'
         }
       ];
       builder.addPatientResults(executionResult);

--- a/test/unit/MeasureReportBuilder.test.ts
+++ b/test/unit/MeasureReportBuilder.test.ts
@@ -79,7 +79,10 @@ const executionResults: ExecutionResult<DetailedPopulationGroupResult>[] = [
           code: 'example',
           system: 'http://example.com',
           display: 'Example'
-        }
+        },
+        id: 'sde-id',
+        criteriaExpression: 'SDE',
+        usage: 'supplemental-data'
       }
     ]
   }
@@ -164,7 +167,10 @@ const ratioExecutionResults: ExecutionResult<DetailedPopulationGroupResult>[] = 
           code: 'example',
           system: 'http://example.com',
           display: 'Example'
-        }
+        },
+        id: 'sde-id',
+        criteriaExpression: 'SDE',
+        usage: 'supplemental-data'
       }
     ]
   }
@@ -210,7 +216,10 @@ const cvExecutionResults: ExecutionResult<DetailedPopulationGroupResult>[] = [
           code: 'example',
           system: 'http://example.com',
           display: 'Example'
-        }
+        },
+        id: 'sde-id',
+        criteriaExpression: 'SDE',
+        usage: 'supplemental-data'
       }
     ]
   }

--- a/test/unit/fixtures/measure/simple-measure.json
+++ b/test/unit/fixtures/measure/simple-measure.json
@@ -123,6 +123,7 @@
   ],
   "supplementalData": [
     {
+      "id": "sde-id",
       "code": {
         "text": "sde-code"
       },


### PR DESCRIPTION
# Summary
Updates SDEResult interface to make `name` optional (not really a useful piece of information, but we're keeping it around for backwards compatibility) and add `id`, `criteriaExpression`, and `usage` as result properties (`usage` required). Updates `getSDEValues` function accordingly to populate these properties.
## New behavior
Output from calculation with SDEs includes these new properties
## Code changes
- `ClauseResultsBuilder.ts` includes updates to `getSDEValues` to populate properties
- `Calculator.ts` types file includes updates to the `SDEResult` interface
-  ClauseResultsBuilder.test.ts` includes added `getSDEValues` unit test
-  `simple-measure.json` fixture includes added `supplementalData` `id`
- Updates `MeasureReportBuilder.addSDE.test.ts` and `MeasureReportBuilder.test.ts` to include new properties as part of test data objects
# Testing guidance
- `npm run check`
- Testing with measure example input: `detailed -m "ecqm-content-r4-2021/bundles/measure/DiabetesHemoglobinA1cHbA1cPoorControl9FHIR/DiabetesHemoglobinA1cHbA1cPoorControl9FHIR-bundle.json" -p "ecqm-content-r4-2021/bundles/measure/DiabetesHemoglobinA1cHbA1cPoorControl9FHIR/DiabetesHemoglobinA1cHbA1cPoorControl9FHIR-files/tests-numer-CMS122-bundle.json" --debug -o` -> Search `output.json` file for `"supplementalData":` to find the updated supplemental data, which should include `id`, `criteriaExpression`, and `usage`