### PR TITLE
Translator 3.7.1 fixes

### DIFF
--- a/src/helpers/ClauseResultsHelpers.ts
+++ b/src/helpers/ClauseResultsHelpers.ts
@@ -74,6 +74,12 @@ export function findAllLocalIdsInStatement(
   emptyResultClauses: any[],
   parentNode: any | null
 ): any {
+  // Stop recursing if this node happens to be any TypeSpecifier. We do not want to collect localIds for these clauses
+  // as they are not executed and will negatively affect clause coverage if captured here. ChoiceTypeSpecifiers do not
+  // identify their type and instead put [] at the `type` attribute which is a deprecated field.
+  if (statement?.type && (Array.isArray(statement.type) || statement.type.endsWith('TypeSpecifier'))) {
+    return localIds;
+  }
   // looking at the key and value of everything on this object or array
   for (const k in statement) {
     let alId;

--- a/src/helpers/ClauseResultsHelpers.ts
+++ b/src/helpers/ClauseResultsHelpers.ts
@@ -100,8 +100,14 @@ export function findAllLocalIdsInStatement(
       if (statement.expression != null && statement.expression.localId != null) {
         // Keep track of the localId of the expression that the alias references
         aliasMap[v] = statement.expression.localId;
-        // Determine the localId in the elm_annotation for this alias.
-        alId = (parseInt(statement.expression.localId, 10) + 1).toString();
+        // Determine the localId for this alias.
+        if (statement.localId) {
+          alId = statement.localId;
+        } else {
+          // Older translator versions created an elm_annotation localId that was not always in the elm. This was a
+          // single increment up from the expression that defines the alias.
+          alId = (parseInt(statement.expression.localId, 10) + 1).toString();
+        }
         emptyResultClauses.push({ lib: libraryName, aliasLocalId: alId, expressionLocalId: aliasMap[v] });
       }
     } else if (k === 'scope') {


### PR DESCRIPTION
# Summary
The cql-to-elm translator was updated recently to version 3.7.1. The major change in this version is that there are now localIds on every statement in the ELM. While this is a good change, it requires us to do some updating in our clause coverage calculation due to workarounds and handling of specific cases that were present in previous translator versions that are now changed. 

## New behavior
Specifically, this PR adds handling in the `findAllLocalIdsInStatement` function for any TypeSpecifiers and aliases. Hoss detailed in comments in the code what exactly is being changed.

## Code changes
- `src/helpers/ClauseResultsHelpers.ts` - handling in `findAllLocalIdsInStatement` that reflects changes made in the translator

# Testing guidance
- `npm run check`
- We were sent two measure bundles for MAT6725- one translated using the old translator version and the other using the new translator version. Run detailed results with the test cases they provided with the `--debug` flag and inspect the clause coverage output. The percentage BEFORE the translator changes on the master branch of fqm-execution should be 99.7%, the percentage AFTER the translator changes on the master branch of fqm-execution should be 57.9% and the percentage AFTER the translator changes on this branch should be 99.5%. Note that it is not back to the previous coverage because there are still issues that we are investigating.
- Think of other ways we can test this. Using Dylan's updates to the `cql-translation-service` (https://github.com/cqframework/cql-translation-service/pull/40), I was able to run the translation service on his branch and retranslate some of the CQL in the unit tests (`test/unit/elm/queries`) and reran the unit tests with no issues. I also did this for the integration tests. 
- Also using Dylan's `cql-translation-service` branch and [ecqm-bundler](https://github.com/projecttacoma/ecqm-bundler), I was able to retranslate CMS165 using the newest translator version. This branch was able to get coverage back to the same as it was pre translator update. 
