### PR TITLE
Uncoverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -933,6 +933,8 @@ have a blue background and dashed underline in the highlighted HTML, indicating 
 
 The highlighted HTML also provides an approximate percentage for what percentage of the measure logic is covered by the patients that were passed in to execution.
 
+This option, `calculateClauseCoverage`, defaults to enabled. When running the CLI in `--debug` mode this option will be enabled and output to the debug directory.
+
 ![Screenshot of Highlighted Clause Coverage HTML](./static/coverage-highlighting-example.png)
 
 HTML strings are returned for each group defined in the `Measure` resource in the lookup object, `groupClauseCoverageHTML`, which maps `group ID -> HTML string`
@@ -959,6 +961,8 @@ const { results, groupClauseCoverageHTML } = await Calculator.calculate(measureB
 
 `fqm-execution` can also generate highlighted HTML that indicate which pieces of the measure logic did NOT have a "truthy" value during calculation. This is the complement to coverage. Clauses that are not covered will be highlighted red.
 
+This option, `calculateClauseUncoverage`, defaults to disabled. When running the CLI in `--debug` mode this option will be enabled and output to the debug directory.
+
 HTML strings are returned for each group defined in the `Measure` resource in the lookup object,`groupClauseUncoverageHTML`, which is structured similarly to Group Clause Coverage.
 
 ```typescript
@@ -982,6 +986,8 @@ const { results, groupClauseUncoverageHTML } = await Calculator.calculate(measur
 ### Coverage Details
 
 Details on clause coverage can also be returned. This includes a count of how many clauses there are, how many are covered and uncovered, and information about which clauses are uncovered.
+
+This option, `calculateCoverageDetails`, defaults to disabled. When running the CLI in `--debug` mode this option will be enabled and output to the debug directory.
 
 This information is returned for each group defined in the `Measure` resource in the lookup object,`groupClauseCoverageDetails`, which maps `group ID -> coverageDetails`. See example below for structure of this object.
 

--- a/README.md
+++ b/README.md
@@ -971,7 +971,7 @@ const { results, groupClauseUncoverageHTML } = await Calculator.calculate(measur
 // groupClauseUncoverageHTML
 /*      ^?
         {
-          'population-group-1': '<div><h2> population-group-1 Clause Uncoverage: X clauses</h2> ...'
+          'population-group-1': '<div><h2> population-group-1 Clause Uncoverage: X of Y clauses</h2> ...'
           ...
         }
 

--- a/README.md
+++ b/README.md
@@ -935,7 +935,7 @@ The highlighted HTML also provides an approximate percentage for what percentage
 
 ![Screenshot of Highlighted Clause Coverage HTML](./static/coverage-highlighting-example.png)
 
-HTML strings are returned for each group defined in the `Measure` resource as a lookup object `groupClauseCoverageHTML` which maps `group ID -> HTML string`
+HTML strings are returned for each group defined in the `Measure` resource in the lookup object, `groupClauseCoverageHTML`, which maps `group ID -> HTML string`
 
 ```typescript
 import { Calculator } from 'fqm-execution';
@@ -957,9 +957,9 @@ const { results, groupClauseCoverageHTML } = await Calculator.calculate(measureB
 
 ### Uncoverage Highlighting
 
-`fqm-execution` can also generate highlighted HTML that indicate which pieces of the measure logic which did NOT have a "truthy" value during calculation. This is the complement to coverage. Clauses that are not covered will be highlighted red.
+`fqm-execution` can also generate highlighted HTML that indicate which pieces of the measure logic did NOT have a "truthy" value during calculation. This is the complement to coverage. Clauses that are not covered will be highlighted red.
 
-HTML strings are returned for each group defined in the `Measure` resource as a lookup object `groupClauseUncoverageHTML` similarly to Group Clause Coverage.
+HTML strings are returned for each group defined in the `Measure` resource in the lookup object,`groupClauseUncoverageHTML`, which is structured similarly to Group Clause Coverage.
 
 ```typescript
 import { Calculator } from 'fqm-execution';
@@ -983,7 +983,7 @@ const { results, groupClauseUncoverageHTML } = await Calculator.calculate(measur
 
 Details on clause coverage can also be returned. This includes a count of how many clauses there are, how many are covered and uncovered, and information about which clauses are uncovered.
 
-This information is returned for each group defined in the `Measure` resource as a lookup object `groupClauseCoverageDetails` similarly to Group Clause Coverage.
+This information is returned for each group defined in the `Measure` resource in the lookup object,`groupClauseCoverageDetails`, which maps `group ID -> coverageDetails`. See example below for structure of this object.
 
 ```typescript
 import { Calculator } from 'fqm-execution';

--- a/README.md
+++ b/README.md
@@ -450,7 +450,8 @@ The options that we support for calculation are as follows:
 
 - `[buildStatementLevelHTML]`<[boolean](#calculation-options)>: Builds and returns HTML at the statement level (default: `false`)
 - `[calculateClauseCoverage]`<[boolean](#calculation-options)>: Include HTML structure with clause coverage highlighting (default: `true`)
-- `[calculateClauseUncoverage]`<[boolean](#calculation-options)>: Include HTML structure with clause coverage highlighting (default: `true`)
+- `[calculateClauseUncoverage]`<[boolean](#calculation-options)>: Include HTML structure with clause uncoverage highlighting (default: `false`)
+- `[calculateCoverageDetails]`<[boolean](#calculation-options)>: Include details on logic clause coverage. (default: `false`)
 - `[calculateHTML]`<[boolean](#calculation-options)>: Include HTML structure for highlighting (default: `true`)
 - `[calculateSDEs]`<[boolean](#calculation-options)>: Include Supplemental Data Elements (SDEs) in calculation (default: `true`)
 - `[clearElmJsonsCache]`<[boolean](#calculation-options)>: If `true`, clears ELM JSON cache before running calculation (default: `false`)
@@ -975,6 +976,40 @@ const { results, groupClauseUncoverageHTML } = await Calculator.calculate(measur
         }
 
 
+*/
+```
+
+### Coverage Details
+
+Details on clause coverage can also be returned. This includes a count of how many clauses there are, how many are covered and uncovered, and information about which clauses are uncovered.
+
+This information is returned for each group defined in the `Measure` resource as a lookup object `groupClauseCoverageDetails` similarly to Group Clause Coverage.
+
+```typescript
+import { Calculator } from 'fqm-execution';
+
+const { results, groupClauseCoverageDetails } = await Calculator.calculate(measureBundle, patientBundles, {
+  calculateCoverageDetails: true /* false by default */
+});
+
+// groupClauseCoverageDetails
+/*      ^?
+        {
+          "population-group-1": {
+            "totalClauseCount": 333,
+            "coveredClauseCount": 330,
+            "uncoveredClauseCount": 3,
+            "uncoveredClauses": [
+              {
+                "localId": "97",
+                "libraryName": "MAT6725TestingMeasureCoverage",
+                "statementName": "Has Medical or Patient Reason for Not Ordering ACEI or ARB or ARNI"
+              },
+              ...
+            ]
+          }
+          ...
+        }
 */
 ```
 

--- a/README.md
+++ b/README.md
@@ -450,6 +450,7 @@ The options that we support for calculation are as follows:
 
 - `[buildStatementLevelHTML]`<[boolean](#calculation-options)>: Builds and returns HTML at the statement level (default: `false`)
 - `[calculateClauseCoverage]`<[boolean](#calculation-options)>: Include HTML structure with clause coverage highlighting (default: `true`)
+- `[calculateClauseUncoverage]`<[boolean](#calculation-options)>: Include HTML structure with clause coverage highlighting (default: `true`)
 - `[calculateHTML]`<[boolean](#calculation-options)>: Include HTML structure for highlighting (default: `true`)
 - `[calculateSDEs]`<[boolean](#calculation-options)>: Include Supplemental Data Elements (SDEs) in calculation (default: `true`)
 - `[clearElmJsonsCache]`<[boolean](#calculation-options)>: If `true`, clears ELM JSON cache before running calculation (default: `false`)
@@ -946,6 +947,30 @@ const { results, groupClauseCoverageHTML } = await Calculator.calculate(measureB
 /*      ^?
         {
           'population-group-1': '<div><h2> population-group-1 Clause Coverage: X%</h2> ...'
+          ...
+        }
+
+
+*/
+```
+
+### Uncoverage Highlighting
+
+`fqm-execution` can also generate highlighted HTML that indicate which pieces of the measure logic which did NOT have a "truthy" value during calculation. This is the complement to coverage. Clauses that are not covered will be highlighted red.
+
+HTML strings are returned for each group defined in the `Measure` resource as a lookup object `groupClauseUncoverageHTML` similarly to Group Clause Coverage.
+
+```typescript
+import { Calculator } from 'fqm-execution';
+
+const { results, groupClauseUncoverageHTML } = await Calculator.calculate(measureBundle, patientBundles, {
+  calculateClauseUncoverage: true /* false by default */
+});
+
+// groupClauseUncoverageHTML
+/*      ^?
+        {
+          'population-group-1': '<div><h2> population-group-1 Clause Uncoverage: X clauses</h2> ...'
           ...
         }
 

--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -41,6 +41,7 @@ import { clearElmInfoCache } from '../helpers/elm/ELMInfoCache';
 import _, { omit } from 'lodash';
 import { ELM } from '../types/ELMTypes';
 import { getReportBuilder } from '../helpers/ReportBuilderFactory';
+import { option } from 'commander';
 
 /**
  * Calculate measure against a set of patients. Returning detailed results for each patient and population group.
@@ -271,7 +272,7 @@ export async function calculate<T extends CalculationOptions>(
         }
       });
 
-      // pull out
+      // pull out uncoverage html
       if (options.calculateClauseUncoverage && coverage.uncoverage) {
         groupClauseUncoverageHTML = coverage.uncoverage;
         if (debugObject && options.enableDebugOutput) {
@@ -295,6 +296,11 @@ export async function calculate<T extends CalculationOptions>(
           name: 'overall-clause-coverage.html',
           html: overallClauseCoverageHTML
         });
+      }
+
+      // grab coverage details
+      if (debugObject && options.enableDebugOutput && options.calculateCoverageDetails) {
+        debugObject.coverageDetails = coverage.details;
       }
     }
   }

--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -14,7 +14,8 @@ import {
   OneOrManyBundles,
   OneOrMultiPatient,
   PopulationGroupResult,
-  DetailedPopulationGroupResult
+  DetailedPopulationGroupResult,
+  ClauseCoverageDetails
 } from '../types/Calculator';
 import { PopulationType, MeasureScoreType, ImprovementNotation } from '../types/Enums';
 import * as Execution from '../execution/Execution';
@@ -71,6 +72,7 @@ export async function calculate<T extends CalculationOptions>(
   options.calculateSDEs = options.calculateSDEs ?? true;
   options.calculateClauseCoverage = options.calculateClauseCoverage ?? true;
   options.calculateClauseUncoverage = options.calculateClauseUncoverage ?? false;
+  options.calculateCoverageDetails = options.calculateCoverageDetails ?? false;
   options.disableHTMLOrdering = options.disableHTMLOrdering ?? false;
   options.buildStatementLevelHTML = options.buildStatementLevelHTML ?? false;
 
@@ -89,6 +91,7 @@ export async function calculate<T extends CalculationOptions>(
   let overallClauseCoverageHTML: string | undefined;
   let groupClauseCoverageHTML: Record<string, string> | undefined;
   let groupClauseUncoverageHTML: Record<string, string> | undefined;
+  let groupClauseCoverageDetails: Record<string, ClauseCoverageDetails> | undefined;
 
   let newValueSetCache: fhir4.ValueSet[] | undefined = [...valueSetCache];
   const allELM: ELM[] = [];
@@ -298,8 +301,11 @@ export async function calculate<T extends CalculationOptions>(
       }
 
       // grab coverage details
-      if (debugObject && options.enableDebugOutput && options.calculateCoverageDetails) {
-        debugObject.coverageDetails = coverage.details;
+      if (options.calculateCoverageDetails && coverage.details) {
+        groupClauseCoverageDetails = coverage.details;
+        if (debugObject && options.enableDebugOutput) {
+          debugObject.coverageDetails = groupClauseCoverageDetails;
+        }
       }
     }
   }
@@ -337,7 +343,8 @@ export async function calculate<T extends CalculationOptions>(
       }),
     ...(overallClauseCoverageHTML && { coverageHTML: overallClauseCoverageHTML }),
     ...(groupClauseCoverageHTML && { groupClauseCoverageHTML: groupClauseCoverageHTML }),
-    ...(groupClauseUncoverageHTML && { groupClauseUncoverageHTML: groupClauseUncoverageHTML })
+    ...(groupClauseUncoverageHTML && { groupClauseUncoverageHTML: groupClauseUncoverageHTML }),
+    ...(groupClauseCoverageDetails && { groupClauseCoverageDetails: groupClauseCoverageDetails })
   };
 }
 

--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -70,6 +70,7 @@ export async function calculate<T extends CalculationOptions>(
   options.calculateHTML = options.calculateHTML ?? true;
   options.calculateSDEs = options.calculateSDEs ?? true;
   options.calculateClauseCoverage = options.calculateClauseCoverage ?? true;
+  options.calculateClauseUncoverage = options.calculateClauseUncoverage ?? false;
   options.disableHTMLOrdering = options.disableHTMLOrdering ?? false;
   options.buildStatementLevelHTML = options.buildStatementLevelHTML ?? false;
 
@@ -86,7 +87,8 @@ export async function calculate<T extends CalculationOptions>(
 
   const executionResults: ExecutionResult<DetailedPopulationGroupResult>[] = [];
   let overallClauseCoverageHTML: string | undefined;
-  let groupClauseCoverageHTML: Record<string, { coverage: string; uncoverage: string }> | undefined;
+  let groupClauseCoverageHTML: Record<string, string> | undefined;
+  let groupClauseUncoverageHTML: Record<string, string> | undefined;
 
   let newValueSetCache: fhir4.ValueSet[] | undefined = [...valueSetCache];
   const allELM: ELM[] = [];
@@ -251,31 +253,42 @@ export async function calculate<T extends CalculationOptions>(
     patientSource = resolvePatientSource(patientBundles, options);
 
     if (!isCompositeExecution && options.calculateClauseCoverage) {
-      groupClauseCoverageHTML = generateClauseCoverageHTML(
-        measure,
-        executedELM,
-        executionResults,
-        options.disableHTMLOrdering
-      );
+      const coverage = generateClauseCoverageHTML(measure, executedELM, executionResults, options);
+      groupClauseCoverageHTML = coverage.coverage;
       overallClauseCoverageHTML = '';
       Object.entries(groupClauseCoverageHTML).forEach(([groupId, result]) => {
-        overallClauseCoverageHTML += result.coverage;
+        overallClauseCoverageHTML += result;
         if (debugObject && options.enableDebugOutput) {
           const debugHTML = {
             name: `clause-coverage-${groupId}.html`,
-            html: result.coverage
-          };
-          const debugUncoverageHTML = {
-            name: `clause-uncoverage-${groupId}.html`,
-            html: result.uncoverage
+            html: result
           };
           if (Array.isArray(debugObject.html)) {
-            debugObject.html.push(debugHTML, debugUncoverageHTML);
+            debugObject.html.push(debugHTML);
           } else {
-            debugObject.html = [debugHTML, debugUncoverageHTML];
+            debugObject.html = [debugHTML];
           }
         }
       });
+
+      // pull out
+      if (options.calculateClauseUncoverage && coverage.uncoverage) {
+        groupClauseUncoverageHTML = coverage.uncoverage;
+        if (debugObject && options.enableDebugOutput) {
+          Object.entries(groupClauseUncoverageHTML).forEach(([groupId, result]) => {
+            const debugUncoverageHTML = {
+              name: `clause-uncoverage-${groupId}.html`,
+              html: result
+            };
+            if (Array.isArray(debugObject.html)) {
+              debugObject.html.push(debugUncoverageHTML);
+            } else {
+              debugObject.html = [debugUncoverageHTML];
+            }
+          });
+        }
+      }
+
       // don't necessarily need this file, but adding it for backwards compatibility
       if (debugObject && options.enableDebugOutput) {
         debugObject.html?.push({
@@ -318,7 +331,8 @@ export async function calculate<T extends CalculationOptions>(
         )
       }),
     ...(overallClauseCoverageHTML && { coverageHTML: overallClauseCoverageHTML }),
-    ...(groupClauseCoverageHTML && { groupClauseCoverageHTML: groupClauseCoverageHTML })
+    ...(groupClauseCoverageHTML && { groupClauseCoverageHTML: groupClauseCoverageHTML }),
+    ...(groupClauseUncoverageHTML && { groupClauseUncoverageHTML: groupClauseUncoverageHTML })
   };
 }
 

--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -86,7 +86,7 @@ export async function calculate<T extends CalculationOptions>(
 
   const executionResults: ExecutionResult<DetailedPopulationGroupResult>[] = [];
   let overallClauseCoverageHTML: string | undefined;
-  let groupClauseCoverageHTML: Record<string, string> | undefined;
+  let groupClauseCoverageHTML: Record<string, { coverage: string; uncoverage: string }> | undefined;
 
   let newValueSetCache: fhir4.ValueSet[] | undefined = [...valueSetCache];
   const allELM: ELM[] = [];
@@ -259,16 +259,20 @@ export async function calculate<T extends CalculationOptions>(
       );
       overallClauseCoverageHTML = '';
       Object.entries(groupClauseCoverageHTML).forEach(([groupId, result]) => {
-        overallClauseCoverageHTML += result;
+        overallClauseCoverageHTML += result.coverage;
         if (debugObject && options.enableDebugOutput) {
           const debugHTML = {
             name: `clause-coverage-${groupId}.html`,
-            html: result
+            html: result.coverage
+          };
+          const debugUncoverageHTML = {
+            name: `clause-uncoverage-${groupId}.html`,
+            html: result.uncoverage
           };
           if (Array.isArray(debugObject.html)) {
-            debugObject.html.push(debugHTML);
+            debugObject.html.push(debugHTML, debugUncoverageHTML);
           } else {
-            debugObject.html = [debugHTML];
+            debugObject.html = [debugHTML, debugUncoverageHTML];
           }
         }
       });

--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -41,7 +41,6 @@ import { clearElmInfoCache } from '../helpers/elm/ELMInfoCache';
 import _, { omit } from 'lodash';
 import { ELM } from '../types/ELMTypes';
 import { getReportBuilder } from '../helpers/ReportBuilderFactory';
-import { option } from 'commander';
 
 /**
  * Calculate measure against a set of patients. Returning detailed results for each patient and population group.

--- a/src/calculation/HTMLBuilder.ts
+++ b/src/calculation/HTMLBuilder.ts
@@ -382,11 +382,7 @@ export function calculateClauseCoverage(
   );
 
   const uncoveredClauses = allUniqueClauses.filter(c => {
-    if (coveredClauses.find(coveredC => c.libraryName === coveredC.libraryName && c.localId === coveredC.localId)) {
-      return false;
-    } else {
-      return true;
-    }
+    return !coveredClauses.find(coveredC => c.libraryName === coveredC.libraryName && c.localId === coveredC.localId);
   });
 
   return {

--- a/src/calculation/HTMLBuilder.ts
+++ b/src/calculation/HTMLBuilder.ts
@@ -95,12 +95,23 @@ Handlebars.registerHelper('highlightCoverage', (localId, context) => {
 // apply highlighting style to uncovered clauses
 Handlebars.registerHelper('highlightUncoverage', (localId, context) => {
   const libraryName: string = context.data.root.libraryName;
-  const clauseResults: ClauseResult[] = context.data.root.clauseResults;
 
-  const clauseResult = clauseResults.filter(result => result.libraryName === libraryName && result.localId === localId);
-  if (clauseResult.length > 0) {
+  if (
+    (context.data.root.uncoveredClauses as ClauseResult[]).some(
+      result => result.libraryName === libraryName && result.localId === localId
+    )
+  ) {
+    // Mark with red styling if clause is found in uncoverage list
     return objToCSS(cqlLogicClauseFalseStyle);
+  } else if (
+    (context.data.root.coveredClauses as ClauseResult[]).some(
+      result => result.libraryName === libraryName && result.localId === localId
+    )
+  ) {
+    // Mark with white (clear out styling) if the clause is in coverage list
+    return objToCSS(cqlLogicUncoveredClauseStyle);
   }
+  // If this clause has no results then it should not be styled
   return '';
 });
 
@@ -316,7 +327,8 @@ export function generateClauseCoverageHTML<T extends CalculationOptions>(
         uncoverageHtmlString += main({
           libraryName: a.libraryName,
           statementName: a.statementName,
-          clauseResults: clauseCoverage.uncoveredClauses,
+          uncoveredClauses: clauseCoverage.uncoveredClauses,
+          coveredClauses: clauseCoverage.coveredClauses,
           ...a.annotation[0].s,
           highlightUncoverage: true
         });

--- a/src/calculation/HTMLBuilder.ts
+++ b/src/calculation/HTMLBuilder.ts
@@ -309,7 +309,9 @@ export function generateClauseCoverageHTML<T extends CalculationOptions>(
     // setup initial html for uncoverage
     let uncoverageHtmlString = '';
     if (options.calculateClauseUncoverage) {
-      uncoverageHtmlString = `<div><h2> ${groupId} Clause Uncoverage: ${clauseCoverage.uncoveredClauses.length} clauses</h2>`;
+      uncoverageHtmlString = `<div><h2> ${groupId} Clause Uncoverage: ${clauseCoverage.uncoveredClauses.length} of ${
+        clauseCoverage.coveredClauses.length + clauseCoverage.uncoveredClauses.length
+      } clauses</h2>`;
     }
 
     // generate HTML clauses using hbs template for each annotation

--- a/src/calculation/HTMLBuilder.ts
+++ b/src/calculation/HTMLBuilder.ts
@@ -333,8 +333,9 @@ export function generateClauseCoverageHTML<T extends CalculationOptions>(
     // If details on coverage are requested, tally them up and add them to the map.
     if (options.calculateCoverageDetails) {
       coverageDetailsGroupLookup[groupId] = {
-        totalClauses: clauseCoverage.coveredClauses.length + clauseCoverage.uncoveredClauses.length,
-        coveredClauses: clauseCoverage.coveredClauses.length,
+        totalClauseCount: clauseCoverage.coveredClauses.length + clauseCoverage.uncoveredClauses.length,
+        coveredClauseCount: clauseCoverage.coveredClauses.length,
+        uncoveredClauseCount: clauseCoverage.uncoveredClauses.length,
         uncoveredClauses: clauseCoverage.uncoveredClauses.map(uncoveredClause => {
           return {
             localId: uncoveredClause.localId,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -114,6 +114,7 @@ async function calc(
   if (program.outputType === 'raw') {
     result = await calculateRaw(measureBundle, patientBundles, calcOptions, valueSetCache);
   } else if (program.outputType === 'detailed') {
+    calcOptions.calculateClauseUncoverage = true;
     result = await calculate(measureBundle, patientBundles, calcOptions, valueSetCache);
   } else if (program.outputType === 'reports') {
     calcOptions.reportType = program.reportType || 'individual';

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -115,6 +115,7 @@ async function calc(
     result = await calculateRaw(measureBundle, patientBundles, calcOptions, valueSetCache);
   } else if (program.outputType === 'detailed') {
     calcOptions.calculateClauseUncoverage = true;
+    calcOptions.calculateCoverageDetails = true;
     result = await calculate(measureBundle, patientBundles, calcOptions, valueSetCache);
   } else if (program.outputType === 'reports') {
     calcOptions.reportType = program.reportType || 'individual';
@@ -241,6 +242,10 @@ populatePatientBundles().then(async patientBundles => {
 
       if (debugOutput?.gaps) {
         dumpObject(debugOutput.gaps, 'gaps.json');
+      }
+
+      if (debugOutput?.coverageDetails) {
+        dumpObject(debugOutput.coverageDetails, 'coverageDetails.json');
       }
 
       // Dump ELM

--- a/src/templates/clause.ts
+++ b/src/templates/clause.ts
@@ -10,6 +10,18 @@ export default `{{~#if @root.highlightCoverage~}}
 {{~/if~}}
 </span>
 {{~else~}}
+{{~#if @root.highlightUncoverage~}}
+<span{{#if r}} data-ref-id="{{r}}" style="{{highlightUncoverage r}}"{{/if}}>
+{{~#if value ~}}
+{{ concat value }}
+{{~/if ~}}
+{{~#if s~}}
+{{~#each s~}}
+{{> clause ~}}
+{{~/each ~}}
+{{~/if~}}
+</span>
+{{~else~}}
 <span{{#if r}} data-ref-id="{{r}}" style="{{highlightClause r}}"{{/if}}>
 {{~#if value ~}}
 {{ concat value }}
@@ -20,4 +32,5 @@ export default `{{~#if @root.highlightCoverage~}}
 {{~/each ~}}
 {{~/if~}}
 </span>
+{{~/if~}}
 {{~/if~}}`;

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -26,6 +26,8 @@ export interface CalculationOptions {
   calculateClauseCoverage?: boolean;
   /** Include HTML structure with clause uncoverage highlighting. Highlights what is not covered */
   calculateClauseUncoverage?: boolean;
+  /** Include details about the clause coverage. Total clause count, total covered count, info on uncovered clauses. */
+  calculateCoverageDetails?: boolean;
   /** Enable debug output including CQL, ELM, results */
   enableDebugOutput?: boolean;
   /** Enables the return of ELM Libraries and name of main library to be used for further processing. ex. gaps in care */
@@ -398,6 +400,17 @@ export interface CalculationOutput<T extends CalculationOptions> extends Calcula
   coverageHTML?: string;
   groupClauseCoverageHTML?: Record<string, string>;
   groupClauseUncoverageHTML?: Record<string, string>;
+  groupClauseCoverageDetails?: Record<string, ClauseCoverageDetails>;
+}
+
+export interface ClauseCoverageDetails {
+  totalClauses: number;
+  coveredClauses: number;
+  uncoveredClauses: {
+    libraryName: string;
+    statementName: string;
+    localId: string;
+  }[];
 }
 
 /**

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -404,6 +404,9 @@ export interface CalculationOutput<T extends CalculationOptions> extends Calcula
   groupClauseCoverageDetails?: Record<string, ClauseCoverageDetails>;
 }
 
+/**
+ * Details on clause coverage for group calculation.
+ */
 export interface ClauseCoverageDetails {
   totalClauseCount: number;
   coveredClauseCount: number;

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -405,8 +405,9 @@ export interface CalculationOutput<T extends CalculationOptions> extends Calcula
 }
 
 export interface ClauseCoverageDetails {
-  totalClauses: number;
-  coveredClauses: number;
+  totalClauseCount: number;
+  coveredClauseCount: number;
+  uncoveredClauseCount: number;
   uncoveredClauses: {
     libraryName: string;
     statementName: string;

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -394,7 +394,7 @@ export interface CalculationOutput<T extends CalculationOptions> extends Calcula
   mainLibraryName?: string;
   parameters?: { [key: string]: any };
   coverageHTML?: string;
-  groupClauseCoverageHTML?: Record<string, string>;
+  groupClauseCoverageHTML?: Record<string, { coverage: string; uncoverage: string }>;
 }
 
 /**

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -358,6 +358,7 @@ export interface DebugOutput {
     retrieves?: DataTypeQuery[];
     bundle?: fhir4.Bundle | fhir4.Bundle[];
   };
+  coverageDetails?: Record<string, ClauseCoverageDetails>;
 }
 
 /*

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -24,6 +24,8 @@ export interface CalculationOptions {
   calculateHTML?: boolean;
   /** Include HTML structure with clause coverage highlighting */
   calculateClauseCoverage?: boolean;
+  /** Include HTML structure with clause uncoverage highlighting. Highlights what is not covered */
+  calculateClauseUncoverage?: boolean;
   /** Enable debug output including CQL, ELM, results */
   enableDebugOutput?: boolean;
   /** Enables the return of ELM Libraries and name of main library to be used for further processing. ex. gaps in care */
@@ -394,7 +396,8 @@ export interface CalculationOutput<T extends CalculationOptions> extends Calcula
   mainLibraryName?: string;
   parameters?: { [key: string]: any };
   coverageHTML?: string;
-  groupClauseCoverageHTML?: Record<string, { coverage: string; uncoverage: string }>;
+  groupClauseCoverageHTML?: Record<string, string>;
+  groupClauseUncoverageHTML?: Record<string, string>;
 }
 
 /**

--- a/test/unit/HTMLBuilder.test.ts
+++ b/test/unit/HTMLBuilder.test.ts
@@ -221,8 +221,8 @@ describe('HTMLBuilder', () => {
     ];
     const res = generateClauseCoverageHTML(simpleMeasure, [elm], executionResults);
 
-    expect(res.test.replace(/\s/g, '')).toEqual(expectedHTML);
-    expect(res.test.includes(coverageStyleString)).toBeTruthy();
+    expect(res.test.coverage.replace(/\s/g, '')).toEqual(expectedHTML);
+    expect(res.test.coverage.includes(coverageStyleString)).toBeTruthy();
   });
 
   test('simple HTML for two groups with generation with clause coverage styling', () => {
@@ -248,10 +248,10 @@ describe('HTMLBuilder', () => {
     ];
     const res = generateClauseCoverageHTML(simpleMeasure, [elm], executionResults);
 
-    expect(res.test.replace(/\s/g, '')).toEqual(expectedHTML);
-    expect(res.test2.replace(/\s/g, '')).toEqual(expectedHTML2);
-    expect(res.test.includes(coverageStyleString)).toBeTruthy();
-    expect(res.test2.includes(coverageStyleString)).toBeTruthy();
+    expect(res.test.coverage.replace(/\s/g, '')).toEqual(expectedHTML);
+    expect(res.test2.coverage.replace(/\s/g, '')).toEqual(expectedHTML2);
+    expect(res.test.coverage.includes(coverageStyleString)).toBeTruthy();
+    expect(res.test2.coverage.includes(coverageStyleString)).toBeTruthy();
   });
 
   test('ordered HTML with generation with clause coverage styling', () => {
@@ -269,8 +269,8 @@ describe('HTMLBuilder', () => {
     ];
     const res = generateClauseCoverageHTML(singlePopMeasure, [popRetrieveFuncElm], executionResults);
 
-    expect(res.test.indexOf('ipp')).toBeLessThan(res.test.indexOf('SimpleVSRetrieve'));
-    expect(res.test.indexOf('SimpleVSRetrieve')).toBeLessThan(res.test.indexOf('A Function'));
+    expect(res.test.coverage.indexOf('ipp')).toBeLessThan(res.test.coverage.indexOf('SimpleVSRetrieve'));
+    expect(res.test.coverage.indexOf('SimpleVSRetrieve')).toBeLessThan(res.test.coverage.indexOf('A Function'));
   });
 
   test('no library found should error', () => {
@@ -336,7 +336,8 @@ describe('HTMLBuilder', () => {
       }
     ];
     const results = calculateClauseCoverage(statementResults, clauseResults);
-    expect(results).toEqual('100');
+    expect(results.percentage).toEqual('100');
+    expect(results.uncoveredClauses).toEqual([]);
   });
 
   test('html generation orders population first, then other, then function', () => {

--- a/test/unit/HTMLBuilder.test.ts
+++ b/test/unit/HTMLBuilder.test.ts
@@ -219,10 +219,10 @@ describe('HTMLBuilder', () => {
         ]
       }
     ];
-    const res = generateClauseCoverageHTML(simpleMeasure, [elm], executionResults);
+    const res = generateClauseCoverageHTML(simpleMeasure, [elm], executionResults, {});
 
-    expect(res.test.coverage.replace(/\s/g, '')).toEqual(expectedHTML);
-    expect(res.test.coverage.includes(coverageStyleString)).toBeTruthy();
+    expect(res.coverage.test.replace(/\s/g, '')).toEqual(expectedHTML);
+    expect(res.coverage.test.includes(coverageStyleString)).toBeTruthy();
   });
 
   test('simple HTML for two groups with generation with clause coverage styling', () => {
@@ -246,12 +246,12 @@ describe('HTMLBuilder', () => {
         ]
       }
     ];
-    const res = generateClauseCoverageHTML(simpleMeasure, [elm], executionResults);
+    const res = generateClauseCoverageHTML(simpleMeasure, [elm], executionResults, {});
 
-    expect(res.test.coverage.replace(/\s/g, '')).toEqual(expectedHTML);
-    expect(res.test2.coverage.replace(/\s/g, '')).toEqual(expectedHTML2);
-    expect(res.test.coverage.includes(coverageStyleString)).toBeTruthy();
-    expect(res.test2.coverage.includes(coverageStyleString)).toBeTruthy();
+    expect(res.coverage.test.replace(/\s/g, '')).toEqual(expectedHTML);
+    expect(res.coverage.test2.replace(/\s/g, '')).toEqual(expectedHTML2);
+    expect(res.coverage.test.includes(coverageStyleString)).toBeTruthy();
+    expect(res.coverage.test2.includes(coverageStyleString)).toBeTruthy();
   });
 
   test('ordered HTML with generation with clause coverage styling', () => {
@@ -267,10 +267,10 @@ describe('HTMLBuilder', () => {
         ]
       }
     ];
-    const res = generateClauseCoverageHTML(singlePopMeasure, [popRetrieveFuncElm], executionResults);
+    const res = generateClauseCoverageHTML(singlePopMeasure, [popRetrieveFuncElm], executionResults, {});
 
-    expect(res.test.coverage.indexOf('ipp')).toBeLessThan(res.test.coverage.indexOf('SimpleVSRetrieve'));
-    expect(res.test.coverage.indexOf('SimpleVSRetrieve')).toBeLessThan(res.test.coverage.indexOf('A Function'));
+    expect(res.coverage.test.indexOf('ipp')).toBeLessThan(res.coverage.test.indexOf('SimpleVSRetrieve'));
+    expect(res.coverage.test.indexOf('SimpleVSRetrieve')).toBeLessThan(res.coverage.test.indexOf('A Function'));
   });
 
   test('no library found should error', () => {


### PR DESCRIPTION
# Summary
New option to show which clauses are uncovered as a new set of output. Also adds details on coverage including the list of clauses that were not coverage.

Additionally coverage html calculation was made considerably faster (~200x). This should be VERY noticeable when run with larger sets of patients. 

## New behavior
New options in calculator that are false by default:
 - `calculateClauseUncoverage`: Calculates HTML that highlights clauses that are not covered by the set of patients.
 - `calculateCoverageDetails`: Calculates the total count of covered and uncovered clauses and lists the location of the uncovered clauses.
 
These new options will run in the CLI and the coverageDetails will be output as it's own debug output file. This is intended to help with pinpointing coverage issues as it can tell you exactly where in the ELM there are gaps in the coverage.

## Code changes
`HTMLBuilder.ts` - Reworked logic for calculating coverage to collect unique lists of covered and uncovered clause results. Reworked coverage highlighting to work off these smaller lists to vastly speed up HTML generation. Added a helper to highlight specifically for uncoverage.
`Calculator.ts` - Now can handle the two new options and writes out the coverageDetails to a new debug file.
`types/Calculator.ts` - New types for the new options and output.
`cli.ts` - Defaults `calculateClauseUncoverage` and `calculateCoverageDetails` to true.


# Testing guidance
Test with any measures that feel appropriate and look for any differences in coverage highlighting or percentage. Check to make sure that uncoverage highlighting looks sane.
