### PR TITLE
Update source parsing for query filter parsing

### DIFF
--- a/src/gaps/GapsReportBuilder.ts
+++ b/src/gaps/GapsReportBuilder.ts
@@ -614,39 +614,42 @@ export function addFiltersToDataRequirement(
   withErrors: GracefulError[]
 ) {
   if (q.queryInfo) {
-    // TODO: compare q.dataType to the resource type in queryInfo.source
+    const relevantSource = q.queryInfo.sources.find(source => source.resourceType === q.dataType);
     // if a source cannot be found that matches, exit the function
-    const detailedFilters = flattenFilters(q.queryInfo.filter);
+    if (relevantSource) {
+      const detailedFilters = flattenFilters(q.queryInfo.filter);
 
-    detailedFilters.forEach(df => {
-      // TODO: check the alias before doing an explicit casting of the filters
-      if (df.type === 'equals' || df.type === 'in') {
-        const cf = generateDetailedCodeFilter(df as EqualsFilter | InFilter, q.dataType);
-
-        if (cf !== null) {
-          dataRequirement.codeFilter?.push(cf);
-        }
-      } else if (df.type === 'during') {
+      detailedFilters.forEach(df => {
         // DuringFilter, etc. inherit from attribute filter (and have alias on them)
-        const dateFilter = generateDetailedDateFilter(df as DuringFilter);
-        if (dataRequirement.dateFilter) {
-          dataRequirement.dateFilter.push(dateFilter);
-        } else {
-          dataRequirement.dateFilter = [dateFilter];
-        }
-      } else {
-        const valueFilter = generateDetailedValueFilter(df);
-        if (didEncounterDetailedValueFilterErrors(valueFilter)) {
-          withErrors.push(valueFilter);
-        } else if (valueFilter) {
-          if (dataRequirement.extension) {
-            dataRequirement.extension.push(valueFilter);
+        if (relevantSource.alias === (df as AttributeFilter).alias) {
+          if (df.type === 'equals' || df.type === 'in') {
+            const cf = generateDetailedCodeFilter(df as EqualsFilter | InFilter, q.dataType);
+
+            if (cf !== null) {
+              dataRequirement.codeFilter?.push(cf);
+            }
+          } else if (df.type === 'during') {
+            const dateFilter = generateDetailedDateFilter(df as DuringFilter);
+            if (dataRequirement.dateFilter) {
+              dataRequirement.dateFilter.push(dateFilter);
+            } else {
+              dataRequirement.dateFilter = [dateFilter];
+            }
           } else {
-            dataRequirement.extension = [valueFilter];
+            const valueFilter = generateDetailedValueFilter(df);
+            if (didEncounterDetailedValueFilterErrors(valueFilter)) {
+              withErrors.push(valueFilter);
+            } else if (valueFilter) {
+              if (dataRequirement.extension) {
+                dataRequirement.extension.push(valueFilter);
+              } else {
+                dataRequirement.extension = [valueFilter];
+              }
+            }
           }
         }
-      }
-    });
+      });
+    }
   }
 }
 

--- a/src/gaps/GapsReportBuilder.ts
+++ b/src/gaps/GapsReportBuilder.ts
@@ -626,7 +626,11 @@ export function addFiltersToDataRequirement(
             const cf = generateDetailedCodeFilter(df as EqualsFilter | InFilter, q.dataType);
 
             if (cf !== null) {
-              dataRequirement.codeFilter?.push(cf);
+              if (dataRequirement.codeFilter) {
+                dataRequirement.codeFilter.push(cf);
+              } else {
+                dataRequirement.codeFilter = [cf];
+              }
             }
           } else if (df.type === 'during') {
             const dateFilter = generateDetailedDateFilter(df as DuringFilter);

--- a/src/gaps/GapsReportBuilder.ts
+++ b/src/gaps/GapsReportBuilder.ts
@@ -614,9 +614,12 @@ export function addFiltersToDataRequirement(
   withErrors: GracefulError[]
 ) {
   if (q.queryInfo) {
+    // TODO: compare q.dataType to the resource type in queryInfo.source
+    // if a source cannot be found that matches, exit the function
     const detailedFilters = flattenFilters(q.queryInfo.filter);
 
     detailedFilters.forEach(df => {
+      // TODO: check the alias before doing an explicit casting of the filters
       if (df.type === 'equals' || df.type === 'in') {
         const cf = generateDetailedCodeFilter(df as EqualsFilter | InFilter, q.dataType);
 
@@ -624,6 +627,7 @@ export function addFiltersToDataRequirement(
           dataRequirement.codeFilter?.push(cf);
         }
       } else if (df.type === 'during') {
+        // DuringFilter, etc. inherit from attribute filter (and have alias on them)
         const dateFilter = generateDetailedDateFilter(df as DuringFilter);
         if (dataRequirement.dateFilter) {
           dataRequirement.dateFilter.push(dateFilter);

--- a/src/gaps/QueryFilterParser.ts
+++ b/src/gaps/QueryFilterParser.ts
@@ -1,4 +1,4 @@
-import { Interval, Expression, PatientContext, Library, DateTime } from 'cql-execution';
+import { Interval, Expression, PatientContext, Library, DateTime, NamedTypeSpecifier, ListTypeSpecifier } from 'cql-execution';
 import { CQLPatient } from '../types/CQLPatient';
 import {
   ELM,
@@ -34,8 +34,7 @@ import {
   ELMLess,
   ELMLessOrEqual,
   ELMRatio,
-  ELMAliasRef,
-  ListTypeSpecifier
+  ELMAliasRef
 } from '../types/ELMTypes';
 import {
   AndFilter,
@@ -274,10 +273,8 @@ function parseDataType(retrieve: ELMRetrieve): string {
  * @returns FHIR ResourceType name.
  */
 function parseElementType(expression: ELMExpression): string {
-  return (expression.resultTypeSpecifier as ListTypeSpecifier).elementType.name.replace(
-    /^(\{http:\/\/hl7.org\/fhir\})?/,
-    ''
-  );
+  const elementType = (expression.resultTypeSpecifier as ListTypeSpecifier).elementType as NamedTypeSpecifier;
+  return elementType.name.replace(/^(\{http:\/\/hl7.org\/fhir\})?/, '');
 }
 
 /**

--- a/src/gaps/QueryFilterParser.ts
+++ b/src/gaps/QueryFilterParser.ts
@@ -233,17 +233,16 @@ function parseSources(query: ELMQuery): SourceInfo[] {
         resourceType: parseDataType(source.expression as ELMRetrieve)
       };
       sources.push(sourceInfo);
-    } else {
-      if (source.expression.resultTypeSpecifier) {
-        const sourceInfo: SourceInfo = {
-          sourceLocalId: source.localId,
-          alias: source.alias,
-          resourceType: parseElementType(source.expression)
-        };
-        sources.push(sourceInfo);
-      }
+    } else if (source.expression.resultTypeSpecifier) {
+      const sourceInfo: SourceInfo = {
+        sourceLocalId: source.localId,
+        alias: source.alias,
+        resourceType: parseElementType(source.expression)
+      };
+      sources.push(sourceInfo);
     }
   });
+  // parse relationship clauses
   query.relationship.forEach(relationship => {
     if (relationship.expression.type == 'Retrieve') {
       const sourceInfo: SourceInfo = {

--- a/src/gaps/QueryFilterParser.ts
+++ b/src/gaps/QueryFilterParser.ts
@@ -227,7 +227,8 @@ function replaceAliasesInFilters(filter: AnyFilter, match: string, replace: stri
  * Parse information about the sources in a given query. Treat relationships as sources.
  *
  * @param query The Query to parse. The query source can consist of aliased query sources or relationship clauses.
- * @returns Information about each source. This is usually an array of one.
+ * @returns Information about each source. This is usually an array of one, except for when we are working with
+ * multi-source queries or relationships.
  */
 function parseSources(query: ELMQuery): SourceInfo[] {
   const sources: SourceInfo[] = [];

--- a/src/gaps/QueryFilterParser.ts
+++ b/src/gaps/QueryFilterParser.ts
@@ -232,6 +232,24 @@ function parseSources(query: ELMQuery): SourceInfo[] {
         resourceType: parseDataType(source.expression as ELMRetrieve)
       };
       sources.push(sourceInfo);
+    } else {
+      const sourceInfo: SourceInfo = {
+        sourceLocalId: source.localId,
+        alias: source.alias,
+        resourceType: parseElementType(source.expression)
+      };
+      sources.push(sourceInfo);
+    }
+  });
+  query.relationship.forEach(relationship => {
+    if (relationship.expression.type == 'Retrieve') {
+      const sourceInfo: SourceInfo = {
+        sourceLocalId: relationship.localId,
+        retrieveLocalId: relationship.expression.localId,
+        alias: relationship.alias,
+        resourceType: parseDataType(relationship.expression as ELMRetrieve)
+      };
+      sources.push(sourceInfo);
     }
   });
   return sources;
@@ -245,6 +263,16 @@ function parseSources(query: ELMQuery): SourceInfo[] {
  */
 function parseDataType(retrieve: ELMRetrieve): string {
   return retrieve.dataType.replace(/^(\{http:\/\/hl7.org\/fhir\})?/, '');
+}
+
+/**
+ * Pulls out the resource type of a result type
+ *
+ * @param expression The expression to pull out resource type from.
+ * @returns FHIR ResourceType name.
+ */
+function parseElementType(expression: any): string {
+  return expression.resultTypeSpecifier.elementType.name.replace(/^(\{http:\/\/hl7.org\/fhir\})?/, '');
 }
 
 /**

--- a/src/gaps/QueryFilterParser.ts
+++ b/src/gaps/QueryFilterParser.ts
@@ -34,7 +34,8 @@ import {
   ELMLess,
   ELMLessOrEqual,
   ELMRatio,
-  ELMAliasRef
+  ELMAliasRef,
+  ListTypeSpecifier
 } from '../types/ELMTypes';
 import {
   AndFilter,
@@ -233,12 +234,14 @@ function parseSources(query: ELMQuery): SourceInfo[] {
       };
       sources.push(sourceInfo);
     } else {
-      const sourceInfo: SourceInfo = {
-        sourceLocalId: source.localId,
-        alias: source.alias,
-        resourceType: parseElementType(source.expression)
-      };
-      sources.push(sourceInfo);
+      if (source.expression.resultTypeSpecifier) {
+        const sourceInfo: SourceInfo = {
+          sourceLocalId: source.localId,
+          alias: source.alias,
+          resourceType: parseElementType(source.expression)
+        };
+        sources.push(sourceInfo);
+      }
     }
   });
   query.relationship.forEach(relationship => {
@@ -271,8 +274,11 @@ function parseDataType(retrieve: ELMRetrieve): string {
  * @param expression The expression to pull out resource type from.
  * @returns FHIR ResourceType name.
  */
-function parseElementType(expression: any): string {
-  return expression.resultTypeSpecifier.elementType.name.replace(/^(\{http:\/\/hl7.org\/fhir\})?/, '');
+function parseElementType(expression: ELMExpression): string {
+  return (expression.resultTypeSpecifier as ListTypeSpecifier).elementType.name.replace(
+    /^(\{http:\/\/hl7.org\/fhir\})?/,
+    ''
+  );
 }
 
 /**

--- a/src/gaps/QueryFilterParser.ts
+++ b/src/gaps/QueryFilterParser.ts
@@ -1,4 +1,12 @@
-import { Interval, Expression, PatientContext, Library, DateTime, NamedTypeSpecifier, ListTypeSpecifier } from 'cql-execution';
+import {
+  Interval,
+  Expression,
+  PatientContext,
+  Library,
+  DateTime,
+  NamedTypeSpecifier,
+  ListTypeSpecifier
+} from 'cql-execution';
 import { CQLPatient } from '../types/CQLPatient';
 import {
   ELM,

--- a/src/types/ELMTypes.ts
+++ b/src/types/ELMTypes.ts
@@ -1,3 +1,5 @@
+import { AnyTypeSpecifier } from 'cql-execution';
+
 /** Top level of an ELM JSON. */
 export interface ELM {
   /** ELM Library definition. */
@@ -64,7 +66,7 @@ export interface ELMInclude {
   locator?: string;
   /** Local identifier that will be used to reference this library in the logic. */
   localIdentifier: string;
-  /** The id of the refereced library. */
+  /** The id of the referenced library. */
   path: string;
   /** The version of the referenced library. */
   version: string;
@@ -168,7 +170,7 @@ export interface ELMExpression {
   /** Locator in the original CQL file. Only exists if compiled with this info. */
   locator?: string;
   /** Type specifier for the result of the expression. */
-  resultTypeSpecifier?: TypeSpecifier;
+  resultTypeSpecifier?: AnyTypeSpecifier;
 }
 
 export type AnyELMExpression =
@@ -477,24 +479,3 @@ export interface AnnotationStatement {
 }
 
 export type ELMComparator = ELMGreaterOrEqual | ELMLessOrEqual | ELMGreater | ELMLess;
-
-/**
- * Abstract base type for all type specifiers.
- */
-export interface TypeSpecifier {
-  /** Type of type specifier. */
-  type: string;
-}
-
-/**
- * Defines a list type by specifying the type of elements the list may contain.
- */
-export interface ListTypeSpecifier extends TypeSpecifier {
-  type: 'ListTypeSpecifier';
-  elementType: {
-    /** Name of data types included in element type. */
-    name: string;
-    /** Type of type specifier. */
-    type: string;
-  };
-}

--- a/src/types/ELMTypes.ts
+++ b/src/types/ELMTypes.ts
@@ -169,7 +169,7 @@ export interface ELMExpression {
   localId?: string;
   /** Locator in the original CQL file. Only exists if compiled with this info. */
   locator?: string;
-  /** Type specifier for the result of the expression. */
+  /** Type specifier for the result of the expression. This field may or may not be included in translator output. */
   resultTypeSpecifier?: AnyTypeSpecifier;
 }
 

--- a/src/types/ELMTypes.ts
+++ b/src/types/ELMTypes.ts
@@ -167,6 +167,8 @@ export interface ELMExpression {
   localId?: string;
   /** Locator in the original CQL file. Only exists if compiled with this info. */
   locator?: string;
+  /** Type specifier for the result of the expression. */
+  resultTypeSpecifier?: TypeSpecifier;
 }
 
 export type AnyELMExpression =
@@ -475,3 +477,24 @@ export interface AnnotationStatement {
 }
 
 export type ELMComparator = ELMGreaterOrEqual | ELMLessOrEqual | ELMGreater | ELMLess;
+
+/**
+ * Abstract base type for all type specifiers.
+ */
+export interface TypeSpecifier {
+  /** Type of type specifier. */
+  type: string;
+}
+
+/**
+ * Defines a list type by specifying the type of elements the list may contain.
+ */
+export interface ListTypeSpecifier extends TypeSpecifier {
+  type: 'ListTypeSpecifier';
+  elementType: {
+    /** Name of data types included in element type. */
+    name: string;
+    /** Type of type specifier. */
+    type: string;
+  };
+}


### PR DESCRIPTION
# Summary
For measures authored using QI-Core, the `sources` array is unpopulated due to unhandled scenarios related to parsing query sources. Updates `parseSources` to drill into expressions on a given query that are not immediate retrieves.

## New behavior
The `sources` arrays on the query info should now be populated appropriately. The approach to source parsing is as follows:

- When parsing sources, handle all sources whose expressions are retrieves (which is the current behavior)
- If the source expression is not a retrieve, check that it contains a `resultTypeSpecifier`. For the QI-Core-authored measures, the `source` is of the following format (for an example of an Encounter datatype and “Union” type):

```bash
“source”: [
  {
    “localId”: 2,
    “alias”: “MyAlias”,
    “resultTypeSpecifier”: {
      “type”: “ListTypeSpecifier”,
      “elementType”: {
        “name”: “{http//hl7.org/fhir}Encounter”,
        “type”: “NamedTypeSpecifier”
      }
    },
    “expression”: {
      “localId”: “1”,
      “type”: “Union”,
      “resultTypeSpecifier”: {
        “type”: “ListTypeSpecifier”,
        “elementType”: {
          “name”: “{http://hl7.org/fhir}Encounter”,
          “type”: “NamedTypeSpecifier”
        }
      }
    }
  }
]
```
Since there is no `datatype` on the expression, the “elementType” is parsed to retrieve the associated datatype.
- The relationship clauses are now also parsed for sources. The relationship clauses allow related sources to be used to restrict the elements included from another source in a query scope.

A potential side effect of the current query filter parsing implementation is that incorrect attribute paths are assigned to resource types during data requirements calculation. Note that this issue is not directly addressed in this pull request, as there are other issues involved, such as the “query stacking” approach that is implemented and how it handles the “Union” type that is seen in the ELM of QI-Core measures.

More information about the ELM structure is available at https://cql.hl7.org/04-logicalspecification.html. 

## Code changes
**QueryFilterParser**
- Update `parseSources` function to now extract sources from the `resultTypeSpecifier` if present (in the case that the type is not a Retrieve)
- Parse the relationship clauses in addition to parsing the sources
- Add function `parseElementType` to parse the `elementType` on the expression (this is an alternative to parsing the `datatype`)
**ELMTypes**
- Adds `resultTypeSpecifier` as an option field on an ELM expression

# Testing guidance
It is important to test against both QI-Core and non-QI-Core measures.
Some potential steps that can be taken for testing:
- `npm run test`, `npm run test:integration`, etc. to ensure that no side effects were introduced. Pay specific attention to the query filter parsing unit tests
- Run data requirements against various measures with the `debug` option enabled.
  - Within `debug/gaps.json`, pay specific attention to the `queryInfo` output on the retrieves. Previously the `sources` array would be empty for some of the QI-Core measures (CMS161 is an example). Check that this is no longer the case, and that the `sources` array is appropriately populated by looking back at the ELM output for the measure being tested.
  - Note that the data requirements output may not be 100% accurate (i.e. the paths on the filters may be inaccurate due to the current query stacking approach)
  - Check that the `gaps.json` output has not changed for non-QI-Core measures, except in the case that the `relationships` array sources are not encompassed in the sources. The data requirements output is not expected to change. This can be done by generating the output on this branch and on the main branch, and using the ‘Select for Compare’ feature in VSCode.
  - Specific measures that can be tested: CMS161, CMS1028, CMS142, CMS177

### Open questions to check for when testing
- Do we want to parse the `relationships` expressions alongside the source expressions? According to the logical specification, the relationship clauses “allow related sources to restrict the elements included from another source in a query scope…The elements of the related source are not included in the query scope.”
- Is it “valid” to pull information from the `resultTypeSpecifier`? The cql-execution library contains types for `TypeSpecifier`s, but little (if any) handling is done in fqm-execution for parsing the `TypeSpecifier`s.
- Right now, if an inner query exists, the inner query is parsed, and the original query’s sources are set to the inner query’s sources. Do we want to keep this logic intact? Using CMS161 as an example, there are instances where the inner query info sources contain a Procedure: 

<img width="336" alt="image" src="https://github.com/projecttacoma/fqm-execution/assets/87094479/240d1070-b2c2-4188-b416-c7aadae71893">

However, the original query info does not contain the Procedure and instead contains an Encounter:

 
<img width="238" alt="image" src="https://github.com/projecttacoma/fqm-execution/assets/87094479/11fb3154-7ec0-4ca6-897c-9c9105ffd328">

When we set `queryInfo.sources = innerQueryInfo.sources`, we lose this Procedure source.


