### PR TITLE
Add support for CQFM Group Id extension (composite measure report building)

### DIFF
--- a/src/calculation/CompositeReportBuilder.ts
+++ b/src/calculation/CompositeReportBuilder.ts
@@ -131,9 +131,9 @@ export class CompositeReportBuilder<T extends PopulationGroupResult> extends Abs
         if (componentResult.componentCanonical) {
           // component info will either consist of mapping of groups to weights, or a single weight
           const componentInfo = this.components[componentResult.componentCanonical];
-          // if only one weight is specified, the component corresponds to a single group
-          const hasSingleGroup = typeof componentInfo === 'number';
-          if (hasSingleGroup) {
+          // if only one weight is specified, then a specific group is not defined
+          const noGroupExt = typeof componentInfo === 'number';
+          if (noGroupExt) {
             if (!(componentResult.componentCanonical in componentPopulationResults)) {
               componentPopulationResults[componentResult.componentCanonical] = {
                 numerator: 0,
@@ -175,7 +175,7 @@ export class CompositeReportBuilder<T extends PopulationGroupResult> extends Abs
             if (
               componentResult.populationResults?.find(pr => pr.populationType === PopulationType.NUMER)?.result === true
             ) {
-              if (hasSingleGroup) {
+              if (noGroupExt) {
                 (componentPopulationResults[componentResult.componentCanonical] as ComponentPopulationResults)
                   .numerator++;
               } else {
@@ -191,7 +191,7 @@ export class CompositeReportBuilder<T extends PopulationGroupResult> extends Abs
             if (
               componentResult.populationResults?.find(pr => pr.populationType === PopulationType.DENOM)?.result === true
             ) {
-              if (hasSingleGroup) {
+              if (noGroupExt) {
                 (componentPopulationResults[componentResult.componentCanonical] as ComponentPopulationResults)
                   .denominator++;
               } else {

--- a/src/calculation/CompositeReportBuilder.ts
+++ b/src/calculation/CompositeReportBuilder.ts
@@ -42,12 +42,18 @@ export class CompositeReportBuilder<T extends PopulationGroupResult> extends Abs
     compositeMeasure.relatedArtifact?.forEach(ra => {
       if (ra.resource && ra.type === 'composed-of') {
         let weight = 1;
-        const weightExtension = ra.extension?.find(
+        const weightExtension = ra.extension?.filter(
           ({ url }) => url === 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-weight'
         );
 
-        if (weightExtension?.valueDecimal) {
-          weight = weightExtension.valueDecimal;
+        if (weightExtension && weightExtension.length > 1) {
+          throw new Error(
+            `Only one CQFM Weight extension can be defined on a component, but ${weightExtension.length} were provided.`
+          );
+        }
+
+        if (weightExtension?.[0]?.valueDecimal) {
+          weight = weightExtension[0].valueDecimal;
         }
 
         this.weightedComponents[ra.resource] = weight;

--- a/src/calculation/CompositeReportBuilder.ts
+++ b/src/calculation/CompositeReportBuilder.ts
@@ -1,7 +1,7 @@
 import { PopulationGroupResult, CalculationOptions, ExecutionResult } from '../types/Calculator';
 import {
   getCompositeScoringFromMeasure,
-  getGroupIdFromComponent,
+  getGroupIdForComponent,
   filterComponentResults
 } from '../helpers/MeasureBundleHelpers';
 import { CompositeScoreType, PopulationType } from '../types/Enums';
@@ -52,7 +52,7 @@ export class CompositeReportBuilder<T extends PopulationGroupResult> extends Abs
 
         this.weightedComponents[ra.resource] = weight;
 
-        const groupId = getGroupIdFromComponent(ra);
+        const groupId = getGroupIdForComponent(ra);
         if (groupId) {
           this.componentGroupIds[ra.resource] = groupId;
         }
@@ -156,6 +156,8 @@ export class CompositeReportBuilder<T extends PopulationGroupResult> extends Abs
   }
 
   public addPatientResults(result: ExecutionResult<T>) {
+    // filter component results according to CQFM Group Id extension
+    // https://build.fhir.org/ig/HL7/cqf-measures/StructureDefinition-cqfm-groupId.html
     const componentResults = filterComponentResults(this.componentGroupIds, result.componentResults);
     // https://build.fhir.org/ig/HL7/cqf-measures/composite-measures.html#all-or-nothing-scoring
     if (this.compositeScoringType === 'all-or-nothing') {

--- a/src/calculation/CompositeReportBuilder.ts
+++ b/src/calculation/CompositeReportBuilder.ts
@@ -117,7 +117,8 @@ export class CompositeReportBuilder<T extends PopulationGroupResult> extends Abs
     const componentPopulationResults: Record<string, { numerator: number; denominator: number; weight: number }> = {};
 
     results.forEach(result => {
-      result.componentResults?.forEach(componentResult => {
+      const componentResults = filterComponentResults(this.componentGroupIds, result.componentResults);
+      componentResults.forEach(componentResult => {
         if (componentResult.componentCanonical && !componentPopulationResults[componentResult.componentCanonical]) {
           componentPopulationResults[componentResult.componentCanonical] = {
             numerator: 0,

--- a/src/calculation/CompositeReportBuilder.ts
+++ b/src/calculation/CompositeReportBuilder.ts
@@ -27,7 +27,7 @@ export class CompositeReportBuilder<T extends PopulationGroupResult> extends Abs
   compositeScoringType: CompositeScoreType;
   compositeFraction: { numerator: number; denominator: number };
   weightedComponents: Record<string, number>;
-  componentGroupIds: Record<string, string>;
+  componentGroupIds: Record<string, Set<string>>;
 
   constructor(compositeMeasure: fhir4.Measure, options: CalculationOptions) {
     super(compositeMeasure, options);
@@ -54,7 +54,10 @@ export class CompositeReportBuilder<T extends PopulationGroupResult> extends Abs
 
         const groupId = getGroupIdForComponent(ra);
         if (groupId) {
-          this.componentGroupIds[ra.resource] = groupId;
+          if (!this.componentGroupIds[ra.resource]) {
+            this.componentGroupIds[ra.resource] = new Set<string>();
+          }
+          this.componentGroupIds[ra.resource].add(groupId);
         }
       }
     });

--- a/src/calculation/CompositeReportBuilder.ts
+++ b/src/calculation/CompositeReportBuilder.ts
@@ -2,6 +2,7 @@ import { PopulationGroupResult, CalculationOptions, ExecutionResult } from '../t
 import {
   getCompositeScoringFromMeasure,
   getGroupIdForComponent,
+  getWeightForComponent,
   filterComponentResults
 } from '../helpers/MeasureBundleHelpers';
 import { CompositeScoreType, PopulationType } from '../types/Enums';
@@ -42,18 +43,10 @@ export class CompositeReportBuilder<T extends PopulationGroupResult> extends Abs
     compositeMeasure.relatedArtifact?.forEach(ra => {
       if (ra.resource && ra.type === 'composed-of') {
         let weight = 1;
-        const weightExtension = ra.extension?.filter(
-          ({ url }) => url === 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-weight'
-        );
+        const weightExtensionValue = getWeightForComponent(ra);
 
-        if (weightExtension && weightExtension.length > 1) {
-          throw new Error(
-            `Only one CQFM Weight extension can be defined on a component, but ${weightExtension.length} were provided.`
-          );
-        }
-
-        if (weightExtension?.[0]?.valueDecimal) {
-          weight = weightExtension[0].valueDecimal;
+        if (weightExtensionValue) {
+          weight = weightExtensionValue;
         }
 
         this.weightedComponents[ra.resource] = weight;

--- a/src/calculation/CompositeReportBuilder.ts
+++ b/src/calculation/CompositeReportBuilder.ts
@@ -1,5 +1,5 @@
 import { PopulationGroupResult, CalculationOptions, ExecutionResult } from '../types/Calculator';
-import { getCompositeScoringFromMeasure } from '../helpers/MeasureBundleHelpers';
+import { getCompositeScoringFromMeasure, getGroupIdFromComponent } from '../helpers/MeasureBundleHelpers';
 import { CompositeScoreType, PopulationType } from '../types/Enums';
 import { v4 as uuidv4 } from 'uuid';
 import { AbstractMeasureReportBuilder } from './AbstractMeasureReportBuilder';
@@ -23,6 +23,7 @@ export class CompositeReportBuilder<T extends PopulationGroupResult> extends Abs
   compositeScoringType: CompositeScoreType;
   compositeFraction: { numerator: number; denominator: number };
   weightedComponents: Record<string, number>;
+  componentGroupIds: Record<string, string>;
 
   constructor(compositeMeasure: fhir4.Measure, options: CalculationOptions) {
     super(compositeMeasure, options);
@@ -31,6 +32,7 @@ export class CompositeReportBuilder<T extends PopulationGroupResult> extends Abs
     this.compositeFraction = { numerator: 0, denominator: 0 };
     this.options = options;
     this.weightedComponents = {};
+    this.componentGroupIds = {};
 
     // if the weight is not specified, then we assume the weight is 1
     compositeMeasure.relatedArtifact?.forEach(ra => {
@@ -45,6 +47,11 @@ export class CompositeReportBuilder<T extends PopulationGroupResult> extends Abs
         }
 
         this.weightedComponents[ra.resource] = weight;
+
+        const groupId = getGroupIdFromComponent(ra);
+        if (groupId) {
+          this.componentGroupIds[ra.resource] = groupId;
+        }
       }
     });
 

--- a/src/helpers/MeasureBundleHelpers.ts
+++ b/src/helpers/MeasureBundleHelpers.ts
@@ -147,7 +147,7 @@ export function filterComponentResults(
     }
   });
   const canonicals = filteredComponentResults.map(cr => cr.componentCanonical);
-  if (canonicals.length !== new Set(canonicals).size) {
+  if (canonicals.length !== new Set(componentResults?.map(cr => cr.componentCanonical)).size) {
     throw new Error(
       'For component measures that contain multiple population groups, the composite measure SHALL specify a specific group, but no group was specified.'
     );

--- a/src/helpers/MeasureBundleHelpers.ts
+++ b/src/helpers/MeasureBundleHelpers.ts
@@ -125,6 +125,12 @@ export function getGroupIdForComponent(relatedArtifact: fhir4.RelatedArtifact): 
   return groupIdExtension?.[0]?.valueString ?? null;
 }
 
+/**
+ * Extracts CQFM Weight from a given composite measure Related Artifact.
+ * https://build.fhir.org/ig/HL7/cqf-measures/StructureDefinition-cqfm-weight.html
+ * @param relatedArtifact related artifact defined on the composite measure
+ * @returns weight extension value, if defined
+ */
 export function getWeightForComponent(relatedArtifact: fhir4.RelatedArtifact): number | null {
   const weightExtension = relatedArtifact.extension?.filter(
     ({ url }) => url === 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-weight'

--- a/src/helpers/MeasureBundleHelpers.ts
+++ b/src/helpers/MeasureBundleHelpers.ts
@@ -125,6 +125,19 @@ export function getGroupIdForComponent(relatedArtifact: fhir4.RelatedArtifact): 
   return groupIdExtension?.[0]?.valueString ?? null;
 }
 
+export function getWeightForComponent(relatedArtifact: fhir4.RelatedArtifact): number | null {
+  const weightExtension = relatedArtifact.extension?.filter(
+    ({ url }) => url === 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-weight'
+  );
+
+  if (weightExtension && weightExtension.length > 1) {
+    throw new Error(
+      `Only one CQFM Weight extension can be defined on a component, but ${weightExtension.length} were provided.`
+    );
+  }
+  return weightExtension?.[0]?.valueDecimal ?? null;
+}
+
 /**
  * Filters component results using mapping of group ids defined by the CQFM Group Id extension on the
  * composite measure. Throws error if a component contains multiple groups but no group is specified to

--- a/test/unit/helpers/MeasureBundleHelpers.test.ts
+++ b/test/unit/helpers/MeasureBundleHelpers.test.ts
@@ -161,7 +161,7 @@ describe('MeasureBundleHelpers tests', () => {
         }
       ];
 
-      const groupIdMapping = { 'http://example.com/Measure/test-measure-1|0.0.1': 'test-group-1' };
+      const groupIdMapping = { 'http://example.com/Measure/test-measure-1|0.0.1': new Set(['test-group-1']) };
       expect(filterComponentResults(groupIdMapping, componentResults)).toHaveLength(2);
     });
 
@@ -192,10 +192,27 @@ describe('MeasureBundleHelpers tests', () => {
           componentCanonical: 'http://example.com/Measure/test-measure-1|0.0.1'
         }
       ];
-      const groupIdMapping = { 'http://example.com/Measure/test-measure-1|0.0.1': 'non-existent-group' };
+      const groupIdMapping = { 'http://example.com/Measure/test-measure-1|0.0.1': new Set(['non-existent-group']) };
       expect(() => filterComponentResults(groupIdMapping, componentResults)).toThrow(
-        /For component measures that contain multiple population groups, the composite measure SHALL specify a specific group, but no group was specified./i
+        /For component measures that contain multiple population groups, the composite measure SHALL specify a specific group. The specified group does not exist./i
       );
+    });
+
+    it('should include component results for components that refer to the same measure but refer to different groups', () => {
+      const componentResults: ComponentResults[] = [
+        {
+          groupId: 'test-group-1',
+          componentCanonical: 'http://example.com/Measure/test-measure-1|0.0.1'
+        },
+        {
+          groupId: 'test-group-2',
+          componentCanonical: 'http://example.com/Measure/test-measure-1|0.0.1'
+        }
+      ];
+      const groupIdMapping = {
+        'http://example.com/Measure/test-measure-1|0.0.1': new Set(['test-group-1', 'test-group-2'])
+      };
+      expect(filterComponentResults(groupIdMapping, componentResults)).toHaveLength(2);
     });
   });
 

--- a/test/unit/helpers/MeasureBundleHelpers.test.ts
+++ b/test/unit/helpers/MeasureBundleHelpers.test.ts
@@ -17,7 +17,7 @@ import {
   parseLibRef,
   extractComponentsFromMeasure,
   extractCompositeMeasure,
-  getGroupIdFromComponent,
+  getGroupIdForComponent,
   filterComponentResults
 } from '../../../src/helpers/MeasureBundleHelpers';
 import { PopulationType } from '../../../src/types/Enums';
@@ -86,7 +86,7 @@ describe('MeasureBundleHelpers tests', () => {
     });
   });
 
-  describe('getGroupIdFromComponent', () => {
+  describe('getGroupIdForComponent', () => {
     it('should return the groupId string when defined on the extension', () => {
       const relatedArtifact: fhir4.RelatedArtifact = {
         type: 'composed-of',
@@ -100,7 +100,7 @@ describe('MeasureBundleHelpers tests', () => {
         ]
       };
 
-      expect(getGroupIdFromComponent(relatedArtifact)).toEqual('test-group');
+      expect(getGroupIdForComponent(relatedArtifact)).toEqual('test-group');
     });
 
     it('should return null when group Id extension is not present', () => {
@@ -110,7 +110,7 @@ describe('MeasureBundleHelpers tests', () => {
         resource: 'http://example.com/Measure/test-measure|0.0.1'
       };
 
-      expect(getGroupIdFromComponent(relatedArtifact)).toBeNull();
+      expect(getGroupIdForComponent(relatedArtifact)).toBeNull();
     });
 
     it('should return null when group Id is not defined on the extension', () => {
@@ -125,7 +125,7 @@ describe('MeasureBundleHelpers tests', () => {
         ]
       };
 
-      expect(getGroupIdFromComponent(relatedArtifact)).toBeNull();
+      expect(getGroupIdForComponent(relatedArtifact)).toBeNull();
     });
   });
 

--- a/test/unit/helpers/MeasureBundleHelpers.test.ts
+++ b/test/unit/helpers/MeasureBundleHelpers.test.ts
@@ -127,6 +127,27 @@ describe('MeasureBundleHelpers tests', () => {
 
       expect(getGroupIdForComponent(relatedArtifact)).toBeNull();
     });
+
+    it('should throw error when multiple CQFM Group Id extensions are defined', () => {
+      const relatedArtifact: fhir4.RelatedArtifact = {
+        type: 'composed-of',
+        display: 'test-related-artifact',
+        resource: 'http://example.com/Measure/test-measure|0.0.1',
+        extension: [
+          {
+            url: 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-groupId',
+            valueString: 'test-group-1'
+          },
+          {
+            url: 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-groupId',
+            valueString: 'test-group-2'
+          }
+        ]
+      };
+      expect(() => getGroupIdForComponent(relatedArtifact)).toThrow(
+        /Only one CQFM Group Id extension can be defined on a component, but 2 were provided./i
+      );
+    });
   });
 
   describe('filterComponentResults', () => {

--- a/test/unit/helpers/MeasureBundleHelpers.test.ts
+++ b/test/unit/helpers/MeasureBundleHelpers.test.ts
@@ -180,6 +180,23 @@ describe('MeasureBundleHelpers tests', () => {
         /For component measures that contain multiple population groups, the composite measure SHALL specify a specific group, but no group was specified./i
       );
     });
+
+    it('should throw error if a component has more than one group but the specified group does not exist', () => {
+      const componentResults: ComponentResults[] = [
+        {
+          groupId: 'test-group-1',
+          componentCanonical: 'http://example.com/Measure/test-measure-1|0.0.1'
+        },
+        {
+          groupId: 'test-group-2',
+          componentCanonical: 'http://example.com/Measure/test-measure-1|0.0.1'
+        }
+      ];
+      const groupIdMapping = { 'http://example.com/Measure/test-measure-1|0.0.1': 'non-existent-group' };
+      expect(() => filterComponentResults(groupIdMapping, componentResults)).toThrow(
+        /For component measures that contain multiple population groups, the composite measure SHALL specify a specific group, but no group was specified./i
+      );
+    });
   });
 
   describe('isRatioMeasure', () => {

--- a/test/unit/helpers/MeasureBundleHelpers.test.ts
+++ b/test/unit/helpers/MeasureBundleHelpers.test.ts
@@ -18,7 +18,8 @@ import {
   extractComponentsFromMeasure,
   extractCompositeMeasure,
   getGroupIdForComponent,
-  filterComponentResults
+  filterComponentResults,
+  getWeightForComponent
 } from '../../../src/helpers/MeasureBundleHelpers';
 import { PopulationType } from '../../../src/types/Enums';
 import { ValueSetResolver } from '../../../src/execution/ValueSetResolver';
@@ -146,6 +147,67 @@ describe('MeasureBundleHelpers tests', () => {
       };
       expect(() => getGroupIdForComponent(relatedArtifact)).toThrow(
         /Only one CQFM Group Id extension can be defined on a component, but 2 were provided./i
+      );
+    });
+  });
+
+  describe('getWeightForComponent', () => {
+    it('should return the weight when defined on the extension', () => {
+      const relatedArtifact: fhir4.RelatedArtifact = {
+        type: 'composed-of',
+        display: 'test-related-artifact',
+        resource: 'http://example.com/Measure/test-measure|0.0.1',
+        extension: [
+          {
+            url: 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-weight',
+            valueDecimal: 0.5
+          }
+        ]
+      };
+      expect(getWeightForComponent(relatedArtifact)).toEqual(0.5);
+    });
+
+    it('should return null when weight extension is not present', () => {
+      const relatedArtifact: fhir4.RelatedArtifact = {
+        type: 'composed-of',
+        display: 'test-related-artifact',
+        resource: 'http://example.com/Measure/test-measure|0.0.1'
+      };
+      expect(getWeightForComponent(relatedArtifact)).toBeNull();
+    });
+
+    it('should return null when weight is not defined on the extension', () => {
+      const relatedArtifact: fhir4.RelatedArtifact = {
+        type: 'composed-of',
+        display: 'test-related-artifact',
+        resource: 'http://example.com/Measure/test-measure|0.0.1',
+        extension: [
+          {
+            url: 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-weight'
+          }
+        ]
+      };
+      expect(getWeightForComponent(relatedArtifact)).toBeNull();
+    });
+
+    it('should throw error when multiple CQFM Weight extensions are defined', () => {
+      const relatedArtifact: fhir4.RelatedArtifact = {
+        type: 'composed-of',
+        display: 'test-related-artifact',
+        resource: 'http://example.com/Measure/test-measure|0.0.1',
+        extension: [
+          {
+            url: 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-weight',
+            valueDecimal: 0.5
+          },
+          {
+            url: 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-weight',
+            valueDecimal: 0.1
+          }
+        ]
+      };
+      expect(() => getWeightForComponent(relatedArtifact)).toThrow(
+        /Only one CQFM Weight extension can be defined on a component, but 2 were provided./i
       );
     });
   });

--- a/test/unit/helpers/MeasureBundleHelpers.test.ts
+++ b/test/unit/helpers/MeasureBundleHelpers.test.ts
@@ -224,8 +224,23 @@ describe('MeasureBundleHelpers tests', () => {
           componentCanonical: 'http://example.com/Measure/test-measure-2|0.0.1'
         }
       ];
-
-      expect(filterComponentResults({}, componentResults)).toEqual(componentResults);
+      const groupIdMapping: Record<string, Record<string, number> | number> = {
+        'http://example.com/Measure/test-measure-1|0.0.1': 1,
+        'http://example.com/Measure/test-measure-2|0.0.1': 1
+      };
+      const filteredComponentResults = filterComponentResults(groupIdMapping, componentResults);
+      expect(filteredComponentResults).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            groupId: 'test-group-1',
+            componentCanonical: 'http://example.com/Measure/test-measure-1|0.0.1'
+          }),
+          expect.objectContaining({
+            groupId: 'test-group-2',
+            componentCanonical: 'http://example.com/Measure/test-measure-2|0.0.1'
+          })
+        ])
+      );
     });
 
     it('should return a filtered array of component results if a component has more than one group and specifies the groupId extension', () => {
@@ -244,8 +259,23 @@ describe('MeasureBundleHelpers tests', () => {
         }
       ];
 
-      const groupIdMapping = { 'http://example.com/Measure/test-measure-1|0.0.1': new Set(['test-group-1']) };
-      expect(filterComponentResults(groupIdMapping, componentResults)).toHaveLength(2);
+      const groupIdMapping = {
+        'http://example.com/Measure/test-measure-1|0.0.1': { 'test-group-1': 1 },
+        'http://example.com/Measure/test-measure-2|0.0.1': 1
+      };
+      const filteredComponentResults = filterComponentResults(groupIdMapping, componentResults);
+      expect(filteredComponentResults).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            groupId: 'test-group-1',
+            componentCanonical: 'http://example.com/Measure/test-measure-1|0.0.1'
+          }),
+          expect.objectContaining({
+            groupId: 'test-group-3',
+            componentCanonical: 'http://example.com/Measure/test-measure-2|0.0.1'
+          })
+        ])
+      );
     });
 
     it('should throw error if a component has more than one group but does not specify a specific group via the groupId extension', () => {
@@ -259,7 +289,8 @@ describe('MeasureBundleHelpers tests', () => {
           componentCanonical: 'http://example.com/Measure/test-measure-1|0.0.1'
         }
       ];
-      expect(() => filterComponentResults({}, componentResults)).toThrow(
+      const groupIdMapping = { 'http://example.com/Measure/test-measure-1|0.0.1': 1 };
+      expect(() => filterComponentResults(groupIdMapping, componentResults)).toThrow(
         /For component measures that contain multiple population groups, the composite measure SHALL specify a specific group, but no group was specified./i
       );
     });
@@ -275,7 +306,7 @@ describe('MeasureBundleHelpers tests', () => {
           componentCanonical: 'http://example.com/Measure/test-measure-1|0.0.1'
         }
       ];
-      const groupIdMapping = { 'http://example.com/Measure/test-measure-1|0.0.1': new Set(['non-existent-group']) };
+      const groupIdMapping = { 'http://example.com/Measure/test-measure-1|0.0.1': { 'non-existent-group': 1 } };
       expect(() => filterComponentResults(groupIdMapping, componentResults)).toThrow(
         /For component measures that contain multiple population groups, the composite measure SHALL specify a specific group. The specified group does not exist./i
       );
@@ -293,7 +324,7 @@ describe('MeasureBundleHelpers tests', () => {
         }
       ];
       const groupIdMapping = {
-        'http://example.com/Measure/test-measure-1|0.0.1': new Set(['test-group-1', 'test-group-2'])
+        'http://example.com/Measure/test-measure-1|0.0.1': { 'test-group-1': 1, 'test-group-2': 1 }
       };
       expect(filterComponentResults(groupIdMapping, componentResults)).toHaveLength(2);
     });


### PR DESCRIPTION
# Summary
For composite measure report building, filters the component results to those corresponding to groups defined by the CQFM Group Id extension (if applicable).

## New behavior
Resources:
* [Composites page in the Quality Measure IG](https://build.fhir.org/ig/HL7/cqf-measures/composite-measures.html) 
* [CQFM Composite Measure Resource Profile](https://build.fhir.org/ig/HL7/cqf-measures/StructureDefinition-composite-measure-cqfm.html)
* [CQFM Group Id Extension Definition](https://build.fhir.org/ig/HL7/cqf-measures/StructureDefinition-cqfm-groupId.html)

From the [Multiple Populations](https://build.fhir.org/ig/HL7/cqf-measures/composite-measures.html#multiple-populations) section of the spec: "Component measures used in a composite SHOULD contain a single population group. For component measures that contain multiple population groups, the composite measure SHALL specify the specific group to be used in the composite using the cqfm-groupId extension."

Behavior does not change for calculating detailed results. Behavior *does* change for composite measure report building. When calculating the measure score, the component results will first be filtered so that the population results used for calculating the measure score are those that correspond to the specified groups. In other words, rather than considering all the component results across all the defined groups for measure score calculation, only one component result for a single group will be considered for measure score calculation. The logic can be broken down as follows:
* If the component only contains one population group, that group is used to get the info necessary for measure report building
* If the component contains multiple population groups and the CQFM Group Id extension is specified for the component, then the specified group will be used to get the info necessary for measure report building
* If the component contains multiple populations groups and the CQFM Group Id extension is *not* defined for the component, an error is thrown

## Code changes
* `MeasureBundleHelpers` - helper functions that extract the group Id `valueString` from the defined CQFM Group Id extension and filter the component results according to the defined group Ids on the extension
* `CompositeReportBuilder` - calls helper functions from `MeasureBundleHelpers` to extract the group Ids and filter the component results before looping through them for measure score calculation
* New unit tests for extracting the group Id from the extension and for filtering the component results according to the defined groups on the extension

# Testing guidance
Since no (known) composite measures exist in the wild, the best way to test functionality will be to run unit tests and integration tests. That being said, testing guidance is as follows:
* Run unit tests —> tests that the Group Id extension can successfully be extracted and that the component results can be appropriately filtered
* Run integration tests —> the integration tests do not test measure report building, but running them ensures that the detailed results are not filtered in any way (we only want to do filtering for report building)
* To test via the CLI, refer to attached `.zip`. The `.zip` contains a directory of patients and two different measure bundles:
    * `composite-mb-no-extension.json` - does not define the group Id extension. Component 1 has two defined groups. Should throw an error since a specific group is not specified with the extension.
    * `composite-mb-with-groupId.json` - defines the group Id extension for Component 1. Component 1 has two defined groups. Should successfully build a composite measure report using the defined group.
    * Test out edge cases by tweaking these measure bundles. For example, change the group Id extension in `composite-mb-with-groupId.json` to specify a non-existent group. This should throw an error.
    * Test across the different composite scoring types. This can be done by changing the value of `compositeScoring.coding.code` on the composite measure in the measure bundle. At a minimum, test one of the scoring types that is checked in `addPatientResults` (all or nothing, opportunity, or linear) and test the `weighted` scoring type since that gets calculated in `addWeightedResults`.



[composite.zip](https://github.com/projecttacoma/fqm-execution/files/11546938/composite.zip)
