### PR TITLE
Add disableHTMLOrdering Calculation Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -845,7 +845,7 @@ The following example of a proportion boolean measure shows how the logic highli
 
 ![Screenshot of Highlighting HTML Measure Logic](./static/logic-highlighting-example-2.png)
 
-### CQL Statement Ordering
+### CQL Statement Ordering in HTML
 By default, the statements in the generated HTML output are sorted into population statements, non-functions, and functions, respectively. Non-population statements appear in alphabetical order. To disable this behavior, use the `disableHTMLOrdering` calculation option.
 
 ## Group Clause Coverage Highlighting

--- a/README.md
+++ b/README.md
@@ -846,7 +846,7 @@ The following example of a proportion boolean measure shows how the logic highli
 ![Screenshot of Highlighting HTML Measure Logic](./static/logic-highlighting-example-2.png)
 
 ### CQL Statement Ordering
-By default, the statements in the generated HTML output are sorted into population statements, non-functions, and functions, respectively. To disable this behavior, use the `disableHTMLOrdering` calculation option.
+By default, the statements in the generated HTML output are sorted into population statements, non-functions, and functions, respectively. Non-population statements appear in alphabetical order. To disable this behavior, use the `disableHTMLOrdering` calculation option.
 
 ## Group Clause Coverage Highlighting
 

--- a/README.md
+++ b/README.md
@@ -432,7 +432,7 @@ The options that we support for calculation are as follows:
 - `[calculateHTML]`<[boolean](#calculation-options)>: Include HTML structure for highlighting (default: `true`)
 - `[calculateSDEs]`<[boolean](#calculation-options)>: Include Supplemental Data Elements (SDEs) in calculation (default: `true`)
 - `[clearElmJsonsCache]`<[boolean](#calculation-options)>: If `true`, clears ELM JSON cache before running calculation (default: `false`)
-- `[disabledHTMLOrdering]`<[boolean](#calculation-options)>: Disables custom ordering of CQL statements in HTML output (default: `false`)
+- `[disableHTMLOrdering]`<[boolean](#calculation-options)>: Disables custom ordering of CQL statements in HTML output (default: `false`)
 - `[enableDebugOutput]`<[boolean](#calculation-options)>: Enable debug output including CQL, ELM, results (default: `false`)
 - `[includeClauseResults]` <[boolean](#calculation-options)>: Option to include clause results (default: `false`)
 - `[measurementPeriodEnd]`<[string](#calculation-options)>: End of measurement period as a valid [FHIR dateTime](https://build.fhir.org/datatypes.html#dateTime). Can be formatted as a date, date-time, or partial date. Milliseconds are optionally allowed. Defaults to the `.effectivePeriod.end` on the `Measure` resource, but can be overridden or specified using this option, which will take precedence
@@ -846,7 +846,7 @@ The following example of a proportion boolean measure shows how the logic highli
 ![Screenshot of Highlighting HTML Measure Logic](./static/logic-highlighting-example-2.png)
 
 ### CQL Statement Ordering
-By default, the statements in the generated HTML output are sorted into population statements, non0functions, and functions, respectively. To disable this behavior, use the `disableHTMLOrdering` calculation option.
+By default, the statements in the generated HTML output are sorted into population statements, non-functions, and functions, respectively. To disable this behavior, use the `disableHTMLOrdering` calculation option.
 
 ## Group Clause Coverage Highlighting
 

--- a/README.md
+++ b/README.md
@@ -432,6 +432,7 @@ The options that we support for calculation are as follows:
 - `[calculateHTML]`<[boolean](#calculation-options)>: Include HTML structure for highlighting (default: `true`)
 - `[calculateSDEs]`<[boolean](#calculation-options)>: Include Supplemental Data Elements (SDEs) in calculation (default: `true`)
 - `[clearElmJsonsCache]`<[boolean](#calculation-options)>: If `true`, clears ELM JSON cache before running calculation (default: `false`)
+- `[disabledHTMLOrdering]`<[boolean](#calculation-options)>: Disables custom ordering of CQL statements in HTML output (default: `false`)
 - `[enableDebugOutput]`<[boolean](#calculation-options)>: Enable debug output including CQL, ELM, results (default: `false`)
 - `[includeClauseResults]` <[boolean](#calculation-options)>: Option to include clause results (default: `false`)
 - `[measurementPeriodEnd]`<[string](#calculation-options)>: End of measurement period as a valid [FHIR dateTime](https://build.fhir.org/datatypes.html#dateTime). Can be formatted as a date, date-time, or partial date. Milliseconds are optionally allowed. Defaults to the `.effectivePeriod.end` on the `Measure` resource, but can be overridden or specified using this option, which will take precedence
@@ -843,6 +844,9 @@ However, highlighted HTML provided by `fqm-execution` is not solely based on whe
 The following example of a proportion boolean measure shows how the logic highlighting will not style the numerator and denominator despite their truthy raw values because the initial population evaluates to false. The relevance calculation matches the semantics for proportion measures defined in [this flowchart](https://build.fhir.org/ig/HL7/cqf-measures/measure-conformance.html#proportion-measure-scoring).
 
 ![Screenshot of Highlighting HTML Measure Logic](./static/logic-highlighting-example-2.png)
+
+### CQL Statement Ordering
+By default, the statements in the generated HTML output are sorted into population statements, non0functions, and functions, respectively. To disable this behavior, use the `disableHTMLOrdering` calculation option.
 
 ## Group Clause Coverage Highlighting
 

--- a/README.md
+++ b/README.md
@@ -846,7 +846,7 @@ The following example of a proportion boolean measure shows how the logic highli
 ![Screenshot of Highlighting HTML Measure Logic](./static/logic-highlighting-example-2.png)
 
 ### CQL Statement Ordering in HTML
-By default, the statements in the generated HTML output are sorted into population statements, non-functions, and functions, respectively. Non-population statements appear in alphabetical order. To disable this behavior, use the `disableHTMLOrdering` calculation option.
+By default, the CQL statements in the generated HTML output are sorted into population statements, non-functions, and functions, respectively. Non-population statements appear in alphabetical order. To disable this behavior, use the `disableHTMLOrdering` calculation option.
 
 ## Group Clause Coverage Highlighting
 

--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -208,7 +208,8 @@ export async function calculate<T extends CalculationOptions>(
             executedELM,
             detailedGroupResult.statementResults,
             detailedGroupResult.clauseResults,
-            detailedGroupResult.groupId
+            detailedGroupResult.groupId,
+            options.disableHTMLOrdering ?? false
           );
           detailedGroupResult.html = html;
           if (debugObject && options.enableDebugOutput) {
@@ -248,7 +249,12 @@ export async function calculate<T extends CalculationOptions>(
     patientSource = resolvePatientSource(patientBundles, options);
 
     if (!isCompositeExecution && options.calculateClauseCoverage) {
-      groupClauseCoverageHTML = generateClauseCoverageHTML(measure, executedELM, executionResults);
+      groupClauseCoverageHTML = generateClauseCoverageHTML(
+        measure,
+        executedELM,
+        executionResults,
+        options.disableHTMLOrdering ?? false
+      );
       overallClauseCoverageHTML = '';
       Object.entries(groupClauseCoverageHTML).forEach(([groupId, result]) => {
         overallClauseCoverageHTML += result;

--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -70,6 +70,7 @@ export async function calculate<T extends CalculationOptions>(
   options.calculateHTML = options.calculateHTML ?? true;
   options.calculateSDEs = options.calculateSDEs ?? true;
   options.calculateClauseCoverage = options.calculateClauseCoverage ?? true;
+  options.disableHTMLOrdering = options.disableHTMLOrdering ?? false;
 
   const compositeMeasureResource = MeasureBundleHelpers.extractCompositeMeasure(measureBundle);
 
@@ -209,7 +210,7 @@ export async function calculate<T extends CalculationOptions>(
             detailedGroupResult.statementResults,
             detailedGroupResult.clauseResults,
             detailedGroupResult.groupId,
-            options.disableHTMLOrdering ?? false
+            options.disableHTMLOrdering
           );
           detailedGroupResult.html = html;
           if (debugObject && options.enableDebugOutput) {
@@ -252,7 +253,7 @@ export async function calculate<T extends CalculationOptions>(
         measure,
         executedELM,
         executionResults,
-        options.disableHTMLOrdering ?? false
+        options.disableHTMLOrdering
       );
       overallClauseCoverageHTML = '';
       Object.entries(groupClauseCoverageHTML).forEach(([groupId, result]) => {

--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -248,6 +248,7 @@ export async function calculate<T extends CalculationOptions>(
     });
 
     patientSource = resolvePatientSource(patientBundles, options);
+
     if (!isCompositeExecution && options.calculateClauseCoverage) {
       groupClauseCoverageHTML = generateClauseCoverageHTML(
         measure,

--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -247,7 +247,6 @@ export async function calculate<T extends CalculationOptions>(
     });
 
     patientSource = resolvePatientSource(patientBundles, options);
-
     if (!isCompositeExecution && options.calculateClauseCoverage) {
       groupClauseCoverageHTML = generateClauseCoverageHTML(
         measure,

--- a/src/calculation/HTMLBuilder.ts
+++ b/src/calculation/HTMLBuilder.ts
@@ -122,7 +122,7 @@ export function sortStatements(measure: fhir4.Measure, groupId: string, statemen
  * @param statementResults StatementResult array from calculation
  * @param clauseResults ClauseResult array from calculation
  * @param groupId ID of population group
- * @param disableHTMLOrdering disables statement sorting
+ * @param disableHTMLOrdering disables CQL statement sorting
  * @returns string of HTML representing the clauses for this group
  */
 export function generateHTML(
@@ -185,7 +185,7 @@ export function generateHTML(
  * @param elmLibraries main ELM and dependencies to lookup statements
  * @param executionResults array of detailed population group results across
  * all patients
- * @param disableHTMLOrdering disables statement sorting
+ * @param disableHTMLOrdering disables CQL statement sorting
  * @returns a lookup object where the key is the groupId and the value is the
  * clause coverage HTML
  */

--- a/src/calculation/HTMLBuilder.ts
+++ b/src/calculation/HTMLBuilder.ts
@@ -122,6 +122,7 @@ export function sortStatements(measure: fhir4.Measure, groupId: string, statemen
  * @param statementResults StatementResult array from calculation
  * @param clauseResults ClauseResult array from calculation
  * @param groupId ID of population group
+ * @param disableHTMLOrdering disables statement sorting
  * @returns string of HTML representing the clauses for this group
  */
 export function generateHTML(
@@ -129,10 +130,13 @@ export function generateHTML(
   elmLibraries: ELM[],
   statementResults: StatementResult[],
   clauseResults: ClauseResult[],
-  groupId: string
+  groupId: string,
+  disableHTMLOrdering?: boolean
 ): string {
   const relevantStatements = statementResults.filter(s => s.relevance !== Relevance.NA);
-  sortStatements(measure, groupId, relevantStatements);
+  if (!disableHTMLOrdering) {
+    sortStatements(measure, groupId, relevantStatements);
+  }
 
   // assemble array of statement annotations to be templated to HTML
   const statementAnnotations: StatementAnnotation[] = [];
@@ -181,13 +185,15 @@ export function generateHTML(
  * @param elmLibraries main ELM and dependencies to lookup statements
  * @param executionResults array of detailed population group results across
  * all patients
+ * @param disableHTMLOrdering disables statement sorting
  * @returns a lookup object where the key is the groupId and the value is the
  * clause coverage HTML
  */
 export function generateClauseCoverageHTML(
   measure: fhir4.Measure,
   elmLibraries: ELM[],
-  executionResults: ExecutionResult<DetailedPopulationGroupResult>[]
+  executionResults: ExecutionResult<DetailedPopulationGroupResult>[],
+  disableHTMLOrdering?: boolean
 ): Record<string, string> {
   const groupResultLookup: Record<string, DetailedPopulationGroupResult[]> = {};
   const htmlGroupLookup: Record<string, string> = {};
@@ -226,7 +232,9 @@ export function generateClauseCoverageHTML(
       (s1, s2) => s1.libraryName === s2.libraryName && s1.localId === s2.localId
     );
 
-    sortStatements(measure, groupId, uniqueRelevantStatements);
+    if (!disableHTMLOrdering) {
+      sortStatements(measure, groupId, uniqueRelevantStatements);
+    }
 
     // assemble array of statement annotations to be templated to HTML
     const statementAnnotations: { libraryName: string; statementName: string; annotation: Annotation[] }[] = [];

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -44,6 +44,8 @@ export interface CalculationOptions {
   clearElmJsonsCache?: boolean;
   /** Reference to root library (should be a canonical URL but resource ID will work if matching one exists in the bundle), to be used in calculateLibraryDataRequirements */
   rootLibRef?: string;
+  /** Disables custom ordering of CQL statements in the HTML structure for highlighting */
+  disableHTMLOrdering?: boolean;
 }
 
 /**


### PR DESCRIPTION
# Summary
Adds a new calculation option `disableHTMLOrdering` that disables CQL statement sorting in HTML output.

## New behavior
When the `disableHTMLOrdering` Calculation Option is used, the CQL statements in the HTML output do not get sorted based on the type of statement (population statement, non-function, function). See https://github.com/projecttacoma/fqm-execution/pull/242 for more information on the sorting that occurs when this calculation option is absent. By default, `disableHTMLOrdering` is set to `false`.

## Code changes
* README - adds calculation option definition, adds section on CQL Statement Ordering
    * **Open to feedback on whether to add more content to the CQL Statement Ordering section - we could maybe make a simple example to show ordering v. no ordering? Not sure if that’s in scope of this task but might be good to add**
* `Calculator.ts` - Passes the disable option to the HTML generation functions for both logic highlighting and clause coverage highlighting
* `HTMLBuilder.ts` - Makes the sorting conditional depending on the value of `disableHTMLOrdering`
* `types/Calculator.ts` - Adds `disableHTMLOrdering` to the `CalculationOptions` interface

# Testing guidance
* Run unit tests
* Test with and without the `disableHTMLOrdering` calculation option and compare results. Here’s one approach for doing this:

1. Run calculation as is with the `CervicalCancerScreeningFHIR` measure.

Example CLI command:
```bash
npm run cli -- -p ecqm-content-r4-2021/bundles/measure/CervicalCancerScreeningFHIR/CervicalCancerScreeningFHIR-files/tests-denom-EXM124-bundle.json -m ecqm-content-r4-2021/bundles/measure/CervicalCancerScreeningFHIR/CervicalCancerScreeningFHIR-bundle.json -o ordered-output.json --debug
```
2. Examine the HTML output for logic highlighting and clause coverage. The HTML output should start with statements “Initial Population,” “Denominator,” “Denominator Exclusions,” etc.
3. Run calculation with HTML ordering disabled. This can be done by changing line 73 to the line `options.disableHTMLOrdering = true;` in`Calculator.ts`. Then, run calculation again with the same command as above, but change the output path to something like `unordered-output.json`.
4. Examine the HTML output for logic highlighting and clause coverage. The HTML output should now start with the functions “Normalize Interval,” “Normalize Abatement,” etc.
5. Compare the clause coverage percentage across the ordered and unordered HTML output - it should be the same. Check that the highlighting is also the same across the two sets of HTML output.
6. Compare the output of both calculations - the calculation output should be the same. An easy way to do this in VSCode is to use the “Select for Compare” feature with the two JSON files, which shows them side by side and highlights any diffs
