### PR TITLE
Additional alias highlighting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2398,9 +2398,9 @@
       }
     },
     "node_modules/cql-execution": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.0.tgz",
-      "integrity": "sha512-5nVt7XExWkyUbb76l+xlCnDd9c3cCuTdKgr88kkPnCy5SeFC+TYSo2pVb1zGVppWCOqVw2+ju8nQyuYX5xaYzA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.1.tgz",
+      "integrity": "sha512-RC6uxrzvrJImFvyKvYDNLdumCS7nufJobhz5abfV3ZeFxbPR6E2gqJcn0T2KxVh4y40+BqbSGABwgiFTEITCdQ==",
       "dependencies": {
         "@lhncbc/ucum-lhc": "^4.1.3",
         "immutable": "^4.1.0",
@@ -8584,9 +8584,9 @@
       }
     },
     "cql-execution": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.0.tgz",
-      "integrity": "sha512-5nVt7XExWkyUbb76l+xlCnDd9c3cCuTdKgr88kkPnCy5SeFC+TYSo2pVb1zGVppWCOqVw2+ju8nQyuYX5xaYzA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.1.tgz",
+      "integrity": "sha512-RC6uxrzvrJImFvyKvYDNLdumCS7nufJobhz5abfV3ZeFxbPR6E2gqJcn0T2KxVh4y40+BqbSGABwgiFTEITCdQ==",
       "requires": {
         "@lhncbc/ucum-lhc": "^4.1.3",
         "immutable": "^4.1.0",

--- a/src/calculation/ClauseResultsHelpers.ts
+++ b/src/calculation/ClauseResultsHelpers.ts
@@ -195,6 +195,18 @@ export function findAllLocalIdsInStatement(
         alId = (parseInt(statement.localId, 10) - 1).toString();
         emptyResultClauses.push({ lib: libraryName, aliasLocalId: alId, expressionLocalId: aliasMap[alias] });
       }
+    } else if (
+      k === 'type' &&
+      v === 'Query' &&
+      Array.isArray(statement.source) &&
+      statement.source[0].localId == null &&
+      statement.source[0].expression.scope != null
+    ) {
+      // Handle aliases that are nested within an expression object in an object on a `source` array of a Query expression
+      // This case is similar to the one above, but we need to drill into `.source[0].expression.scope` instead
+      const alias = statement.source[0].expression.scope;
+      alId = (parseInt(statement.localId, 10) - 1).toString();
+      emptyResultClauses.push({ lib: libraryName, aliasLocalId: alId, expressionLocalId: aliasMap[alias] });
     } else if (k === 'type' && v === 'Null' && statement.localId) {
       // If this is a "Null" expression, mark that it `isFalsyLiteral` so we can interpret final results differently.
       localIds[statement.localId] = { localId: statement.localId, isFalsyLiteral: true };

--- a/src/calculation/ClauseResultsHelpers.ts
+++ b/src/calculation/ClauseResultsHelpers.ts
@@ -202,7 +202,7 @@ export function findAllLocalIdsInStatement(
       statement.source[0].localId == null &&
       statement.source[0].expression.scope != null
     ) {
-      // Handle aliases that are nested within an expression object in an object on a `source` array of a Query expression
+      // Handle aliases that are nested within an expression object in the one object on a `source` array of a Query expression
       // This case is similar to the one above, but we need to drill into `.source[0].expression.scope` instead
       const alias = statement.source[0].expression.scope;
       alId = (parseInt(statement.localId, 10) - 1).toString();

--- a/src/calculation/ClauseResultsHelpers.ts
+++ b/src/calculation/ClauseResultsHelpers.ts
@@ -199,6 +199,7 @@ export function findAllLocalIdsInStatement(
       k === 'type' &&
       v === 'Query' &&
       Array.isArray(statement.source) &&
+      statement.source.length === 1 &&
       statement.source[0].localId == null &&
       statement.source[0].expression.scope != null
     ) {

--- a/test/unit/ClauseResultsHelper.test.ts
+++ b/test/unit/ClauseResultsHelper.test.ts
@@ -118,6 +118,17 @@ describe('ClauseResultsHelpers', () => {
       // '8' is in the annotations but not in the ELM. We use '9' as the localId from the actual expression and subtract one from it
       expect(localIds['8']).toEqual({ localId: '8', sourceLocalId: '6' });
     });
+
+    test('should get the localIds for the query statement including the localId that is not in the ELM but is in the ELM annotation', () => {
+      const libraryElm: ELM = getJSONFixture('elm/queries/QICoreQuery.json');
+      const statementName = 'Query';
+
+      const localIds = ClauseResultsHelpers.findAllLocalIdsInStatementByName(libraryElm, statementName);
+
+      // '7' is in the annotations but not in the ELM. We use '8' as the localId from the actual expression and subtract one from it
+      expect(localIds[7]).not.toBeUndefined();
+      expect(localIds['7']).toEqual({ localId: '7', sourceLocalId: '5' });
+    });
   });
 
   describe('findLocalIdForLibraryRef for functionRefs', () => {

--- a/test/unit/ClauseResultsHelper.test.ts
+++ b/test/unit/ClauseResultsHelper.test.ts
@@ -14,7 +14,7 @@ describe('ClauseResultsHelpers', () => {
       // For the fixture loaded for this test it is known that the localId for the literal is 10 and
       // the localId for the comparison expression itself is 11 so the sourceLocalId for the literal
       // should be 11
-      expect(localIds[10]).not.toBeUndefined();
+      expect(localIds[10]).toBeDefined();
       expect(localIds[10]).toEqual({ localId: '10', sourceLocalId: '11' });
     });
 
@@ -27,7 +27,7 @@ describe('ClauseResultsHelpers', () => {
 
       // For the fixture loaded for this test it is known that the ELM Binary Expression does not have a literal
       // so the localId for the right side of the comparison should just be 12 and not have a sourceLocalId
-      expect(localIds[12]).not.toBeUndefined();
+      expect(localIds[12]).toBeDefined();
       expect(localIds[12]).toEqual({ localId: '12' });
     });
 
@@ -67,7 +67,7 @@ describe('ClauseResultsHelpers', () => {
       const localIds = ClauseResultsHelpers.findAllLocalIdsInStatementByName(libraryElm, statementName);
 
       // For the fixture loaded for this test it is known that the library reference is 49 and the functionRef itself is 55.
-      expect(localIds[49]).not.toBeUndefined();
+      expect(localIds[49]).toBeDefined();
       expect(localIds[49]).toEqual({ localId: '49', sourceLocalId: '55' });
     });
 
@@ -81,7 +81,7 @@ describe('ClauseResultsHelpers', () => {
       const localIds = ClauseResultsHelpers.findAllLocalIdsInStatementByName(libraryElm, statementName);
 
       // For the fixture loaded for this test it is known that the library reference is 109 and the functionRef itself is 110.
-      expect(localIds[109]).not.toBeUndefined();
+      expect(localIds[109]).toBeDefined();
       expect(localIds[109]).toEqual({ localId: '109', sourceLocalId: '110' });
     });
 
@@ -95,7 +95,7 @@ describe('ClauseResultsHelpers', () => {
       const localIds = ClauseResultsHelpers.findAllLocalIdsInStatementByName(libraryElm, statementName);
 
       // For the fixture loaded for this test it is known that the library reference is 109 and the functionRef itself is 110.
-      expect(localIds[42]).not.toBeUndefined();
+      expect(localIds[42]).toBeDefined();
       expect(localIds[42]).toEqual({ localId: '42' });
     });
 
@@ -126,7 +126,7 @@ describe('ClauseResultsHelpers', () => {
       const localIds = ClauseResultsHelpers.findAllLocalIdsInStatementByName(libraryElm, statementName);
 
       // '7' is in the annotations but not in the ELM. We use '8' as the localId from the actual expression and subtract one from it
-      expect(localIds[7]).not.toBeUndefined();
+      expect(localIds[7]).toBeDefined();
       expect(localIds['7']).toEqual({ localId: '7', sourceLocalId: '5' });
     });
   });

--- a/test/unit/fixtures/elm/queries/QICoreQuery.cql
+++ b/test/unit/fixtures/elm/queries/QICoreQuery.cql
@@ -1,0 +1,14 @@
+library QICoreQuery
+
+using QICore version '4.1.1'
+
+include FHIRHelpers version '4.0.1'
+
+codesystem "EXAMPLE": 'http://example.com'
+
+valueset "test-vs": 'http://example.com/test-vs'
+
+context Patient
+
+define "Query":
+    [Encounter] ValidEncounter where ValidEncounter.reasonCode in "test-vs"

--- a/test/unit/fixtures/elm/queries/QICoreQuery.json
+++ b/test/unit/fixtures/elm/queries/QICoreQuery.json
@@ -1,0 +1,392 @@
+{
+  "library": {
+    "annotation": [
+      {
+        "translatorVersion": "2.10.0",
+        "translatorOptions": "EnableAnnotations,EnableLocators",
+        "type": "CqlToElmInfo"
+      },
+      {
+        "type": "Annotation",
+        "s": {
+          "r": "12",
+          "s": [
+            {
+              "value": [
+                "",
+                "library QICoreQuery"
+              ]
+            }
+          ]
+        }
+      }
+    ],
+    "identifier": {
+      "id": "QICoreQuery"
+    },
+    "schemaIdentifier": {
+      "id": "urn:hl7-org:elm",
+      "version": "r1"
+    },
+    "usings": {
+      "def": [
+        {
+          "localIdentifier": "System",
+          "uri": "urn:hl7-org:elm-types:r1"
+        },
+        {
+          "localId": "1",
+          "locator": "3:1-3:28",
+          "localIdentifier": "QICore",
+          "uri": "http://hl7.org/fhir",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "1",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "using "
+                    ]
+                  },
+                  {
+                    "s": [
+                      {
+                        "value": [
+                          "QICore"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " version ",
+                      "'4.1.1'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "includes": {
+      "def": [
+        {
+          "localId": "2",
+          "locator": "5:1-5:35",
+          "localIdentifier": "FHIRHelpers",
+          "path": "FHIRHelpers",
+          "version": "4.0.1",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "2",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "include "
+                    ]
+                  },
+                  {
+                    "s": [
+                      {
+                        "value": [
+                          "FHIRHelpers"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " version ",
+                      "'4.0.1'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "codeSystems": {
+      "def": [
+        {
+          "localId": "3",
+          "locator": "7:1-7:42",
+          "name": "EXAMPLE",
+          "id": "http://example.com",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "3",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "codesystem ",
+                      "\"EXAMPLE\"",
+                      ": ",
+                      "'http://example.com'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "valueSets": {
+      "def": [
+        {
+          "localId": "4",
+          "locator": "9:1-9:48",
+          "name": "test-vs",
+          "id": "http://example.com/test-vs",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "4",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "valueset ",
+                      "\"test-vs\"",
+                      ": ",
+                      "'http://example.com/test-vs'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "contexts": {
+      "def": [
+        {
+          "locator": "11:1-11:15",
+          "name": "Patient"
+        }
+      ]
+    },
+    "statements": {
+      "def": [
+        {
+          "locator": "11:1-11:15",
+          "name": "Patient",
+          "context": "Patient",
+          "expression": {
+            "type": "SingletonFrom",
+            "operand": {
+              "locator": "11:1-11:15",
+              "dataType": "{http://hl7.org/fhir}Patient",
+              "templateId": "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient",
+              "type": "Retrieve"
+            }
+          }
+        },
+        {
+          "localId": "12",
+          "locator": "13:1-14:75",
+          "name": "Query",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "12",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Query\"",
+                      ":\n    "
+                    ]
+                  },
+                  {
+                    "r": "11",
+                    "s": [
+                      {
+                        "s": [
+                          {
+                            "r": "6",
+                            "s": [
+                              {
+                                "r": "5",
+                                "s": [
+                                  {
+                                    "r": "5",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "[",
+                                          "Encounter",
+                                          "]"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "ValidEncounter"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          " "
+                        ]
+                      },
+                      {
+                        "r": "10",
+                        "s": [
+                          {
+                            "value": [
+                              "where "
+                            ]
+                          },
+                          {
+                            "r": "10",
+                            "s": [
+                              {
+                                "r": "8",
+                                "s": [
+                                  {
+                                    "r": "7",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "ValidEncounter"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "."
+                                    ]
+                                  },
+                                  {
+                                    "r": "8",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "reasonCode"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " in "
+                                ]
+                              },
+                              {
+                                "r": "9",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "\"test-vs\""
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "11",
+            "locator": "14:5-14:75",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "6",
+                "locator": "14:5-14:30",
+                "alias": "ValidEncounter",
+                "expression": {
+                  "localId": "5",
+                  "locator": "14:5-14:15",
+                  "dataType": "{http://hl7.org/fhir}Encounter",
+                  "templateId": "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter",
+                  "type": "Retrieve"
+                }
+              }
+            ],
+            "relationship": [],
+            "where": {
+              "localId": "10",
+              "locator": "14:32-14:75",
+              "type": "AnyInValueSet",
+              "codes": {
+                "localId": "8",
+                "locator": "14:38-14:62",
+                "type": "Query",
+                "source": [
+                  {
+                    "alias": "$this",
+                    "expression": {
+                      "path": "reasonCode",
+                      "scope": "ValidEncounter",
+                      "type": "Property"
+                    }
+                  }
+                ],
+                "return": {
+                  "distinct": false,
+                  "expression": {
+                    "name": "ToConcept",
+                    "libraryName": "FHIRHelpers",
+                    "type": "FunctionRef",
+                    "operand": [
+                      {
+                        "name": "$this",
+                        "type": "AliasRef"
+                      }
+                    ]
+                  }
+                }
+              },
+              "valueset": {
+                "localId": "9",
+                "locator": "14:67-14:75",
+                "name": "test-vs",
+                "preserve": true
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
# Summary
Fixes #275 
This PR fixes the highlighting issue with the `ValidEncounter` alias in the above issue. This PR does not fix the clause coverage calculation issue and highlighting for `reasonCode`, that is being done in [this](https://github.com/cqframework/cql-execution/pull/314) PR in cql-execution.

## New behavior
Added new handling to `findAllLocalIdsInStatement` to account for aliases that are nested within queries from CQL that was authored using QICore. 

## Code changes
- `ClauseResultsHelpers.ts` - added branch to `findAllLocalIdsInStatement`  to handle query expressions that have a source that is an array with a single value but that value does not have a localId. In this case (that seems to occur when the CQL is authored using QICore), the alias is within this `source[0].expression.scope`. The alias localId is then going to be one less than the localId of the query statement. 
- `ClauseResultsHelpers.test.ts` - added a unit test for this new handling that uses CQL query expression authored using QICore.
- `QICoreQuery.cql` / `QICoreQuery.json` - test fixtures for the above unit test

# Testing guidance
- `npm run check`, `npm run test:integration`, run regression tests (all should pass)
- Run `detailed` calculation on the above issue with a measurement period start of 2024-01-01 and a measurement period end of 2024-12-31 and the debug option off.
- Look at the overall clause coverage html (`cd debug/html`). `ValidEncounter` should be highlighted (again, `reasonCode` will not be highlighted)
- Look at the measure logic highlighting. `ValidEncounter` should be highlighted green (`reasonCode` will be highlighted red)