### PR TITLE
Add statement-level HTML to statement results

### DIFF
--- a/README.md
+++ b/README.md
@@ -886,6 +886,41 @@ The order of these populations is determined by most inclusive to least inclusiv
 
 To disable this behavior, use the `disableHTMLOrdering` calculation option.
 
+### Statement-level HTML
+Optionally, `fqm-execution` can generate the stylized HTML markup for each individual statement. To access the statement-level HTML, specify the `buildStatementLevelHTML` in the `CalculationOptions` prior to measure calculation. From the `detailedResults` returned for a given patient, the `statementLevelHTML` will be available as an element on each `statementResult` whose relevance is *not* N/A.
+
+```typescript
+[
+  {
+    "patientId": "test-patient",
+    "detailedResults": [
+      {
+        "groupId": "test-group",
+        "statementResults": [
+          // no HTML returned since relevance is NA
+          {
+            "libraryName": "MATGlobalCommonFunctionsFHIR4",
+            "statementName": "Patient",
+            "final": "NA",
+            "relevance": "NA",
+            "isFunction": false,
+            "pretty": "NA"
+          },
+          {
+            "libraryName": "CancerScreening",
+            "statementName": "SDE Sex",
+            "final": "TRUE",
+            "relevance": "TRUE",
+            "isFunction": false,
+            "statementLevelHTML": "<pre style=\"tab-size: 2; border-bottom-width: 4px; line-height: 1.4\"\n  data-library-name=\"CancerScreening\" data-statement-name=\"SDE Sex\">\n...\n</pre>"
+          },
+        ]
+      }
+    ]
+  }
+]
+```
+
 ## Group Clause Coverage Highlighting
 
 `fqm-execution` can generate highlighted HTML that indicates which individual pieces of the measure logic CQL were processed at all during calculation and held "truthy" values. This is often referred to as "Clause Coverage". "Covered" clauses will

--- a/README.md
+++ b/README.md
@@ -448,7 +448,7 @@ Add missing ValueSet resources to a measure bundle.
 
 The options that we support for calculation are as follows:
 
-- `[buildStatementLevelHTML]`<[boolean](#calculation-options)>: Builds and returns HTML at the statement level (default: `true`)
+- `[buildStatementLevelHTML]`<[boolean](#calculation-options)>: Builds and returns HTML at the statement level (default: `false`)
 - `[calculateClauseCoverage]`<[boolean](#calculation-options)>: Include HTML structure with clause coverage highlighting (default: `true`)
 - `[calculateHTML]`<[boolean](#calculation-options)>: Include HTML structure for highlighting (default: `true`)
 - `[calculateSDEs]`<[boolean](#calculation-options)>: Include Supplemental Data Elements (SDEs) in calculation (default: `true`)

--- a/README.md
+++ b/README.md
@@ -152,7 +152,8 @@ Statement results are a part of the calculation's `detailedResults` data. Statem
   "relevance": <whether the statement impacted the calculation>,
   "raw": <raw result of the statement calculation>,
   "isFunction": <whether the statement is a function>,
-  "pretty": <human readable version of the raw result>
+  "pretty": <human readable version of the raw result>,
+  "statementLevelHTML": <Generated HTML markup for the CQL statement>
 }
 ```
 
@@ -447,6 +448,7 @@ Add missing ValueSet resources to a measure bundle.
 
 The options that we support for calculation are as follows:
 
+- `[buildStatementLevelHTML]`<[boolean](#calculation-options)>: Builds and returns HTML at the statement level (default: `true`)
 - `[calculateClauseCoverage]`<[boolean](#calculation-options)>: Include HTML structure with clause coverage highlighting (default: `true`)
 - `[calculateHTML]`<[boolean](#calculation-options)>: Include HTML structure for highlighting (default: `true`)
 - `[calculateSDEs]`<[boolean](#calculation-options)>: Include Supplemental Data Elements (SDEs) in calculation (default: `true`)

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Statement results are a part of the calculation's `detailedResults` data. Statem
 }
 ```
 
-The statement result `.pretty` attribute can be used to show results data in a more user-friendly way for any of the calculated statements.
+The statement result `.pretty` attribute can be used to show results data in a more user-friendly way for any of the calculated statements. The statement result `.statementLevelHTML` attribute can be used to build the HTML markup alongside the "pretty" formatted statements without having to do so on the entire HTML output.
 
 ## Interpreting Calculation Results
 
@@ -912,6 +912,7 @@ Optionally, `fqm-execution` can generate the stylized HTML markup for each indiv
             "final": "TRUE",
             "relevance": "TRUE",
             "isFunction": false,
+            "pretty": "CODE: http://hl7.org/fhir/v3/AdministrativeGender F, Female",
             "statementLevelHTML": "<pre style=\"tab-size: 2; border-bottom-width: 4px; line-height: 1.4\"\n  data-library-name=\"CancerScreening\" data-statement-name=\"SDE Sex\">\n...\n</pre>"
           },
         ]

--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -71,7 +71,7 @@ export async function calculate<T extends CalculationOptions>(
   options.calculateSDEs = options.calculateSDEs ?? true;
   options.calculateClauseCoverage = options.calculateClauseCoverage ?? true;
   options.disableHTMLOrdering = options.disableHTMLOrdering ?? false;
-  options.buildStatementLevelHTML = options.buildStatementLevelHTML ?? true;
+  options.buildStatementLevelHTML = options.buildStatementLevelHTML ?? false;
 
   const compositeMeasureResource = MeasureBundleHelpers.extractCompositeMeasure(measureBundle);
 

--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -211,7 +211,7 @@ export async function calculate<T extends CalculationOptions>(
             detailedGroupResult.statementResults,
             detailedGroupResult.clauseResults,
             detailedGroupResult.groupId,
-            options.disableHTMLOrdering
+            options
           );
           detailedGroupResult.html = html;
           if (debugObject && options.enableDebugOutput) {

--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -71,6 +71,7 @@ export async function calculate<T extends CalculationOptions>(
   options.calculateSDEs = options.calculateSDEs ?? true;
   options.calculateClauseCoverage = options.calculateClauseCoverage ?? true;
   options.disableHTMLOrdering = options.disableHTMLOrdering ?? false;
+  options.buildStatementLevelHTML = options.buildStatementLevelHTML ?? true;
 
   const compositeMeasureResource = MeasureBundleHelpers.extractCompositeMeasure(measureBundle);
 

--- a/src/calculation/HTMLBuilder.ts
+++ b/src/calculation/HTMLBuilder.ts
@@ -35,8 +35,6 @@ export const cqlLogicUncoveredClauseStyle = {
   'border-bottom-style': 'solid'
 };
 
-type StatementAnnotation = { libraryName: string; annotation: Annotation[]; statementName: string };
-
 /**
  * Convert JS object to CSS Style string
  *
@@ -165,8 +163,8 @@ export function generateHTML(
     sortStatements(measure, groupId, relevantStatements);
   }
 
-  // assemble array of statement annotations to be templated to HTML
-  const statementAnnotations: StatementAnnotation[] = [];
+  let result = `<div><h2>Population Group: ${groupId}</h2>`;
+
   relevantStatements.forEach(s => {
     const matchingLibrary = elmLibraries.find(e => e.library.identifier.id === s.libraryName);
     if (!matchingLibrary) {
@@ -179,25 +177,15 @@ export function generateHTML(
     }
 
     if (matchingExpression.annotation) {
-      statementAnnotations.push({
+      const res = main({
         libraryName: s.libraryName,
         statementName: s.statementName,
-        annotation: matchingExpression.annotation
+        clauseResults: clauseResults,
+        ...matchingExpression.annotation[0].s
       });
+      result += res;
+      s.statementLevelHTML = res;
     }
-  });
-
-  let result = `<div><h2>Population Group: ${groupId}</h2>`;
-
-  // generate HTML clauses using hbs template for each annotation
-  statementAnnotations.forEach(a => {
-    const res = main({
-      libraryName: a.libraryName,
-      statementName: a.statementName,
-      clauseResults: clauseResults,
-      ...a.annotation[0].s
-    });
-    result += res;
   });
 
   result += '</div>';

--- a/src/calculation/HTMLBuilder.ts
+++ b/src/calculation/HTMLBuilder.ts
@@ -1,6 +1,12 @@
 import { Annotation, ELM } from '../types/ELMTypes';
 import Handlebars from 'handlebars';
-import { CalculationOptions, ClauseResult, DetailedPopulationGroupResult, ExecutionResult, StatementResult } from '../types/Calculator';
+import {
+  CalculationOptions,
+  ClauseResult,
+  DetailedPopulationGroupResult,
+  ExecutionResult,
+  StatementResult
+} from '../types/Calculator';
 import { FinalResult, PopulationType, Relevance } from '../types/Enums';
 import mainTemplate from '../templates/main';
 import clauseTemplate from '../templates/clause';

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -46,6 +46,8 @@ export interface CalculationOptions {
   rootLibRef?: string;
   /** Disables custom ordering of CQL statements in the HTML structure for highlighting */
   disableHTMLOrdering?: boolean;
+  /** Builds and returns HTML at the statement level */
+  buildStatementLevelHTML?: boolean;
 }
 
 /**
@@ -209,6 +211,8 @@ export interface StatementResult {
   pretty?: string;
   /** TRUE if the statement is a function */
   isFunction?: boolean;
+  /** Generated HTML markup for the CQL statement */
+  statementLevelHTML?: boolean;
 }
 
 /**

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -212,7 +212,7 @@ export interface StatementResult {
   /** TRUE if the statement is a function */
   isFunction?: boolean;
   /** Generated HTML markup for the CQL statement */
-  statementLevelHTML?: boolean;
+  statementLevelHTML?: string;
 }
 
 /**

--- a/test/unit/HTMLBuilder.test.ts
+++ b/test/unit/HTMLBuilder.test.ts
@@ -176,6 +176,34 @@ describe('HTMLBuilder', () => {
     }
   });
 
+  test('statement-level HTML is not added to statement results when statement relevance is NA', () => {
+    const statementResultsNA = [
+      {
+        statementName: 'statementName',
+        libraryName: 'libraryName',
+        final: FinalResult.NA,
+        relevance: Relevance.NA,
+        localId: 'localId'
+      }
+    ];
+
+    const clauseResultsNA = [
+      {
+        statementName: 'statementName',
+        libraryName: 'libraryName',
+        localId: 'localId',
+        final: FinalResult.NA,
+        raw: true
+      }
+    ];
+
+    generateHTML(simpleMeasure, [elm], statementResultsNA, clauseResultsNA, 'test', {
+      buildStatementLevelHTML: true
+    });
+
+    expect(statementResults[0].statementLevelHTML).toBeUndefined();
+  });
+
   test('simple HTML with generation with clause coverage styling', () => {
     // Ignore tabs and new lines
     const expectedHTML = getHTMLFixture('simpleCoverageAnnotation.html').replace(/\s/g, '');

--- a/test/unit/HTMLBuilder.test.ts
+++ b/test/unit/HTMLBuilder.test.ts
@@ -165,6 +165,17 @@ describe('HTMLBuilder', () => {
     expect(res.includes(falseStyleString)).toBeTruthy();
   });
 
+  test('statement-level HTML is added to statement results when calculation option is specified', () => {
+    const res = generateHTML(simpleMeasure, [elm], statementResults, trueClauseResults, 'test', {
+      buildStatementLevelHTML: true
+    });
+
+    expect(statementResults[0].statementLevelHTML).toBeDefined();
+    if (statementResults[0].statementLevelHTML) {
+      expect(res.includes(statementResults[0].statementLevelHTML)).toBeTruthy();
+    }
+  });
+
   test('simple HTML with generation with clause coverage styling', () => {
     // Ignore tabs and new lines
     const expectedHTML = getHTMLFixture('simpleCoverageAnnotation.html').replace(/\s/g, '');


### PR DESCRIPTION
# Summary
Adds statement-level HTML as a field on each statement result returned from measure calculation.

See https://github.com/projecttacoma/fqm-execution/issues/268 for more details on this feature.

## New behavior
The user can now specify a new calculation option: `buildStatementLevelHTML`. When set to `true`, the statement results returned from the detailed results will contain a new element `statementLevelHTML` that maps to a string of the HTML markup for the given statement. Thus, the structure of each `statementResult` will be as follows:

```
{
   "libraryName": "library name",
   "statementName": "statement name",
   ...
   "statementLevelHTML": "statement-level HTML"
}
```

For backwards compatibility, the overall `html` element and corresponding debug output are still available.

## Code changes
* Documentation updates to reflect the new calculation option and updated output
* Calculator type updates to reflect the new calculation option
* HTML Builder changes
    * Removed the `statementAnnotations` array, which stores all the statement annotations and then loops over each one for generating HTML clauses. Instead generates the statement-level HTML when looping over the relevant statements, and appends the statement-level HTML to an overall HTML structure.
* HTML Builder unit tests

# Testing guidance
* Run unit tests and integration tests (`npm run test:plus`)
* Run measure calculation against a measure with the `--debug` flag enabled. After calculation finishes, compare the logic highlighting `html` to the `statementResults` available on the `detailedResults`.
    * For statements that are not highlighted in the debug html (that have relevance equal to `NA`), the `statementLevelHTML` element should *not* be present on the statement’s `statementResults` object.
    * For statements that do not have relevance equal to `NA`, the `statementLevelHTML` element should be present on the statement’s `statementResults` object, and the statement-level HTML should match the HTML markup for the given statement in the debug HTML file. You can search by the `data-statement-name`/`data-library-name` in both the `statementResults` and debug html to compare the markup. The statement-level HTML markup should include the `<pre>` tag with the appropriate styling.

Note - open to thoughts on integration testing for this feature. A backlog task exists for adding more thorough testing for HTML building since the unit tests are very small in scope, but we could incorporate the beginnings of integration testing into this PR if desired. I did some brainstorming but am not 100% sure of a path forward for the integration testing (ex. Do we want to add HTML building tests for each measure type? Do we want to add tests to just the proportion boolean integration test? Do we want to make a whole new directory of integration tests specifically for HTML building?)