### PR TITLE
dataRequirements/gaps-in-care catch un-calculable intervals before they error out

### DIFF
--- a/src/types/ELMTypes.ts
+++ b/src/types/ELMTypes.ts
@@ -191,6 +191,8 @@ export type AnyELMExpression =
   | ELMEnd
   | ELMStart
   | ELMToDateTime
+  | ELMAdd
+  | ELMSubtract
   | ELMExpressionRef
   | ELMFunctionRef
   | ELMParameterRef
@@ -352,6 +354,14 @@ export interface ELMToDateTime extends ELMUnaryExpression {
   type: 'ToDateTime';
 }
 
+export interface ELMAdd extends ELMBinaryExpression {
+  type: 'Add';
+}
+
+export interface ELMSubtract extends ELMBinaryExpression {
+  type: 'Subtract';
+}
+
 interface ELMIExpressionRef extends ELMExpression {
   name: string;
   libraryName?: string;
@@ -380,7 +390,7 @@ export interface ELMProperty extends ELMExpression {
 
 export interface ELMAliasRef extends ELMExpression {
   type: 'AliasRef';
-  name: 'string';
+  name: string;
 }
 
 export interface ELMConceptRef extends ELMExpression {

--- a/test/unit/fixtures/elm/queries/ExtraQueries.cql
+++ b/test/unit/fixtures/elm/queries/ExtraQueries.cql
@@ -1,4 +1,7 @@
-/* Extra queries that may have ELM chunks used for QueryFilterParsing tests. */
+/* Extra queries that may have ELM chunks used for QueryFilterParsing tests. *//* Extra queries that may have ELM chunks used for QueryFilterParsing tests. *//* Extra queries that may have ELM chunks used for QueryFilterParsing tests. *//* Extra queries that may have ELM chunks used for QueryFilterParsing tests. */
+
+
+
 library ExtraQueries version '0.0.1'
 
 using FHIR version '4.0.1'
@@ -14,25 +17,21 @@ valueset "test-vs": 'http://example.com/test-vs'
 
 code "test-code": 'test' from "EXAMPLE"
 code "test-code-2": 'test-2' from "EXAMPLE-2"
-
 code "Active": 'active' from "ConditionClinicalStatusCodes"
 code "Recurrence": 'recurrence' from "ConditionClinicalStatusCodes"
 code "Relapse": 'relapse' from "ConditionClinicalStatusCodes"
 
 concept "test-concept": { "test-code", "test-code-2" } display 'test-concept'
-
 concept "Condition Active": { "Active", "Recurrence", "Relapse" } display 'Active'
 
-parameter "Measurement Period" Interval<DateTime>
-  default Interval[@2019-01-01T00:00:00.0, @2020-01-01T00:00:00.0)
-
+parameter "Measurement Period" Interval<DateTime>default Interval[@2019-01-01T00:00:00.0, @2020-01-01T00:00:00.0 )
 parameter "Index Date" Interval<DateTime>
 
 context Patient
 
 define "Function Result is not null":
   [Condition: "test-vs"] C
-    where Global."Normalize Interval"(C.abatement) is not null
+    where Global."Normalize Interval" ( C.abatement ) is not null
 
 define "Random Interval Param end is not null":
   [Condition: "test-vs"] C
@@ -47,7 +46,7 @@ define "FunctionRef In Same library":
 
 define "FunctionRef With More Complexity in parameter":
   [Condition: "test-vs"] C
-    where Global."Normalize Interval"("Passthrough"(C).abatement) during "Measurement Period"
+    where Global."Normalize Interval" ( "Passthrough"(C).abatement ) during "Measurement Period"
 
 define "Equivalent with Parameter":
   [Condition: "test-vs"] C
@@ -55,23 +54,33 @@ define "Equivalent with Parameter":
 
 define "Encounter Starts 2 Years Or Less Before MP":
   [Encounter: "test-vs"] Enc
-    where Global."Normalize Interval"(Enc.period) starts 2 years or less before end of "Measurement Period"
+    where Global."Normalize Interval" ( Enc.period ) starts 2 years or less before end of "Measurement Period"
 
 define "Encounter In MP":
   [Encounter: "test-vs"] Enc
-    where Global."Normalize Interval"(Enc.period) in "Measurement Period"
+    where Global."Normalize Interval" ( Enc.period ) in "Measurement Period"
 
 define "Function call in Interval":
   [Encounter: "test-vs"] Enc
-    where "Interval From Period"(Enc.period) in Interval[@2019-01-01T00:00:00.0, @2020-01-01T00:00:00.0)
+    where "Interval From Period"(Enc.period) in Interval[@2019-01-01T00:00:00.0, @2020-01-01T00:00:00.0 )
 
 define "GreaterThanOrEqual Birthdate at start of Observation":
-	[Observation: "test-vs"] HPVTest
-    where Global."CalendarAgeInYearsAt"(FHIRHelpers.ToDate(Patient.birthDate), start of Global."Normalize Interval"(HPVTest.effective))>= 30
+  [Observation: "test-vs"] HPVTest
+    where Global."CalendarAgeInYearsAt" ( FHIRHelpers.ToDate ( Patient.birthDate ), start of Global."Normalize Interval" ( HPVTest.effective ) ) >= 30
 
 define "GreaterThanOrEqual Observation Value":
   [Observation: "test-vs"] Test
     where Test.value >= 2 'mg'
+
+define "Observation Issued During First 10 min of Encounter":
+  [Observation] Obs
+    with [Encounter: "test-vs"] Enc
+      such that Obs.issued during Interval[Enc.startTime ( ), Enc.startTime ( ) + 10 'min']
+
+define "Observation Issued Between Start of MP and Encounter":
+  [Observation] Obs
+    with [Encounter: "test-vs"] Enc
+      such that Obs.issued during Interval[start of "Measurement Period", start of Enc.period]
 
 define function "A Function"(period Interval<DateTime>):
   start of period
@@ -80,4 +89,7 @@ define function "Passthrough"(cond Condition):
   cond
 
 define function "Interval From Period"(period FHIR.Period):
-  Global."Normalize Interval"(period)
+  Global."Normalize Interval" ( period )
+
+define fluent function "startTime"(e FHIR.Encounter):
+  start of e.period

--- a/test/unit/fixtures/elm/queries/ExtraQueries.cql
+++ b/test/unit/fixtures/elm/queries/ExtraQueries.cql
@@ -1,7 +1,4 @@
-/* Extra queries that may have ELM chunks used for QueryFilterParsing tests. *//* Extra queries that may have ELM chunks used for QueryFilterParsing tests. *//* Extra queries that may have ELM chunks used for QueryFilterParsing tests. *//* Extra queries that may have ELM chunks used for QueryFilterParsing tests. */
-
-
-
+/* Extra queries that may have ELM chunks used for QueryFilterParsing tests. */
 library ExtraQueries version '0.0.1'
 
 using FHIR version '4.0.1'

--- a/test/unit/queryFilters/interpretIn.test.ts
+++ b/test/unit/queryFilters/interpretIn.test.ts
@@ -1,7 +1,7 @@
 import { getELMFixture } from '../helpers/testHelpers';
 import { DateTime, Interval } from 'cql-execution';
 import * as QueryFilter from '../../../src/gaps/QueryFilterParser';
-import { ELMIn } from '../../../src/types/ELMTypes';
+import { ELMIn, ELMIncludedIn } from '../../../src/types/ELMTypes';
 import { DuringFilter } from '../../../src/types/QueryFilterTypes';
 
 // to use as a library parameter for tests
@@ -330,6 +330,137 @@ const IN_MP: ELMIn = {
   ]
 };
 
+/** From ExtraQueries.cql "Observation Issued During First 10 min of Encounter" */
+const OBSERVATION_ISSUED_DURING_ENCOUNTER: ELMIn = {
+  localId: '172',
+  locator: '78:17-78:91',
+  type: 'In',
+  operand: [
+    {
+      name: 'ToDateTime',
+      libraryName: 'FHIRHelpers',
+      type: 'FunctionRef',
+      operand: [
+        {
+          localId: '159',
+          locator: '78:17-78:26',
+          path: 'issued',
+          scope: 'Obs',
+          type: 'Property'
+        }
+      ]
+    },
+    {
+      localId: '171',
+      locator: '78:35-78:91',
+      lowClosed: true,
+      highClosed: true,
+      type: 'Interval',
+      low: {
+        localId: '166',
+        locator: '78:44-78:60',
+        name: 'startTime',
+        type: 'FunctionRef',
+        operand: [
+          {
+            localId: '160',
+            locator: '78:44-78:46',
+            name: 'Enc',
+            type: 'AliasRef'
+          }
+        ]
+      },
+      high: {
+        localId: '170',
+        locator: '78:63-78:90',
+        type: 'Add',
+        operand: [
+          {
+            localId: '168',
+            locator: '78:63-78:79',
+            name: 'startTime',
+            type: 'FunctionRef',
+            operand: [
+              {
+                localId: '167',
+                locator: '78:63-78:65',
+                name: 'Enc',
+                type: 'AliasRef'
+              }
+            ]
+          },
+          {
+            localId: '169',
+            locator: '78:83-78:90',
+            value: 10,
+            unit: 'min',
+            type: 'Quantity'
+          }
+        ]
+      }
+    }
+  ]
+};
+
+const OBSERVATION_ISSUED_BETWEEN_MP_AND_ENCOUNTER: ELMIn = {
+  localId: '188',
+  locator: '83:17-83:94',
+  type: 'In',
+  operand: [
+    {
+      name: 'ToDateTime',
+      libraryName: 'FHIRHelpers',
+      type: 'FunctionRef',
+      operand: [
+        {
+          localId: '181',
+          locator: '83:17-83:26',
+          path: 'issued',
+          scope: 'Obs',
+          type: 'Property'
+        }
+      ]
+    },
+    {
+      localId: '187',
+      locator: '83:35-83:94',
+      lowClosed: true,
+      highClosed: true,
+      type: 'Interval',
+      low: {
+        localId: '183',
+        locator: '83:44-83:72',
+        type: 'Start',
+        operand: {
+          localId: '182',
+          locator: '83:53-83:72',
+          name: 'Measurement Period',
+          type: 'ParameterRef'
+        }
+      },
+      high: {
+        localId: '186',
+        locator: '83:75-83:93',
+        type: 'Start',
+        operand: {
+          name: 'ToInterval',
+          libraryName: 'FHIRHelpers',
+          type: 'FunctionRef',
+          operand: [
+            {
+              localId: '185',
+              locator: '83:84-83:93',
+              path: 'period',
+              scope: 'Enc',
+              type: 'Property'
+            }
+          ]
+        }
+      }
+    }
+  ]
+};
+
 describe('interpretIn', () => {
   test('valid parameter interval ref', async () => {
     // Note: Global.Latest generates type:In instead of type:IncludedIn
@@ -382,5 +513,21 @@ describe('interpretIn', () => {
     expect(filter.type).toEqual('unknown');
     expect(filter.alias).toEqual('Enc');
     expect(filter.attribute).toEqual('period');
+  });
+
+  test('does not support creating interval based on alias usage in a function ref for low', async () => {
+    const filter = await QueryFilter.interpretIn(OBSERVATION_ISSUED_DURING_ENCOUNTER, complexQueryELM, EXEC_PARAMS);
+    expect(filter.type).toEqual('unknown');
+    expect(filter.alias).toEqual('Obs');
+  });
+
+  test('does not support creating interval based on property usage for high', async () => {
+    const filter = await QueryFilter.interpretIn(
+      OBSERVATION_ISSUED_BETWEEN_MP_AND_ENCOUNTER,
+      complexQueryELM,
+      EXEC_PARAMS
+    );
+    expect(filter.type).toEqual('unknown');
+    expect(filter.alias).toEqual('Obs');
   });
 });

--- a/test/unit/queryFilters/interpretIn.test.ts
+++ b/test/unit/queryFilters/interpretIn.test.ts
@@ -1,7 +1,7 @@
 import { getELMFixture } from '../helpers/testHelpers';
 import { DateTime, Interval } from 'cql-execution';
 import * as QueryFilter from '../../../src/gaps/QueryFilterParser';
-import { ELMIn, ELMIncludedIn } from '../../../src/types/ELMTypes';
+import { ELMIn } from '../../../src/types/ELMTypes';
 import { DuringFilter } from '../../../src/types/QueryFilterTypes';
 
 // to use as a library parameter for tests


### PR DESCRIPTION
# Summary

Fixes error with running `dataRequirements` on CMS1028.

## New behavior

Now checks for query source alias usage (often done in a function call) in the `Interval` operator before attempting to calculate an Interval for a data requirement which would fail if one exists.

Also adds the ability to scan one level deep in folders when using `--patient-directory`. Also filters out non `.json` files. This is need to run the new MADiE test case export format.

## Code changes
- `src/cli.ts` - New function for finding json files in a given directory and immediate sub directory. Use this function when `--patient-directory` is defined.
- `src/gaps/QueryFilterParser.ts` - Added function to find AliasRef usage and expanded the search for both `AliasRef` and `Property` usages to properly traverse the `low` and `high` properties of an ELM Interval statement. This are used to not attempt interval calculation and denote an unknown filter while parsing a comparison to an interval for gaps of care and data requirements.
- `src/types/ELMTypes` - Added some missing ELM Types that were needed for unit tests.
- `test/unit/queryFilters/interpretIn.test.ts` - Unit tests for these

# Testing guidance
Run unit tests. Run `dataRequirements` on CMS1028 and insure it doesn't error out.

For `--patient-directory` change: Ensure the functionality still is functional with a normal directory of patients. Move a patient into a sub folder and see if it is still executed.