### PR TITLE
Update clause coverage percentage calculation to capture all relevant clauses

### DIFF
--- a/src/calculation/HTMLBuilder.ts
+++ b/src/calculation/HTMLBuilder.ts
@@ -240,16 +240,13 @@ export function generateClauseCoverageHTML(
   // go through the lookup object of each of the groups with their total
   // detailedResults and calculate the clause coverage html for each group
   Object.entries(groupResultLookup).forEach(([groupId, detailedResults]) => {
-    const flattenedStatementResults = detailedResults.flatMap(s => s.statementResults);
+    // Grab the statement results from just the first patient since just only need the names
+    // of the statements and whether or not their relevance is NA
+    const flattenedStatementResults = detailedResults[0].statementResults;
     const flattenedClauseResults = detailedResults.flatMap(c => (c.clauseResults ? c.clauseResults : []));
 
-    // Filter out any statement results where the statement relevance is not NA and filter out duplicates from that
-    // uniqWith appears to pick the first element it encounters that matches the uniqueness condition
-    // when iterating, which is fine because the relevance not being N/A is the only thing that matters now
-    const uniqueRelevantStatements = uniqWith(
-      flattenedStatementResults.filter(s => s.relevance !== Relevance.NA),
-      (s1, s2) => s1.libraryName === s2.libraryName && s1.localId === s2.localId
-    );
+    // Filter out any statement results where the statement relevance is NA
+    const uniqueRelevantStatements = flattenedStatementResults.filter(s => s.relevance !== Relevance.NA);
 
     if (!disableHTMLOrdering) {
       sortStatements(measure, groupId, uniqueRelevantStatements);

--- a/src/calculation/HTMLBuilder.ts
+++ b/src/calculation/HTMLBuilder.ts
@@ -243,7 +243,7 @@ export function generateClauseCoverageHTML(
     const flattenedStatementResults = detailedResults.flatMap(s => s.statementResults);
     const flattenedClauseResults = detailedResults.flatMap(c => (c.clauseResults ? c.clauseResults : []));
 
-    // From all the relevant ones, filter out any duplicate statements
+    // Filter out any statement results where the statement relevance it not NA and filter out duplicates from that
     // uniqWith appears to pick the first element it encounters that matches the uniqueness condition
     // when iterating, which is fine because the relevance not being N/A is the only thing that matters now
     const uniqueRelevantStatements = uniqWith(

--- a/src/calculation/HTMLBuilder.ts
+++ b/src/calculation/HTMLBuilder.ts
@@ -243,7 +243,7 @@ export function generateClauseCoverageHTML(
     const flattenedStatementResults = detailedResults.flatMap(s => s.statementResults);
     const flattenedClauseResults = detailedResults.flatMap(c => (c.clauseResults ? c.clauseResults : []));
 
-    // Filter out any statement results where the statement relevance it not NA and filter out duplicates from that
+    // Filter out any statement results where the statement relevance is not NA and filter out duplicates from that
     // uniqWith appears to pick the first element it encounters that matches the uniqueness condition
     // when iterating, which is fine because the relevance not being N/A is the only thing that matters now
     const uniqueRelevantStatements = uniqWith(


### PR DESCRIPTION
# Summary
Fixes #262 

## New behavior
- Fixes a bug in the clause coverage percentage calculation. 
- Clause coverage percentage calculation now captures all relevant clauses and therefore matches the clause coverage highlighting.

## Code changes
- Before, we were getting `allRelevantClauses` by finding the clauseResults whose `localID` and `libraryName` matched a statement in `relevantStatements`. This does not capture all of the relevant clauses. We want to find the clauseResults whose `statementName` and `libraryName` match statements in `relevantStatements`. This way all clauses are included in the calculation, not just the root statement clauses like it was doing before.
- Additionally, combines some code in `generateClauseCoverageHTML` that didn't need to be separate.

# Testing guidance
- `npm run check`
- `npm run test:integration`
- Make sure nothing breaks in the testing.
- Test with the bundle and test cases provided in the issue. The clause coverage percentage for this should now be 65.6% and not 100%. 
- Test some other cases to make sure that the highlighting matches the percentage. Specifically, check that the percentage changes when additional clauses end up being highlighted.