### PR TITLE
Make highlighting backwards compatible with older translator versions

### DIFF
--- a/src/helpers/ClauseResultsHelpers.ts
+++ b/src/helpers/ClauseResultsHelpers.ts
@@ -102,7 +102,14 @@ export function findAllLocalIdsInStatement(
         aliasMap[v] = statement.expression.localId;
         // Determine the localId for this alias.
         if (statement.localId) {
-          alId = statement.localId;
+          // Older translator versions require with statements to use the statement.expression.localId + 1 as the alias Id
+          // even if the statement already has a localId. There is not a clear mapping for alias with statements in the new
+          // translator, so they will go un highlighted but this will not affect coverage calculation
+          if (statement.type === 'With') {
+            alId = (parseInt(statement.expression.localId, 10) + 1).toString();
+          } else {
+            alId = statement.localId;
+          }
         } else {
           // Older translator versions created an elm_annotation localId that was not always in the elm. This was a
           // single increment up from the expression that defines the alias.


### PR DESCRIPTION
# Summary
Our most recent [PR](https://github.com/projecttacoma/fqm-execution/pull/296) addresses updates to clause coverage calculation and highlighting that were necessary to reflect the functionality of the `3.7.1` version of the cql to elm translator. Due to the nature of changes to localId assignment in the translator versions, this broke just the highlighting of some aliases (no affect to clause coverage calculation) for measures that use older translator versions. This PR makes sure that highlighting is backwards compatible with the older translator version (there should be no change to highlighting). 

## New behavior
I have a comment in the code that details these translator version quirks, but essentially we can't always use the `statement.localId` if it exists for measures that were translated using the other translator. I was able to narrow this down to just `With` statements. 

## Code changes
- `ClauseResultsHelpers.ts` - ONLY use `statement.localId` if it is NOT a with statement. In the older translator version, with statements require the use of the `statement.expression.localId + 1`. In the new translator version, you will see that these aliases are not highlighted. This is because there is no longer a clear mapping to the localId in the ELM annotation that we want (pending translator fix).

# Testing guidance
- On the `master` branch, you will see that the MAT6725 Good (pre translator change) bundle and test cases produce 99.7% clause coverage highlighting HOWEVER there are aliases that are unhiglighted. On the `1.3.3` version of `fqm-execution`, MAT6725 Good (pre translator change) bundle and test cases produce 99.7% clause coverage highlighting with no highlighting issues. This is the desired behavior. On this branch (`alias-highlighting-fix`), the MAT6725 Good (pre translator change) bundle and test cases should produce the SAME results. as `1.3.3` (99.7% coverage, no highlighting issues).
- On the `master` branch, you will see that the MAT6725 Bad (post translator change) bundle and test cases produce 99.5% clause coverage highlighting and there are aliases that are un highlighted. This is to be expected (need translator fix for this). On this branch, we want the same results.
- Overall, the idea of this PR is that we want to keep the changes that we just merged so that fqm-execution is compatible with the new translator version but we also want results to be the same for measures that use the older translator. The best way to test this is to ensure that the new translator bundles have the fixes but also test a bunch of our older measures and make sure that their results are the same as results on fqm-execution version `1.3.3`. 