### PR TITLE
Add conditional to error.message to avoid type error

### DIFF
--- a/src/types/errors/GracefulError.ts
+++ b/src/types/errors/GracefulError.ts
@@ -6,7 +6,7 @@ export interface GracefulError {
 }
 
 export const isOfTypeGracefulError = (tbd: any): tbd is GracefulError => {
-  if ((tbd as GracefulError).message) {
+  if ((tbd as GracefulError)?.message) {
     return true;
   }
   return false;


### PR DESCRIPTION
# Summary
When trying to run `dataRequirements` on the measure bundles and test cases in [this](https://oncprojectracking.healthit.gov/support/browse/BONNIEMAT-1479) issue, I got a `Cannot read properties of undefined (reading 'message')` error. (Initially noticed when trying to look at these test cases in `fqm-testify`) This prevents this error from being thrown.

## New behavior
- No type error

## Code changes
- `src/types/errors/GracefulError.ts` - `tbd.message` can be undefined

# Testing guidance
- `npm run check`
- Run `dataRequirements` on the measure bundle and test cases in the above issue and make sure that no errors are thrown.