### PR TITLE
Not Equal and Not Equivalent clause coverage calculation handling

### DIFF
--- a/src/calculation/ClauseResultsHelpers.ts
+++ b/src/calculation/ClauseResultsHelpers.ts
@@ -214,6 +214,20 @@ export function findAllLocalIdsInStatement(
     } else if (k === 'type' && v === 'Literal' && statement.localId && statement.value === 'false') {
       // If this is a "Literal" expression whose value is false, mark that it `isFalsyLiteral` so we can interpret final results differently
       localIds[statement.localId] = { localId: statement.localId, isFalsyLiteral: true };
+    } else if (k === 'type' && v === 'Not') {
+      // If this is a "Not" expression, we will want to check if it's operand type is 'Equivalent' or 'Equal'
+      // If so, we will want to treat this as a 'Not Equivalent' or 'Not Equal' expression which we can do so
+      // by mapping the 'Equal' or 'Equivalent' clause localId to that of the 'Not' clause
+      if (statement.operand) {
+        if (statement.operand.type === 'Equivalent' || statement.operand.type === 'Equal') {
+          emptyResultClauses.push({
+            lib: libraryName,
+            aliasLocalId: statement.operand.localId,
+            expressionLocalId: statement.localId
+          });
+        }
+      }
+      localIds[statement.localId] = { localId: v };
     } else if (k === 'localId') {
       // else if the key is localId, push the value
       localIds[v] = { localId: v };

--- a/src/calculation/ClauseResultsHelpers.ts
+++ b/src/calculation/ClauseResultsHelpers.ts
@@ -230,7 +230,6 @@ export function findAllLocalIdsInStatement(
           });
         }
       }
-      localIds[statement.localId] = { localId: v };
     } else if (k === 'localId') {
       // else if the key is localId, push the value
       localIds[v] = { localId: v };

--- a/src/calculation/ClauseResultsHelpers.ts
+++ b/src/calculation/ClauseResultsHelpers.ts
@@ -219,7 +219,10 @@ export function findAllLocalIdsInStatement(
       // If so, we will want to treat this as a 'Not Equivalent' or 'Not Equal' expression which we can do so
       // by mapping the 'Equal' or 'Equivalent' clause localId to that of the 'Not' clause
       if (statement.operand) {
-        if (statement.operand.type === 'Equivalent' || statement.operand.type === 'Equal') {
+        if (
+          statement.operand.type === 'Equivalent' ||
+          (statement.operand.type === 'Equal' && statement.operand.localId)
+        ) {
           emptyResultClauses.push({
             lib: libraryName,
             aliasLocalId: statement.operand.localId,

--- a/src/calculation/ClauseResultsHelpers.ts
+++ b/src/calculation/ClauseResultsHelpers.ts
@@ -218,11 +218,8 @@ export function findAllLocalIdsInStatement(
       // If this is a "Not" expression, we will want to check if it's operand type is 'Equivalent' or 'Equal'
       // If so, we will want to treat this as a 'Not Equivalent' or 'Not Equal' expression which we can do so
       // by mapping the 'Equal' or 'Equivalent' clause localId to that of the 'Not' clause
-      if (statement.operand) {
-        if (
-          statement.operand.type === 'Equivalent' ||
-          (statement.operand.type === 'Equal' && statement.operand.localId)
-        ) {
+      if (statement.operand && statement.localId && statement.operand.localId) {
+        if (statement.operand.type === 'Equivalent' || statement.operand.type === 'Equal') {
           emptyResultClauses.push({
             lib: libraryName,
             aliasLocalId: statement.operand.localId,

--- a/test/unit/ClauseResultsHelper.test.ts
+++ b/test/unit/ClauseResultsHelper.test.ts
@@ -4,6 +4,20 @@ import { getJSONFixture } from './helpers/testHelpers';
 
 describe('ClauseResultsHelpers', () => {
   describe('findAllLocalIdsInStatementByName', () => {
+    test('finds localIds for a Equivalent comparison operator that is wrapped in a Not expression', () => {
+      // ELM from test/unit/fixtures/cql/NotEquivalent.cql
+      const libraryElm: ELM = getJSONFixture('elm/NotEquivalent.json');
+
+      const statementName = 'Not Equivalent Clause';
+      const localIds = ClauseResultsHelpers.findAllLocalIdsInStatementByName(libraryElm, statementName);
+
+      // For the fixture loaded for this test it is known that the localId for the Equivalent statement
+      // is 23 and the localId for the Not expression is 24 but we want the Equivalent clause to take
+      // the result of the Not expression
+      expect(localIds[23]).toBeDefined();
+      expect(localIds[23]).toEqual({ localId: '23', sourceLocalId: '24' });
+    });
+
     test('finds localIds for an ELM Binary Expression with a comparison operator with a literal', () => {
       // ELM from test/unit/fixtures/cql/comparisonWithLiteral.cql
       const libraryElm: ELM = getJSONFixture('elm/ComparisonWithLiteral.json');

--- a/test/unit/ClauseResultsHelper.test.ts
+++ b/test/unit/ClauseResultsHelper.test.ts
@@ -28,10 +28,10 @@ describe('ClauseResultsHelpers', () => {
       const localIds = ClauseResultsHelpers.findAllLocalIdsInStatementByName(libraryElm, statementName);
 
       // For the fixture loaded for this test it is known that the localId for the Equal statement
-      // is 100 and the localId for the Not expression is 5 but we want the Equal clause to take
+      // is 100 and the localId for the Not expression is 23 but we want the Equal clause to take
       // the result of the Not expression
       expect(localIds[100]).toBeDefined();
-      expect(localIds[100]).toEqual({ localId: '100', sourceLocalId: '5' });
+      expect(localIds[100]).toEqual({ localId: '100', sourceLocalId: '23' });
     });
 
     test('finds localIds for an ELM Binary Expression with a comparison operator with a literal', () => {

--- a/test/unit/ClauseResultsHelper.test.ts
+++ b/test/unit/ClauseResultsHelper.test.ts
@@ -4,7 +4,7 @@ import { getJSONFixture } from './helpers/testHelpers';
 
 describe('ClauseResultsHelpers', () => {
   describe('findAllLocalIdsInStatementByName', () => {
-    test('finds localIds for a Equivalent comparison operator that is wrapped in a Not expression', () => {
+    test('finds localIds for an Equivalent comparison operator that is wrapped in a Not expression', () => {
       // ELM from test/unit/fixtures/cql/NotEquivalent.cql
       const libraryElm: ELM = getJSONFixture('elm/NotEquivalent.json');
 
@@ -16,6 +16,22 @@ describe('ClauseResultsHelpers', () => {
       // the result of the Not expression
       expect(localIds[23]).toBeDefined();
       expect(localIds[23]).toEqual({ localId: '23', sourceLocalId: '24' });
+    });
+
+    test('finds localIds for an Equal comparison operator that is wrapped in a Not expression', () => {
+      // ELM from test/unit/fixtures/cql/NotEqual.cql, but modified so that Equal has a localId of "100"
+      // This will soon be the translator functionality, the Equal clause will get a localId (it currently
+      // does not get one)
+      const libraryElm: ELM = getJSONFixture('elm/NotEqual.json');
+
+      const statementName = 'Not Equal Clause';
+      const localIds = ClauseResultsHelpers.findAllLocalIdsInStatementByName(libraryElm, statementName);
+
+      // For the fixture loaded for this test it is known that the localId for the Equal statement
+      // is 100 and the localId for the Not expression is 5 but we want the Equal clause to take
+      // the result of the Not expression
+      expect(localIds[100]).toBeDefined();
+      expect(localIds[100]).toEqual({ localId: '100', sourceLocalId: '5' });
     });
 
     test('finds localIds for an ELM Binary Expression with a comparison operator with a literal', () => {

--- a/test/unit/fixtures/cql/NotEqual.cql
+++ b/test/unit/fixtures/cql/NotEqual.cql
@@ -3,8 +3,22 @@ library Test
 using FHIR version '4.0.1'
 
 include FHIRHelpers version '4.0.1'
+include MATGlobalCommonFunctions version '5.0.000' called Global
+
+codesystem "EXAMPLE": 'http://example.com'
+codesystem "EXAMPLE-2": 'http://example.com/2'
+codesystem "ConditionClinicalStatusCodes": 'http://terminology.hl7.org/CodeSystem/condition-clinical'
+
+valueset "test-vs": 'http://example.com/test-vs'
+
+code "Active": 'active' from "ConditionClinicalStatusCodes"
+code "Recurrence": 'recurrence' from "ConditionClinicalStatusCodes"
+code "Relapse": 'relapse' from "ConditionClinicalStatusCodes"
+
+concept "Condition Active": { "Active", "Recurrence", "Relapse" } display 'Active'
 
 context Patient
 
 define "Not Equal Clause":
-    true != false
+    [Condition: "test-vs"] C
+        where C.id != 'notId'

--- a/test/unit/fixtures/cql/NotEqual.cql
+++ b/test/unit/fixtures/cql/NotEqual.cql
@@ -1,0 +1,10 @@
+library Test
+
+using FHIR version '4.0.1'
+
+include FHIRHelpers version '4.0.1'
+
+context Patient
+
+define "Not Equal Clause":
+    true != false

--- a/test/unit/fixtures/cql/NotEquivalent.cql
+++ b/test/unit/fixtures/cql/NotEquivalent.cql
@@ -1,0 +1,24 @@
+library Test
+
+using FHIR version '4.0.1'
+
+include FHIRHelpers version '4.0.1'
+include MATGlobalCommonFunctions version '5.0.000' called Global
+
+codesystem "EXAMPLE": 'http://example.com'
+codesystem "EXAMPLE-2": 'http://example.com/2'
+codesystem "ConditionClinicalStatusCodes": 'http://terminology.hl7.org/CodeSystem/condition-clinical'
+
+valueset "test-vs": 'http://example.com/test-vs'
+
+code "Active": 'active' from "ConditionClinicalStatusCodes"
+code "Recurrence": 'recurrence' from "ConditionClinicalStatusCodes"
+code "Relapse": 'relapse' from "ConditionClinicalStatusCodes"
+
+concept "Condition Active": { "Active", "Recurrence", "Relapse" } display 'Active'
+
+context Patient
+
+define "Not Equivalent Clause":
+    [Condition: "test-vs"] C
+        where C.clinicalStatus !~ "Condition Active"

--- a/test/unit/fixtures/elm/NotEqual.json
+++ b/test/unit/fixtures/elm/NotEqual.json
@@ -7,9 +7,21 @@
         "type": "CqlToElmInfo"
       },
       {
+        "libraryId": "MATGlobalCommonFunctions",
+        "libraryVersion": "5.0.000",
+        "startLine": 277,
+        "startChar": 19,
+        "endLine": 277,
+        "endChar": 53,
+        "message": "Could not resolve membership operator for terminology target of the retrieve.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
         "type": "Annotation",
         "s": {
-          "r": "6",
+          "r": "25",
           "s": [
             {
               "value": ["", "library Test"]
@@ -94,38 +106,86 @@
               }
             }
           ]
-        }
-      ]
-    },
-    "contexts": {
-      "def": [
+        },
         {
-          "locator": "7:1-7:15",
-          "name": "Patient"
-        }
-      ]
-    },
-    "statements": {
-      "def": [
-        {
-          "locator": "7:1-7:15",
-          "name": "Patient",
-          "context": "Patient",
-          "expression": {
-            "type": "SingletonFrom",
-            "operand": {
-              "locator": "7:1-7:15",
-              "dataType": "{http://hl7.org/fhir}Patient",
-              "templateId": "http://hl7.org/fhir/StructureDefinition/Patient",
-              "type": "Retrieve"
+          "localId": "3",
+          "locator": "6:1-6:64",
+          "localIdentifier": "Global",
+          "path": "MATGlobalCommonFunctions",
+          "version": "5.0.000",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "3",
+                "s": [
+                  {
+                    "value": ["", "include "]
+                  },
+                  {
+                    "s": [
+                      {
+                        "value": ["MATGlobalCommonFunctions"]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [" version ", "'5.0.000'", " called ", "Global"]
+                  }
+                ]
+              }
             }
-          }
+          ]
+        }
+      ]
+    },
+    "codeSystems": {
+      "def": [
+        {
+          "localId": "4",
+          "locator": "8:1-8:42",
+          "name": "EXAMPLE",
+          "id": "http://example.com",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "4",
+                "s": [
+                  {
+                    "value": ["", "codesystem ", "\"EXAMPLE\"", ": ", "'http://example.com'"]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "localId": "5",
+          "locator": "9:1-9:46",
+          "name": "EXAMPLE-2",
+          "id": "http://example.com/2",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "5",
+                "s": [
+                  {
+                    "value": ["", "codesystem ", "\"EXAMPLE-2\"", ": ", "'http://example.com/2'"]
+                  }
+                ]
+              }
+            }
+          ]
         },
         {
           "localId": "6",
-          "locator": "9:1-10:17",
-          "name": "Not Equal Clause",
-          "context": "Patient",
+          "locator": "10:1-10:101",
+          "name": "ConditionClinicalStatusCodes",
+          "id": "http://terminology.hl7.org/CodeSystem/condition-clinical",
           "accessLevel": "Public",
           "annotation": [
             {
@@ -134,14 +194,349 @@
                 "r": "6",
                 "s": [
                   {
+                    "value": [
+                      "",
+                      "codesystem ",
+                      "\"ConditionClinicalStatusCodes\"",
+                      ": ",
+                      "'http://terminology.hl7.org/CodeSystem/condition-clinical'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "valueSets": {
+      "def": [
+        {
+          "localId": "7",
+          "locator": "12:1-12:48",
+          "name": "test-vs",
+          "id": "http://example.com/test-vs",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "7",
+                "s": [
+                  {
+                    "value": ["", "valueset ", "\"test-vs\"", ": ", "'http://example.com/test-vs'"]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "codes": {
+      "def": [
+        {
+          "localId": "9",
+          "locator": "14:1-14:59",
+          "name": "Active",
+          "id": "active",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "9",
+                "s": [
+                  {
+                    "value": ["", "code ", "\"Active\"", ": ", "'active'", " from "]
+                  },
+                  {
+                    "r": "8",
+                    "s": [
+                      {
+                        "value": ["\"ConditionClinicalStatusCodes\""]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": {
+            "localId": "8",
+            "locator": "14:30-14:59",
+            "name": "ConditionClinicalStatusCodes"
+          }
+        },
+        {
+          "localId": "11",
+          "locator": "15:1-15:67",
+          "name": "Recurrence",
+          "id": "recurrence",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "11",
+                "s": [
+                  {
+                    "value": ["", "code ", "\"Recurrence\"", ": ", "'recurrence'", " from "]
+                  },
+                  {
+                    "r": "10",
+                    "s": [
+                      {
+                        "value": ["\"ConditionClinicalStatusCodes\""]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": {
+            "localId": "10",
+            "locator": "15:38-15:67",
+            "name": "ConditionClinicalStatusCodes"
+          }
+        },
+        {
+          "localId": "13",
+          "locator": "16:1-16:61",
+          "name": "Relapse",
+          "id": "relapse",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "13",
+                "s": [
+                  {
+                    "value": ["", "code ", "\"Relapse\"", ": ", "'relapse'", " from "]
+                  },
+                  {
+                    "r": "12",
+                    "s": [
+                      {
+                        "value": ["\"ConditionClinicalStatusCodes\""]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": {
+            "localId": "12",
+            "locator": "16:32-16:61",
+            "name": "ConditionClinicalStatusCodes"
+          }
+        }
+      ]
+    },
+    "concepts": {
+      "def": [
+        {
+          "localId": "17",
+          "locator": "18:1-18:82",
+          "name": "Condition Active",
+          "display": "Active",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "17",
+                "s": [
+                  {
+                    "value": ["", "concept ", "\"Condition Active\"", ": { "]
+                  },
+                  {
+                    "r": "14",
+                    "s": [
+                      {
+                        "value": ["\"Active\""]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [", "]
+                  },
+                  {
+                    "r": "15",
+                    "s": [
+                      {
+                        "value": ["\"Recurrence\""]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [", "]
+                  },
+                  {
+                    "r": "16",
+                    "s": [
+                      {
+                        "value": ["\"Relapse\""]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [" } display ", "'Active'"]
+                  }
+                ]
+              }
+            }
+          ],
+          "code": [
+            {
+              "localId": "14",
+              "locator": "18:31-18:38",
+              "name": "Active"
+            },
+            {
+              "localId": "15",
+              "locator": "18:41-18:52",
+              "name": "Recurrence"
+            },
+            {
+              "localId": "16",
+              "locator": "18:55-18:63",
+              "name": "Relapse"
+            }
+          ]
+        }
+      ]
+    },
+    "contexts": {
+      "def": [
+        {
+          "locator": "20:1-20:15",
+          "name": "Patient"
+        }
+      ]
+    },
+    "statements": {
+      "def": [
+        {
+          "locator": "20:1-20:15",
+          "name": "Patient",
+          "context": "Patient",
+          "expression": {
+            "type": "SingletonFrom",
+            "operand": {
+              "locator": "20:1-20:15",
+              "dataType": "{http://hl7.org/fhir}Patient",
+              "templateId": "http://hl7.org/fhir/StructureDefinition/Patient",
+              "type": "Retrieve"
+            }
+          }
+        },
+        {
+          "localId": "25",
+          "locator": "22:1-24:29",
+          "name": "Not Equal Clause",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "25",
+                "s": [
+                  {
                     "value": ["", "define ", "\"Not Equal Clause\"", ":\n    "]
                   },
                   {
-                    "r": "5",
+                    "r": "24",
                     "s": [
                       {
-                        "r": "3",
-                        "value": ["true", " ", "!=", " ", "false"]
+                        "s": [
+                          {
+                            "r": "19",
+                            "s": [
+                              {
+                                "r": "18",
+                                "s": [
+                                  {
+                                    "r": "18",
+                                    "s": [
+                                      {
+                                        "value": ["[", "Condition", ": "]
+                                      },
+                                      {
+                                        "s": [
+                                          {
+                                            "value": ["\"test-vs\""]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": ["]"]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [" ", "C"]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": ["\n        "]
+                      },
+                      {
+                        "r": "23",
+                        "s": [
+                          {
+                            "value": ["where "]
+                          },
+                          {
+                            "r": "23",
+                            "s": [
+                              {
+                                "r": "21",
+                                "s": [
+                                  {
+                                    "r": "20",
+                                    "s": [
+                                      {
+                                        "value": ["C"]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": ["."]
+                                  },
+                                  {
+                                    "r": "21",
+                                    "s": [
+                                      {
+                                        "value": ["id"]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [" ", "!=", " "]
+                              },
+                              {
+                                "r": "22",
+                                "s": [
+                                  {
+                                    "value": ["'notId'"]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
                       }
                     ]
                   }
@@ -150,29 +545,64 @@
             }
           ],
           "expression": {
-            "localId": "5",
-            "locator": "10:5-10:17",
-            "type": "Not",
-            "operand": {
-              "locator": "10:5-10:17",
-              "localId": "100",
-              "type": "Equal",
-              "operand": [
-                {
-                  "localId": "3",
-                  "locator": "10:5-10:8",
-                  "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
-                  "value": "true",
-                  "type": "Literal"
-                },
-                {
-                  "localId": "4",
-                  "locator": "10:13-10:17",
-                  "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
-                  "value": "false",
-                  "type": "Literal"
+            "localId": "24",
+            "locator": "23:5-24:29",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "19",
+                "locator": "23:5-23:28",
+                "alias": "C",
+                "expression": {
+                  "localId": "18",
+                  "locator": "23:5-23:26",
+                  "dataType": "{http://hl7.org/fhir}Condition",
+                  "templateId": "http://hl7.org/fhir/StructureDefinition/Condition",
+                  "codeProperty": "code",
+                  "codeComparator": "in",
+                  "type": "Retrieve",
+                  "codes": {
+                    "locator": "23:17-23:25",
+                    "name": "test-vs",
+                    "preserve": true,
+                    "type": "ValueSetRef"
+                  }
                 }
-              ]
+              }
+            ],
+            "relationship": [],
+            "where": {
+              "localId": "23",
+              "locator": "24:9-24:29",
+              "type": "Not",
+              "operand": {
+                "locator": "24:15-24:29",
+                "localId": "100",
+                "type": "Equal",
+                "operand": [
+                  {
+                    "name": "ToString",
+                    "libraryName": "FHIRHelpers",
+                    "type": "FunctionRef",
+                    "operand": [
+                      {
+                        "localId": "21",
+                        "locator": "24:15-24:18",
+                        "path": "id",
+                        "scope": "C",
+                        "type": "Property"
+                      }
+                    ]
+                  },
+                  {
+                    "localId": "22",
+                    "locator": "24:23-24:29",
+                    "valueType": "{urn:hl7-org:elm-types:r1}String",
+                    "value": "notId",
+                    "type": "Literal"
+                  }
+                ]
+              }
             }
           }
         }

--- a/test/unit/fixtures/elm/NotEqual.json
+++ b/test/unit/fixtures/elm/NotEqual.json
@@ -1,0 +1,182 @@
+{
+  "library": {
+    "annotation": [
+      {
+        "translatorVersion": "2.11.0",
+        "translatorOptions": "EnableAnnotations,EnableLocators",
+        "type": "CqlToElmInfo"
+      },
+      {
+        "type": "Annotation",
+        "s": {
+          "r": "6",
+          "s": [
+            {
+              "value": ["", "library Test"]
+            }
+          ]
+        }
+      }
+    ],
+    "identifier": {
+      "id": "Test"
+    },
+    "schemaIdentifier": {
+      "id": "urn:hl7-org:elm",
+      "version": "r1"
+    },
+    "usings": {
+      "def": [
+        {
+          "localIdentifier": "System",
+          "uri": "urn:hl7-org:elm-types:r1"
+        },
+        {
+          "localId": "1",
+          "locator": "3:1-3:26",
+          "localIdentifier": "FHIR",
+          "uri": "http://hl7.org/fhir",
+          "version": "4.0.1",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "1",
+                "s": [
+                  {
+                    "value": ["", "using "]
+                  },
+                  {
+                    "s": [
+                      {
+                        "value": ["FHIR"]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [" version ", "'4.0.1'"]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "includes": {
+      "def": [
+        {
+          "localId": "2",
+          "locator": "5:1-5:35",
+          "localIdentifier": "FHIRHelpers",
+          "path": "FHIRHelpers",
+          "version": "4.0.1",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "2",
+                "s": [
+                  {
+                    "value": ["", "include "]
+                  },
+                  {
+                    "s": [
+                      {
+                        "value": ["FHIRHelpers"]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [" version ", "'4.0.1'"]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "contexts": {
+      "def": [
+        {
+          "locator": "7:1-7:15",
+          "name": "Patient"
+        }
+      ]
+    },
+    "statements": {
+      "def": [
+        {
+          "locator": "7:1-7:15",
+          "name": "Patient",
+          "context": "Patient",
+          "expression": {
+            "type": "SingletonFrom",
+            "operand": {
+              "locator": "7:1-7:15",
+              "dataType": "{http://hl7.org/fhir}Patient",
+              "templateId": "http://hl7.org/fhir/StructureDefinition/Patient",
+              "type": "Retrieve"
+            }
+          }
+        },
+        {
+          "localId": "6",
+          "locator": "9:1-10:17",
+          "name": "Not Equal Clause",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "6",
+                "s": [
+                  {
+                    "value": ["", "define ", "\"Not Equal Clause\"", ":\n    "]
+                  },
+                  {
+                    "r": "5",
+                    "s": [
+                      {
+                        "r": "3",
+                        "value": ["true", " ", "!=", " ", "false"]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "5",
+            "locator": "10:5-10:17",
+            "type": "Not",
+            "operand": {
+              "locator": "10:5-10:17",
+              "localId": "100",
+              "type": "Equal",
+              "operand": [
+                {
+                  "localId": "3",
+                  "locator": "10:5-10:8",
+                  "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+                  "value": "true",
+                  "type": "Literal"
+                },
+                {
+                  "localId": "4",
+                  "locator": "10:13-10:17",
+                  "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+                  "value": "false",
+                  "type": "Literal"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/test/unit/fixtures/elm/NotEquivalent.json
+++ b/test/unit/fixtures/elm/NotEquivalent.json
@@ -1,0 +1,611 @@
+{
+  "library": {
+    "annotation": [
+      {
+        "translatorVersion": "2.11.0",
+        "translatorOptions": "EnableAnnotations,EnableLocators",
+        "type": "CqlToElmInfo"
+      },
+      {
+        "libraryId": "MATGlobalCommonFunctions",
+        "libraryVersion": "5.0.000",
+        "startLine": 277,
+        "startChar": 19,
+        "endLine": 277,
+        "endChar": 53,
+        "message": "Could not resolve membership operator for terminology target of the retrieve.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "type": "Annotation",
+        "s": {
+          "r": "26",
+          "s": [
+            {
+              "value": ["", "library Test"]
+            }
+          ]
+        }
+      }
+    ],
+    "identifier": {
+      "id": "Test"
+    },
+    "schemaIdentifier": {
+      "id": "urn:hl7-org:elm",
+      "version": "r1"
+    },
+    "usings": {
+      "def": [
+        {
+          "localIdentifier": "System",
+          "uri": "urn:hl7-org:elm-types:r1"
+        },
+        {
+          "localId": "1",
+          "locator": "3:1-3:26",
+          "localIdentifier": "FHIR",
+          "uri": "http://hl7.org/fhir",
+          "version": "4.0.1",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "1",
+                "s": [
+                  {
+                    "value": ["", "using "]
+                  },
+                  {
+                    "s": [
+                      {
+                        "value": ["FHIR"]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [" version ", "'4.0.1'"]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "includes": {
+      "def": [
+        {
+          "localId": "2",
+          "locator": "5:1-5:35",
+          "localIdentifier": "FHIRHelpers",
+          "path": "FHIRHelpers",
+          "version": "4.0.1",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "2",
+                "s": [
+                  {
+                    "value": ["", "include "]
+                  },
+                  {
+                    "s": [
+                      {
+                        "value": ["FHIRHelpers"]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [" version ", "'4.0.1'"]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "localId": "3",
+          "locator": "6:1-6:64",
+          "localIdentifier": "Global",
+          "path": "MATGlobalCommonFunctions",
+          "version": "5.0.000",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "3",
+                "s": [
+                  {
+                    "value": ["", "include "]
+                  },
+                  {
+                    "s": [
+                      {
+                        "value": ["MATGlobalCommonFunctions"]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [" version ", "'5.0.000'", " called ", "Global"]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "codeSystems": {
+      "def": [
+        {
+          "localId": "4",
+          "locator": "8:1-8:42",
+          "name": "EXAMPLE",
+          "id": "http://example.com",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "4",
+                "s": [
+                  {
+                    "value": ["", "codesystem ", "\"EXAMPLE\"", ": ", "'http://example.com'"]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "localId": "5",
+          "locator": "9:1-9:46",
+          "name": "EXAMPLE-2",
+          "id": "http://example.com/2",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "5",
+                "s": [
+                  {
+                    "value": ["", "codesystem ", "\"EXAMPLE-2\"", ": ", "'http://example.com/2'"]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "localId": "6",
+          "locator": "10:1-10:101",
+          "name": "ConditionClinicalStatusCodes",
+          "id": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "6",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "codesystem ",
+                      "\"ConditionClinicalStatusCodes\"",
+                      ": ",
+                      "'http://terminology.hl7.org/CodeSystem/condition-clinical'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "valueSets": {
+      "def": [
+        {
+          "localId": "7",
+          "locator": "12:1-12:48",
+          "name": "test-vs",
+          "id": "http://example.com/test-vs",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "7",
+                "s": [
+                  {
+                    "value": ["", "valueset ", "\"test-vs\"", ": ", "'http://example.com/test-vs'"]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "codes": {
+      "def": [
+        {
+          "localId": "9",
+          "locator": "14:1-14:59",
+          "name": "Active",
+          "id": "active",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "9",
+                "s": [
+                  {
+                    "value": ["", "code ", "\"Active\"", ": ", "'active'", " from "]
+                  },
+                  {
+                    "r": "8",
+                    "s": [
+                      {
+                        "value": ["\"ConditionClinicalStatusCodes\""]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": {
+            "localId": "8",
+            "locator": "14:30-14:59",
+            "name": "ConditionClinicalStatusCodes"
+          }
+        },
+        {
+          "localId": "11",
+          "locator": "15:1-15:67",
+          "name": "Recurrence",
+          "id": "recurrence",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "11",
+                "s": [
+                  {
+                    "value": ["", "code ", "\"Recurrence\"", ": ", "'recurrence'", " from "]
+                  },
+                  {
+                    "r": "10",
+                    "s": [
+                      {
+                        "value": ["\"ConditionClinicalStatusCodes\""]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": {
+            "localId": "10",
+            "locator": "15:38-15:67",
+            "name": "ConditionClinicalStatusCodes"
+          }
+        },
+        {
+          "localId": "13",
+          "locator": "16:1-16:61",
+          "name": "Relapse",
+          "id": "relapse",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "13",
+                "s": [
+                  {
+                    "value": ["", "code ", "\"Relapse\"", ": ", "'relapse'", " from "]
+                  },
+                  {
+                    "r": "12",
+                    "s": [
+                      {
+                        "value": ["\"ConditionClinicalStatusCodes\""]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": {
+            "localId": "12",
+            "locator": "16:32-16:61",
+            "name": "ConditionClinicalStatusCodes"
+          }
+        }
+      ]
+    },
+    "concepts": {
+      "def": [
+        {
+          "localId": "17",
+          "locator": "18:1-18:82",
+          "name": "Condition Active",
+          "display": "Active",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "17",
+                "s": [
+                  {
+                    "value": ["", "concept ", "\"Condition Active\"", ": { "]
+                  },
+                  {
+                    "r": "14",
+                    "s": [
+                      {
+                        "value": ["\"Active\""]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [", "]
+                  },
+                  {
+                    "r": "15",
+                    "s": [
+                      {
+                        "value": ["\"Recurrence\""]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [", "]
+                  },
+                  {
+                    "r": "16",
+                    "s": [
+                      {
+                        "value": ["\"Relapse\""]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [" } display ", "'Active'"]
+                  }
+                ]
+              }
+            }
+          ],
+          "code": [
+            {
+              "localId": "14",
+              "locator": "18:31-18:38",
+              "name": "Active"
+            },
+            {
+              "localId": "15",
+              "locator": "18:41-18:52",
+              "name": "Recurrence"
+            },
+            {
+              "localId": "16",
+              "locator": "18:55-18:63",
+              "name": "Relapse"
+            }
+          ]
+        }
+      ]
+    },
+    "contexts": {
+      "def": [
+        {
+          "locator": "20:1-20:15",
+          "name": "Patient"
+        }
+      ]
+    },
+    "statements": {
+      "def": [
+        {
+          "locator": "20:1-20:15",
+          "name": "Patient",
+          "context": "Patient",
+          "expression": {
+            "type": "SingletonFrom",
+            "operand": {
+              "locator": "20:1-20:15",
+              "dataType": "{http://hl7.org/fhir}Patient",
+              "templateId": "http://hl7.org/fhir/StructureDefinition/Patient",
+              "type": "Retrieve"
+            }
+          }
+        },
+        {
+          "localId": "26",
+          "locator": "22:1-24:52",
+          "name": "Not Equivalent Clause",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "26",
+                "s": [
+                  {
+                    "value": ["", "define ", "\"Not Equivalent Clause\"", ":\n    "]
+                  },
+                  {
+                    "r": "25",
+                    "s": [
+                      {
+                        "s": [
+                          {
+                            "r": "19",
+                            "s": [
+                              {
+                                "r": "18",
+                                "s": [
+                                  {
+                                    "r": "18",
+                                    "s": [
+                                      {
+                                        "value": ["[", "Condition", ": "]
+                                      },
+                                      {
+                                        "s": [
+                                          {
+                                            "value": ["\"test-vs\""]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": ["]"]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [" ", "C"]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": ["\n        "]
+                      },
+                      {
+                        "r": "24",
+                        "s": [
+                          {
+                            "value": ["where "]
+                          },
+                          {
+                            "r": "24",
+                            "s": [
+                              {
+                                "r": "21",
+                                "s": [
+                                  {
+                                    "r": "20",
+                                    "s": [
+                                      {
+                                        "value": ["C"]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": ["."]
+                                  },
+                                  {
+                                    "r": "21",
+                                    "s": [
+                                      {
+                                        "value": ["clinicalStatus"]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [" ", "!~", " "]
+                              },
+                              {
+                                "r": "22",
+                                "s": [
+                                  {
+                                    "value": ["\"Condition Active\""]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "25",
+            "locator": "23:5-24:52",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "19",
+                "locator": "23:5-23:28",
+                "alias": "C",
+                "expression": {
+                  "localId": "18",
+                  "locator": "23:5-23:26",
+                  "dataType": "{http://hl7.org/fhir}Condition",
+                  "templateId": "http://hl7.org/fhir/StructureDefinition/Condition",
+                  "codeProperty": "code",
+                  "codeComparator": "in",
+                  "type": "Retrieve",
+                  "codes": {
+                    "locator": "23:17-23:25",
+                    "name": "test-vs",
+                    "preserve": true,
+                    "type": "ValueSetRef"
+                  }
+                }
+              }
+            ],
+            "relationship": [],
+            "where": {
+              "localId": "24",
+              "locator": "24:9-24:52",
+              "type": "Not",
+              "operand": {
+                "localId": "23",
+                "locator": "24:15-24:52",
+                "type": "Equivalent",
+                "operand": [
+                  {
+                    "name": "ToConcept",
+                    "libraryName": "FHIRHelpers",
+                    "type": "FunctionRef",
+                    "operand": [
+                      {
+                        "localId": "21",
+                        "locator": "24:15-24:30",
+                        "path": "clinicalStatus",
+                        "scope": "C",
+                        "type": "Property"
+                      }
+                    ]
+                  },
+                  {
+                    "localId": "22",
+                    "locator": "24:35-24:52",
+                    "name": "Condition Active",
+                    "type": "ConceptRef"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
# Summary
#287 contains CMS69 which includes a `!~` (not equivalent) operation in the CQL that has some undesirable coverage calculation behavior due to the way Not Equivalent and Not Equal operations are translated from CQL to ELM json. This PR provides a workaround so that Not Equivalent and Not Equal clauses behave like Equal and Equivalent clauses. 

## New behavior
Before, in order to reach 100% clause coverage with CMS69, test cases where `BMIEncounter.class` WAS equivalent to 'virtual' AND where `BMIEncounter.class` was NOT equivalent to 'virtual' needed to be provided. This behavior did not match the clause coverage highlighting where only the not equivalent test case was needed for the clause to be highlighted as covered. Now, the coverage calculation matches the coverage highlighting. For CMS69 to reach 100% clause coverage, ONLY a test case where `BMIEncounter.class` is NOT equivalent (`!~`) to 'virtual' is needed. 

## Code changes
- `ClauseResultsHelpers.ts` - a workaround was added to for this specific case in `findAllLocalIdsInStatement` so that the result of the equal or equivalent is now the result of the not. 

# Testing guidance
- `npm run check`
- `npm run cli -- detailed -m <path-to-CMS69> --patients-directory <path-to-CMS69-patients-directory> --trust-meta-profile true --debug` on the master branch with the test cases provided in the should result in 96% clause coverage.
- Switch to this branch and run the same command. This should result in 96.2% clause coverage, showing that the `!~` clause is now included in the calculation.
- Another good way to test this would to be to `npm link` this branch to fqm-testify to play around with different test cases.