### PR TITLE
Place reasonDetail on reasonCode, not coding

### DIFF
--- a/src/gaps/GapsReportBuilder.ts
+++ b/src/gaps/GapsReportBuilder.ts
@@ -236,6 +236,7 @@ export function generateGuidanceResponses(
                 display: CareGapReasonCodeDisplay[CareGapReasonCode.PRESENT]
               }
             ];
+
       gapStatus = [
         {
           coding: gapCoding
@@ -287,7 +288,7 @@ export function generateReasonCode(reason: ReasonDetailData): fhir4.CodeableConc
     display: CareGapReasonCodeDisplay[reason.code]
   };
 
-  const gapStatus: fhir4.CodeableConcept = {
+  const reasonCode: fhir4.CodeableConcept = {
     coding: [reasonCoding]
   };
 
@@ -310,9 +311,9 @@ export function generateReasonCode(reason: ReasonDetailData): fhir4.CodeableConc
         valueString: reason.path
       });
     }
-    gapStatus.extension = [detailExt];
+    reasonCode.extension = [detailExt];
   }
-  return gapStatus;
+  return reasonCode;
 }
 
 /**

--- a/test/unit/GapsInCareHelpers.test.ts
+++ b/test/unit/GapsInCareHelpers.test.ts
@@ -7,7 +7,7 @@ import {
   calculateReasonDetail,
   groupGapQueries,
   generateGuidanceResponses,
-  generateReasonCoding,
+  generateReasonCode,
   hasDetailedReasonCode
 } from '../../src/gaps/GapsReportBuilder';
 import {
@@ -1527,29 +1527,28 @@ describe('Guidance Response', () => {
           {
             system: 'http://hl7.org/fhir/us/davinci-deqm/CodeSystem/care-gap-reason',
             code: 'DateOutOfRange',
-            display: 'Date is out of specified range',
+            display: 'Date is out of specified range'
+          }
+        ],
+        extension: [
+          {
+            url: 'http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/reasonDetail',
             extension: [
               {
-                url: 'http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/reasonDetail',
-                extension: [
-                  {
-                    url: 'reference',
-                    valueReference: {
-                      reference: 'Procedure/denom-EXM130-2'
-                    }
-                  },
-                  {
-                    url: 'path',
-                    valueString: 'performed.end'
-                  }
-                ]
+                url: 'reference',
+                valueReference: {
+                  reference: 'Procedure/denom-EXM130-2'
+                }
+              },
+              {
+                url: 'path',
+                valueString: 'performed.end'
               }
             ]
           }
         ]
       }
     ];
-
     const grs = generateGuidanceResponses([query], '', ImprovementNotation.POSITIVE).guidanceResponses;
 
     expect(grs).toHaveLength(1);
@@ -1572,7 +1571,8 @@ describe('Guidance Response ReasonCode Coding', () => {
       code: 'Missing',
       display: 'Missing Data Element'
     };
-    expect(generateReasonCoding(reasonDetail)).toEqual(expectedCoding);
+    const expectedReasonCode: fhir4.CodeableConcept = { coding: [expectedCoding] };
+    expect(generateReasonCode(reasonDetail)).toEqual(expectedReasonCode);
   });
 
   test('should handle reason detail with reference and no path', () => {
@@ -1583,22 +1583,26 @@ describe('Guidance Response ReasonCode Coding', () => {
     const expectedCoding: fhir4.Coding = {
       system: 'http://hl7.org/fhir/us/davinci-deqm/CodeSystem/care-gap-reason',
       code: 'Present',
-      display: 'Data Element is Present',
+      display: 'Data Element is Present'
+    };
+
+    const expectedDetailExt: fhir4.Extension = {
+      url: 'http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/reasonDetail',
       extension: [
         {
-          url: 'http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/reasonDetail',
-          extension: [
-            {
-              url: 'reference',
-              valueReference: {
-                reference: 'Procedure/denom-EXM130-2'
-              }
-            }
-          ]
+          url: 'reference',
+          valueReference: {
+            reference: 'Procedure/denom-EXM130-2'
+          }
         }
       ]
     };
-    expect(generateReasonCoding(reasonDetail)).toEqual(expectedCoding);
+
+    const expectedReasonCode: fhir4.CodeableConcept = {
+      coding: [expectedCoding],
+      extension: [expectedDetailExt]
+    };
+    expect(generateReasonCode(reasonDetail)).toEqual(expectedReasonCode);
   });
 
   test('should handle reason detail with reference and path', () => {
@@ -1610,26 +1614,28 @@ describe('Guidance Response ReasonCode Coding', () => {
     const expectedCoding: fhir4.Coding = {
       system: 'http://hl7.org/fhir/us/davinci-deqm/CodeSystem/care-gap-reason',
       code: 'DateOutOfRange',
-      display: 'Date is out of specified range',
+      display: 'Date is out of specified range'
+    };
+    const expectedDetailExt: fhir4.Extension = {
+      url: 'http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/reasonDetail',
       extension: [
         {
-          url: 'http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/reasonDetail',
-          extension: [
-            {
-              url: 'reference',
-              valueReference: {
-                reference: 'Procedure/denom-EXM130-2'
-              }
-            },
-            {
-              url: 'path',
-              valueString: 'performed.end'
-            }
-          ]
+          url: 'reference',
+          valueReference: {
+            reference: 'Procedure/denom-EXM130-2'
+          }
+        },
+        {
+          url: 'path',
+          valueString: 'performed.end'
         }
       ]
     };
-    expect(generateReasonCoding(reasonDetail)).toEqual(expectedCoding);
+    const expectedReasonCode: fhir4.CodeableConcept = {
+      coding: [expectedCoding],
+      extension: [expectedDetailExt]
+    };
+    expect(generateReasonCode(reasonDetail)).toEqual(expectedReasonCode);
   });
 
   describe('hasDetailedReasonCode', () => {

--- a/test/unit/GapsInCareHelpers.test.ts
+++ b/test/unit/GapsInCareHelpers.test.ts
@@ -1549,6 +1549,7 @@ describe('Guidance Response', () => {
         ]
       }
     ];
+
     const grs = generateGuidanceResponses([query], '', ImprovementNotation.POSITIVE).guidanceResponses;
 
     expect(grs).toHaveLength(1);
@@ -1566,12 +1567,15 @@ describe('Guidance Response ReasonCode Coding', () => {
     const reasonDetail: ReasonDetailData = {
       code: CareGapReasonCode.MISSING
     };
-    const expectedCoding: fhir4.Coding = {
-      system: 'http://hl7.org/fhir/us/davinci-deqm/CodeSystem/care-gap-reason',
-      code: 'Missing',
-      display: 'Missing Data Element'
+    const expectedReasonCode: fhir4.CodeableConcept = {
+      coding: [
+        {
+          system: 'http://hl7.org/fhir/us/davinci-deqm/CodeSystem/care-gap-reason',
+          code: 'Missing',
+          display: 'Missing Data Element'
+        }
+      ]
     };
-    const expectedReasonCode: fhir4.CodeableConcept = { coding: [expectedCoding] };
     expect(generateReasonCode(reasonDetail)).toEqual(expectedReasonCode);
   });
 
@@ -1580,6 +1584,7 @@ describe('Guidance Response ReasonCode Coding', () => {
       code: CareGapReasonCode.PRESENT,
       reference: 'Procedure/denom-EXM130-2'
     };
+
     const expectedCoding: fhir4.Coding = {
       system: 'http://hl7.org/fhir/us/davinci-deqm/CodeSystem/care-gap-reason',
       code: 'Present',
@@ -1602,6 +1607,7 @@ describe('Guidance Response ReasonCode Coding', () => {
       coding: [expectedCoding],
       extension: [expectedDetailExt]
     };
+
     expect(generateReasonCode(reasonDetail)).toEqual(expectedReasonCode);
   });
 
@@ -1611,11 +1617,13 @@ describe('Guidance Response ReasonCode Coding', () => {
       reference: 'Procedure/denom-EXM130-2',
       path: 'performed.end'
     };
+
     const expectedCoding: fhir4.Coding = {
       system: 'http://hl7.org/fhir/us/davinci-deqm/CodeSystem/care-gap-reason',
       code: 'DateOutOfRange',
       display: 'Date is out of specified range'
     };
+
     const expectedDetailExt: fhir4.Extension = {
       url: 'http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/reasonDetail',
       extension: [
@@ -1631,10 +1639,12 @@ describe('Guidance Response ReasonCode Coding', () => {
         }
       ]
     };
+
     const expectedReasonCode: fhir4.CodeableConcept = {
       coding: [expectedCoding],
       extension: [expectedDetailExt]
     };
+
     expect(generateReasonCode(reasonDetail)).toEqual(expectedReasonCode);
   });
 


### PR DESCRIPTION
# Summary
For care gaps, updates the `GuidanceResponse.reasonCode` to have the `reasonDetail` extension on the `reasonCode` itself rather than on the `coding`.

## New behavior
When running care gaps, the structure of the generated `GuidanceResponse` resources will be different if the reason contains a reference. Previously, the output would look like the following:

```json
"reasonCode": [
  {
    "coding": [
      {
        "system": ... ,
        "code": ... ,
        "display": ...
        "extension": [
          {
            "url": "http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/reasonDetail",
            "extension": [<reason detail extension >]
          }
        ]
      }
    ]
  }
]
```

The expected output should now have the following format:

```json
"reasonCode": [
  {
    "coding": [
      {
        "system": ...,
        "code": ...,
        "display": ...
      }
    ],
    "extension": [
      {
        "url": "http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/reasonDetail",
        "extension": [<reason detail extension>]
      }
    ]
  }
],
```

See the `GuidanceResponse` attachment in this [Jira issue](https://jira.hl7.org/browse/FHIR-40803) to get an understanding of the updated structure.
NOTE: it appears that there are several ways of attaching the extension (might be possible to attach it to the `reasonCode.coding` as well as including it on the root of `reasonCode`). For now, we will use this approach, but the extension may change in the future.

See the [resource profile for Detailed Care Gap Guidance Response](http://hl7.org/fhir/us/davinci-deqm/2023Jan/StructureDefinition-gaps-guidanceresponse-detailedcaregap.html) for more detail.

## Code changes
* `src/gaps/GapsReportBuilder` —> Change the `generateReasonCoding` function to now be named `generateReasonCode`. Now generates the `reasonCode` rather than just the `coding` (which would then be added to the `reasonCode` outside the function). Update `generateGuidanceResponse` function according to this change.
    * Reasoning for this: We still want to map all the reasons to their reason codings, but creating the whole reason code in this function means we won’t need to do an additional mapping to the detailed extension as well. We can just construct the reason code all at once in this function
* `test/unit/GapsInCareHelpers.test.ts` —> Updates unit test fixtures to have the extension defined on the `reasonCode` elements rather than on the `reasonCode`’s `coding`’s. Also updates the function name from `generateReasonCoding` to `generateReasonCode`.

# Testing guidance
* Run unit tests and check that the new unit test fixtures align with the spec
* Run care gaps via the CLI on a measure and patient bundle, and compare the resulting `GuidanceResponse` structure against the output received from the main branch. The only difference should be the placement of the `reasonDetail` extension (if present).
    * Example CLI command: 

```
npm run cli -- gaps -m <EXM 130 measure bundle> -p <EXM 130 denominator patient bundle> -o -s 2019-01-01 -e 2019-12-31
```