### PR TITLE
Allow for UNHIT clauses to be highlighted as specifically uncovered

### DIFF
--- a/src/calculation/HTMLBuilder.ts
+++ b/src/calculation/HTMLBuilder.ts
@@ -84,7 +84,7 @@ Handlebars.registerHelper('highlightCoverage', (localId, context) => {
   if (clauseResult) {
     if (clauseResult.some(c => c.final === FinalResult.TRUE)) {
       return objToCSS(cqlLogicClauseCoveredStyle);
-    } else if (clauseResult.every(c => c.final === FinalResult.FALSE)) {
+    } else if (clauseResult.every(c => c.final === FinalResult.FALSE || c.final === FinalResult.UNHIT)) {
       return objToCSS(cqlLogicUncoveredClauseStyle);
     }
   }


### PR DESCRIPTION
# Summary
Fixes an issue with coverage highlighting where clauses that may have situations with "UNHIT" final results may not be specifically highlighted without coverage and show as covered when they were not. This can happen for any logic that is only relevant when the IPP or DENOM is satisfied. There was no issue with coverage percentage in this situation.

In the case of CMS108, the DENEX related logic would have this bug exhibited when any patients that were testing the IPP fail scenario were included in the set of test patients.

## New behavior
Now allows for the UNHIT results to be valid for marking a clause as uncovered instead of inheriting style from the parent clause.

## Code changes
`HTMLBuilder.ts` - Add UNHIT as an option for a clause to be marked uncovered which "whites" out the coverage styling if the parent clause was covered.

# Testing guidance
Run coverage calculation with CMS108 and ensure that `doNotPerform` and the uncovered equality comparisons `~` show as uncovered instead of inheriting the coverage of their parent clauses.