### PR TITLE
returnELM hotfix

### DIFF
--- a/regression/regression.ts
+++ b/regression/regression.ts
@@ -63,9 +63,7 @@ async function main() {
       const testResultsPath = path.join(regressionResultsPath, `results-${tfp}`);
 
       try {
-        const { results } = await Calculator.calculate(measureBundle, [patientBundle], {
-          verboseCalculationResults: false
-        });
+        const { results } = await Calculator.calculate(measureBundle, [patientBundle], {});
 
         fs.writeFileSync(testResultsPath, JSON.stringify(results, undefined, verbose ? 2 : undefined), 'utf8');
         console.log(`${FG_GREEN}%s${RESET}: Results written to ${testResultsPath}`, 'SUCCESS');

--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -118,9 +118,7 @@ export async function calculate<T extends CalculationOptions>(
       newValueSetCache = newValueSetCache.concat(results.valueSetCache);
     }
 
-    if (options.returnELM) {
-      elmLibraries.push(...results.elmLibraries);
-    }
+    elmLibraries.push(...results.elmLibraries);
 
     mainLibraryName = results.mainLibraryName;
 


### PR DESCRIPTION
We should not only push on to elmLibraries if returnELM is true since building the clause and statement results depends on it. We only use this calculation option when determining if we should return it from the overall function call.

Keep track of all of them in a master list to be potentially returned at the end, but always reset the one within the loop so that only the ELM executed is passed in to the statement results list