### PR TITLE
Check if dataRequirement resourceType does not have patient search params

### DIFF
--- a/src/helpers/DataRequirementHelpers.ts
+++ b/src/helpers/DataRequirementHelpers.ts
@@ -284,7 +284,7 @@ export function addFhirQueryPatternToDataRequirements(dataRequirement: fhir4.Dat
   }
 
   // Create an extension for each way that exists for referencing the patient
-  (<any>PatientParameters)[dataRequirement.type].forEach((patientContext: string) => {
+  (<any>PatientParameters)[dataRequirement.type]?.forEach((patientContext: string) => {
     const fhirPathExtension: Extension = {
       url: FHIR_QUERY_PATTERN_URL,
       valueString: queryString.concat(`${patientContext}=Patient/{{context.patientId}}`)


### PR DESCRIPTION
# Summary
We found an issue when running `dataRequirements` with CMS68. It will error out with the Task resource on CMS68 since the Task resource type is in the compartment definition, but does not have any search parameters so it is not included in `PatientParameters.ts` (the file that is a result of running the `parseCompartmentDefiniton.js` script in the `deqm-test-server` repo). Now, running `dataRequirements` on this measure no longer errors out.

## New behavior
Now, we only do a `.forEach` on the indexed content of PatientParameters for a resourceType if that resourceType exists in PatientParameters. 

## Code changes
- `DataRequirementsHelpers.ts` - skips adding an extension to a data requirement whose resourceType is not in `PatientParameters.ts`.

# Testing guidance
- `npm run check`
- `npm run test:integration`
- Run data requirements on CMS68.

QUESTION: Should we be adding an extension to dataRequirements whose resourceType is not in `PatientParameters.ts`? I tried looking into the spec for `fhirQueryPattern` but wasn't sure...
