### PR TITLE
update cql-execution to 3.0.0-beta.5 and bump package version to 1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "fqm-execution",
-  "version": "1.0.8",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "fqm-execution",
-      "version": "1.0.8",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/fhir": "0.0.34",
         "axios": "^0.21.1",
         "commander": "^6.1.0",
         "cql-exec-fhir": "^2.1.3",
-        "cql-execution": "^3.0.0-beta.4",
+        "cql-execution": "^3.0.0-beta.5",
         "handlebars": "^4.7.7",
         "lodash": "^4.17.21",
         "moment": "^2.29.4",
@@ -2343,9 +2343,9 @@
       }
     },
     "node_modules/cql-execution": {
-      "version": "3.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.0-beta.4.tgz",
-      "integrity": "sha512-TWAVtdZEr0h/P7CXRV+DBdPRdougBkG30AgXg/N8Xz4upbmc4zNTg2cfAAvMbJrsYl5sqZbJFcUvxaGcTZGjqw==",
+      "version": "3.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.0-beta.5.tgz",
+      "integrity": "sha512-6n0nR5+Usdpxax5tG/ky9qIjhWZ0rb72/D93TINsQU6PUqsqhlGpka57vNOrQI6jmqFHw/CB3S614R3lyLOL8Q==",
       "dependencies": {
         "@lhncbc/ucum-lhc": "^4.1.3",
         "immutable": "^4.1.0",
@@ -8453,9 +8453,9 @@
       }
     },
     "cql-execution": {
-      "version": "3.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.0-beta.4.tgz",
-      "integrity": "sha512-TWAVtdZEr0h/P7CXRV+DBdPRdougBkG30AgXg/N8Xz4upbmc4zNTg2cfAAvMbJrsYl5sqZbJFcUvxaGcTZGjqw==",
+      "version": "3.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.0-beta.5.tgz",
+      "integrity": "sha512-6n0nR5+Usdpxax5tG/ky9qIjhWZ0rb72/D93TINsQU6PUqsqhlGpka57vNOrQI6jmqFHw/CB3S614R3lyLOL8Q==",
       "requires": {
         "@lhncbc/ucum-lhc": "^4.1.3",
         "immutable": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fqm-execution",
-  "version": "1.0.8",
+  "version": "1.1.0",
   "description": "FHIR Quality Measure Execution",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -15,7 +15,7 @@
     "axios": "^0.21.1",
     "commander": "^6.1.0",
     "cql-exec-fhir": "^2.1.3",
-    "cql-execution": "^3.0.0-beta.4",
+    "cql-execution": "^3.0.0-beta.5",
     "handlebars": "^4.7.7",
     "lodash": "^4.17.21",
     "moment": "^2.29.4",


### PR DESCRIPTION
# Summary

cql-execution version bump and fqm-execution versioning bump

## New behavior
## Code changes
# Testing guidance
