### PR TITLE
Highlighting compliance

### DIFF
--- a/src/calculation/HTMLBuilder.ts
+++ b/src/calculation/HTMLBuilder.ts
@@ -18,28 +18,32 @@ export const cqlLogicClauseTrueStyle = {
   'background-color': '#ccebe0',
   color: '#20744c',
   'border-bottom-color': '#20744c',
-  'border-bottom-style': 'solid'
+  'border-bottom-style': 'solid',
+  'border-bottom-width': '0.35em'
 };
 
 export const cqlLogicClauseFalseStyle = {
   'background-color': '#edd8d0',
   color: '#a63b12',
   'border-bottom-color': '#a63b12',
-  'border-bottom-style': 'double'
+  'border-bottom-style': 'double',
+  'border-bottom-width': '0.35em'
 };
 
 export const cqlLogicClauseCoveredStyle = {
   'background-color': '#daeaf5',
   color: '#004e82',
   'border-bottom-color': '#006cb4',
-  'border-bottom-style': 'dashed'
+  'border-bottom-style': 'dashed',
+  'border-bottom-width': '0.35em'
 };
 
 export const cqlLogicUncoveredClauseStyle = {
   'background-color': 'white',
   color: 'black',
   'border-bottom-color': 'white',
-  'border-bottom-style': 'solid'
+  'border-bottom-style': 'solid',
+  'border-bottom-width': '0.35em'
 };
 
 /**

--- a/src/calculation/HTMLBuilder.ts
+++ b/src/calculation/HTMLBuilder.ts
@@ -32,18 +32,12 @@ export const cqlLogicClauseFalseStyle = {
 
 export const cqlLogicClauseCoveredStyle = {
   'background-color': '#daeaf5',
-  color: '#004e82',
-  'border-bottom-color': '#006cb4',
-  'border-bottom-style': 'dashed',
-  'border-bottom-width': '0.35em'
+  color: '#004e82'
 };
 
 export const cqlLogicUncoveredClauseStyle = {
   'background-color': 'white',
-  color: 'black',
-  'border-bottom-color': 'white',
-  'border-bottom-style': 'solid',
-  'border-bottom-width': '0.35em'
+  color: 'black'
 };
 
 /**

--- a/src/calculation/HTMLBuilder.ts
+++ b/src/calculation/HTMLBuilder.ts
@@ -40,7 +40,7 @@ export const cqlLogicUncoveredClauseStyle = {
   color: 'black'
 };
 
-export const cqlLogicUncoveredUncoveredClauseStyle = {
+export const cqlLogicUncoveredUncoverageClauseStyle = {
   'background-color': '#edd8d0',
   color: '#a63b12'
 };
@@ -105,7 +105,7 @@ Handlebars.registerHelper('highlightUncoverage', (localId, context) => {
     )
   ) {
     // Mark with red styling if clause is found in uncoverage list
-    return objToCSS(cqlLogicUncoveredUncoveredClauseStyle);
+    return objToCSS(cqlLogicUncoveredUncoverageClauseStyle);
   } else if (
     (context.data.root.coveredClauses as ClauseResult[]).some(
       result => result.libraryName === libraryName && result.localId === localId

--- a/src/calculation/HTMLBuilder.ts
+++ b/src/calculation/HTMLBuilder.ts
@@ -40,6 +40,11 @@ export const cqlLogicUncoveredClauseStyle = {
   color: 'black'
 };
 
+export const cqlLogicUncoveredUncoveredClauseStyle = {
+  'background-color': '#edd8d0',
+  color: '#a63b12'
+};
+
 /**
  * Convert JS object to CSS Style string
  *
@@ -100,7 +105,7 @@ Handlebars.registerHelper('highlightUncoverage', (localId, context) => {
     )
   ) {
     // Mark with red styling if clause is found in uncoverage list
-    return objToCSS(cqlLogicClauseFalseStyle);
+    return objToCSS(cqlLogicUncoveredUncoveredClauseStyle);
   } else if (
     (context.data.root.coveredClauses as ClauseResult[]).some(
       result => result.libraryName === libraryName && result.localId === localId
@@ -209,7 +214,8 @@ export function generateHTML(
         libraryName: s.libraryName,
         statementName: s.statementName,
         clauseResults: clauseResults,
-        ...matchingExpression.annotation[0].s
+        ...matchingExpression.annotation[0].s,
+        highlightLogic: true
       });
       overallHTML += statementHTML;
       if (options?.buildStatementLevelHTML) {

--- a/src/templates/main.ts
+++ b/src/templates/main.ts
@@ -1,4 +1,4 @@
-export default `<pre style="tab-size: 2; border-bottom-width: 4px; {{~#unless @root.highlightCoverage~}} line-height: 1.51em{{~/unless~}}"
+export default `<pre style="tab-size: 2; {{~#if @root.highlightLogic~}} line-height: 1.51em{{~/if~}}"
   data-library-name="{{ libraryName }}" data-statement-name="{{ statementName }}">
 <code>
 {{> clause}}

--- a/src/templates/main.ts
+++ b/src/templates/main.ts
@@ -1,15 +1,6 @@
-export default `{{~#if @root.highlightCoverage~}}
-<pre style="tab-size: 2; border-bottom-width: 4px"
+export default `<pre style="tab-size: 2; border-bottom-width: 4px; {{~#unless @root.highlightCoverage~}} line-height: 1.51em{{~/unless~}}"
   data-library-name="{{ libraryName }}" data-statement-name="{{ statementName }}">
 <code>
 {{> clause}}
 </code>
-</pre>
-{{else}}
-<pre style="tab-size: 2; border-bottom-width: 4px; line-height: 1.51em"
-  data-library-name="{{ libraryName }}" data-statement-name="{{ statementName }}">
-<code>
-{{> clause}}
-</code>
-</pre>
-{{~/if~}}`;
+</pre>`;

--- a/src/templates/main.ts
+++ b/src/templates/main.ts
@@ -1,4 +1,4 @@
-export default `<pre style="tab-size: 2; {{~#if @root.highlightLogic~}} line-height: 1.51em{{~/if~}}"
+export default `<pre style="tab-size: 2 {{~#if @root.highlightLogic~}}; line-height: 1.51em{{~/if~}}"
   data-library-name="{{ libraryName }}" data-statement-name="{{ statementName }}">
 <code>
 {{> clause}}

--- a/src/templates/main.ts
+++ b/src/templates/main.ts
@@ -1,6 +1,15 @@
-export default `<pre style="tab-size: 2; border-bottom-width: 4px; line-height: 1.51em"
+export default `{{~#if @root.highlightCoverage~}}
+<pre style="tab-size: 2; border-bottom-width: 4px"
   data-library-name="{{ libraryName }}" data-statement-name="{{ statementName }}">
 <code>
 {{> clause}}
 </code>
-</pre>`;
+</pre>
+{{else}}
+<pre style="tab-size: 2; border-bottom-width: 4px; line-height: 1.51em"
+  data-library-name="{{ libraryName }}" data-statement-name="{{ statementName }}">
+<code>
+{{> clause}}
+</code>
+</pre>
+{{~/if~}}`;

--- a/src/templates/main.ts
+++ b/src/templates/main.ts
@@ -1,4 +1,4 @@
-export default `<pre style="tab-size: 2; border-bottom-width: 4px; line-height: 1.4"
+export default `<pre style="tab-size: 2; border-bottom-width: 4px; line-height: 1.51em"
   data-library-name="{{ libraryName }}" data-statement-name="{{ statementName }}">
 <code>
 {{> clause}}

--- a/test/unit/fixtures/html/simpleCoverageAnnotation.html
+++ b/test/unit/fixtures/html/simpleCoverageAnnotation.html
@@ -1,25 +1,25 @@
 <div>
   <h2>test Clause Coverage: 100%</h2>
   <pre
-    style="tab-size: 2; border-bottom-width: 4px; line-height: 1.4"
+    style="tab-size: 2; border-bottom-width: 4px; line-height: 1.51em"
     data-library-name="AnticoagulationTherapyforAtrialFibrillationFlutter"
     data-statement-name="Denominator"
   >
       <code>
-        <span data-ref-id="119" style="background-color:#daeaf5;color:#004e82;border-bottom-color:#006cb4;border-bottom-style:dashed">
+        <span data-ref-id="119" style="background-color:#daeaf5;color:#004e82;border-bottom-color:#006cb4;border-bottom-style:dashed;border-bottom-width:0.35em">
           <span>define &quot;Denominator&quot;: </span>
-          <span data-ref-id="118" style="background-color:white;color:black;border-bottom-color:white;border-bottom-style:solid">
-            <span data-ref-id="116" style="background-color:white;color:black;border-bottom-color:white;border-bottom-style:solid">
-              <span data-ref-id="101" style="background-color:white;color:black;border-bottom-color:white;border-bottom-style:solid">
+          <span data-ref-id="118" style="background-color:white;color:black;border-bottom-color:white;border-bottom-style:solid;border-bottom-width:0.35em">
+            <span data-ref-id="116" style="background-color:white;color:black;border-bottom-color:white;border-bottom-style:solid;border-bottom-width:0.35em">
+              <span data-ref-id="101" style="background-color:white;color:black;border-bottom-color:white;border-bottom-style:solid;border-bottom-width:0.35em">
                 <span>&quot;Encounter with Atrial Ablation Procedure&quot;</span>
               </span>
               <span>union</span>
-              <span data-ref-id="115" style="background-color:white;color:black;border-bottom-color:white;border-bottom-style:solid">
+              <span data-ref-id="115" style="background-color:white;color:black;border-bottom-color:white;border-bottom-style:solid;border-bottom-width:0.35em">
                 <span>&quot;History of Atrial FibrillationFlutter&quot;</span>
               </span>
             </span>
             <span>union</span>
-            <span data-ref-id="117" style="background-color:white;color:black;border-bottom-color:white;border-bottom-style:solid">
+            <span data-ref-id="117" style="background-color:white;color:black;border-bottom-color:white;border-bottom-style:solid;border-bottom-width:0.35em">
               <span>&quot;Current Diagnosis Atrial FibrillationFlutter&quot;</span>
             </span>
           </span>

--- a/test/unit/fixtures/html/simpleCoverageAnnotation.html
+++ b/test/unit/fixtures/html/simpleCoverageAnnotation.html
@@ -1,25 +1,25 @@
 <div>
   <h2>test Clause Coverage: 100%</h2>
   <pre
-    style="tab-size: 2; border-bottom-width: 4px; line-height: 1.51em"
+    style="tab-size: 2"
     data-library-name="AnticoagulationTherapyforAtrialFibrillationFlutter"
     data-statement-name="Denominator"
   >
       <code>
-        <span data-ref-id="119" style="background-color:#daeaf5;color:#004e82;border-bottom-color:#006cb4;border-bottom-style:dashed;border-bottom-width:0.35em">
+        <span data-ref-id="119" style="background-color:#daeaf5;color:#004e82">
           <span>define &quot;Denominator&quot;: </span>
-          <span data-ref-id="118" style="background-color:white;color:black;border-bottom-color:white;border-bottom-style:solid;border-bottom-width:0.35em">
-            <span data-ref-id="116" style="background-color:white;color:black;border-bottom-color:white;border-bottom-style:solid;border-bottom-width:0.35em">
-              <span data-ref-id="101" style="background-color:white;color:black;border-bottom-color:white;border-bottom-style:solid;border-bottom-width:0.35em">
+          <span data-ref-id="118" style="background-color:white;color:black">
+            <span data-ref-id="116" style="background-color:white;color:black">
+              <span data-ref-id="101" style="background-color:white;color:black">
                 <span>&quot;Encounter with Atrial Ablation Procedure&quot;</span>
               </span>
               <span>union</span>
-              <span data-ref-id="115" style="background-color:white;color:black;border-bottom-color:white;border-bottom-style:solid;border-bottom-width:0.35em">
+              <span data-ref-id="115" style="background-color:white;color:black">
                 <span>&quot;History of Atrial FibrillationFlutter&quot;</span>
               </span>
             </span>
             <span>union</span>
-            <span data-ref-id="117" style="background-color:white;color:black;border-bottom-color:white;border-bottom-style:solid;border-bottom-width:0.35em">
+            <span data-ref-id="117" style="background-color:white;color:black">
               <span>&quot;Current Diagnosis Atrial FibrillationFlutter&quot;</span>
             </span>
           </span>

--- a/test/unit/fixtures/html/simpleCoverageAnnotation2.html
+++ b/test/unit/fixtures/html/simpleCoverageAnnotation2.html
@@ -1,25 +1,25 @@
 <div>
   <h2>test2 Clause Coverage: 100%</h2>
   <pre
-    style="tab-size: 2; border-bottom-width: 4px; line-height: 1.4"
+    style="tab-size: 2; border-bottom-width: 4px; line-height: 1.51em"
     data-library-name="AnticoagulationTherapyforAtrialFibrillationFlutter"
     data-statement-name="Denominator"
   >
         <code>
-          <span data-ref-id="119" style="background-color:#daeaf5;color:#004e82;border-bottom-color:#006cb4;border-bottom-style:dashed">
+          <span data-ref-id="119" style="background-color:#daeaf5;color:#004e82;border-bottom-color:#006cb4;border-bottom-style:dashed;border-bottom-width:0.35em">
             <span>define &quot;Denominator&quot;: </span>
-            <span data-ref-id="118" style="background-color:white;color:black;border-bottom-color:white;border-bottom-style:solid">
-              <span data-ref-id="116" style="background-color:white;color:black;border-bottom-color:white;border-bottom-style:solid">
-                <span data-ref-id="101" style="background-color:white;color:black;border-bottom-color:white;border-bottom-style:solid">
+            <span data-ref-id="118" style="background-color:white;color:black;border-bottom-color:white;border-bottom-style:solid;border-bottom-width:0.35em">
+              <span data-ref-id="116" style="background-color:white;color:black;border-bottom-color:white;border-bottom-style:solid;border-bottom-width:0.35em">
+                <span data-ref-id="101" style="background-color:white;color:black;border-bottom-color:white;border-bottom-style:solid;border-bottom-width:0.35em">
                   <span>&quot;Encounter with Atrial Ablation Procedure&quot;</span>
                 </span>
                 <span>union</span>
-                <span data-ref-id="115" style="background-color:white;color:black;border-bottom-color:white;border-bottom-style:solid">
+                <span data-ref-id="115" style="background-color:white;color:black;border-bottom-color:white;border-bottom-style:solid;border-bottom-width:0.35em">
                   <span>&quot;History of Atrial FibrillationFlutter&quot;</span>
                 </span>
               </span>
               <span>union</span>
-              <span data-ref-id="117" style="background-color:white;color:black;border-bottom-color:white;border-bottom-style:solid">
+              <span data-ref-id="117" style="background-color:white;color:black;border-bottom-color:white;border-bottom-style:solid;border-bottom-width:0.35em">
                 <span>&quot;Current Diagnosis Atrial FibrillationFlutter&quot;</span>
               </span>
             </span>

--- a/test/unit/fixtures/html/simpleCoverageAnnotation2.html
+++ b/test/unit/fixtures/html/simpleCoverageAnnotation2.html
@@ -1,25 +1,25 @@
 <div>
   <h2>test2 Clause Coverage: 100%</h2>
   <pre
-    style="tab-size: 2; border-bottom-width: 4px; line-height: 1.51em"
+    style="tab-size: 2"
     data-library-name="AnticoagulationTherapyforAtrialFibrillationFlutter"
     data-statement-name="Denominator"
   >
         <code>
-          <span data-ref-id="119" style="background-color:#daeaf5;color:#004e82;border-bottom-color:#006cb4;border-bottom-style:dashed;border-bottom-width:0.35em">
+          <span data-ref-id="119" style="background-color:#daeaf5;color:#004e82">
             <span>define &quot;Denominator&quot;: </span>
-            <span data-ref-id="118" style="background-color:white;color:black;border-bottom-color:white;border-bottom-style:solid;border-bottom-width:0.35em">
-              <span data-ref-id="116" style="background-color:white;color:black;border-bottom-color:white;border-bottom-style:solid;border-bottom-width:0.35em">
-                <span data-ref-id="101" style="background-color:white;color:black;border-bottom-color:white;border-bottom-style:solid;border-bottom-width:0.35em">
+            <span data-ref-id="118" style="background-color:white;color:black">
+              <span data-ref-id="116" style="background-color:white;color:black">
+                <span data-ref-id="101" style="background-color:white;color:black">
                   <span>&quot;Encounter with Atrial Ablation Procedure&quot;</span>
                 </span>
                 <span>union</span>
-                <span data-ref-id="115" style="background-color:white;color:black;border-bottom-color:white;border-bottom-style:solid;border-bottom-width:0.35em">
+                <span data-ref-id="115" style="background-color:white;color:black">
                   <span>&quot;History of Atrial FibrillationFlutter&quot;</span>
                 </span>
               </span>
               <span>union</span>
-              <span data-ref-id="117" style="background-color:white;color:black;border-bottom-color:white;border-bottom-style:solid;border-bottom-width:0.35em">
+              <span data-ref-id="117" style="background-color:white;color:black">
                 <span>&quot;Current Diagnosis Atrial FibrillationFlutter&quot;</span>
               </span>
             </span>

--- a/test/unit/fixtures/html/simpleFalseAnnotation.html
+++ b/test/unit/fixtures/html/simpleFalseAnnotation.html
@@ -1,7 +1,7 @@
 <div>
   <h2>Population Group: test</h2>
   <pre
-    style="tab-size: 2; border-bottom-width: 4px; line-height: 1.51em"
+    style="tab-size: 2; line-height: 1.51em"
     data-library-name="AnticoagulationTherapyforAtrialFibrillationFlutter"
     data-statement-name="Denominator"
   >

--- a/test/unit/fixtures/html/simpleFalseAnnotation.html
+++ b/test/unit/fixtures/html/simpleFalseAnnotation.html
@@ -1,12 +1,12 @@
 <div>
   <h2>Population Group: test</h2>
   <pre
-    style="tab-size: 2; border-bottom-width: 4px; line-height: 1.4"
+    style="tab-size: 2; border-bottom-width: 4px; line-height: 1.51em"
     data-library-name="AnticoagulationTherapyforAtrialFibrillationFlutter"
     data-statement-name="Denominator"
   >
     <code>
-      <span data-ref-id="119" style="background-color:#edd8d0; color:#a63b12; border-bottom-color:#a63b12; border-bottom-style:double">
+      <span data-ref-id="119" style="background-color:#edd8d0; color:#a63b12; border-bottom-color:#a63b12; border-bottom-style:double;border-bottom-width:0.35em">
         <span>define &quot;Denominator&quot;: </span>
         <span data-ref-id="118" style="">
           <span data-ref-id="116" style="">

--- a/test/unit/fixtures/html/simpleTrueAnnotation.html
+++ b/test/unit/fixtures/html/simpleTrueAnnotation.html
@@ -1,7 +1,7 @@
 <div>
   <h2>Population Group: test</h2>
   <pre
-    style="tab-size: 2; border-bottom-width: 4px; line-height: 1.51em"
+    style="tab-size: 2; line-height: 1.51em"
     data-library-name="AnticoagulationTherapyforAtrialFibrillationFlutter"
     data-statement-name="Denominator"
   >

--- a/test/unit/fixtures/html/simpleTrueAnnotation.html
+++ b/test/unit/fixtures/html/simpleTrueAnnotation.html
@@ -1,12 +1,12 @@
 <div>
   <h2>Population Group: test</h2>
   <pre
-    style="tab-size: 2; border-bottom-width: 4px; line-height: 1.4"
+    style="tab-size: 2; border-bottom-width: 4px; line-height: 1.51em"
     data-library-name="AnticoagulationTherapyforAtrialFibrillationFlutter"
     data-statement-name="Denominator"
   >
     <code>
-      <span data-ref-id="119" style="background-color:#ccebe0;color:#20744c;border-bottom-color:#20744c;border-bottom-style:solid">
+      <span data-ref-id="119" style="background-color:#ccebe0;color:#20744c;border-bottom-color:#20744c;border-bottom-style:solid;border-bottom-width:0.35em">
         <span>define &quot;Denominator&quot;: </span>
         <span data-ref-id="118" style="">
           <span data-ref-id="116" style="">


### PR DESCRIPTION
# Summary
Fixes #297 
This PR updates our logic and coverage highlighting to be 508 compliant and also be more resistant to external CSS styling in order to maintain that compliance.

## New behavior
Clause coverage highlighting should no longer have a dashed underline for covered clauses.

## Code changes
- `HTMLBuilder.ts` - adds border-botton-width to logic highlighting styles, makes the uncoverage highlighting style separate, adds a flag to the handlebars main function to signal logic highlighting
- `src/templates/main.ts` - removes `line-height` and `border-bottom-width` from the main template, conditionally adds a `line-height` if it's logic highlighting
- `test/unit/fixtures/html/*` - updated unit test fixtures to reflect styling changes 

# Testing guidance
- `npm run check`
- Run detailed calculation (`npm run cli -m <path to measure bundle> --patients-directory <path to test cases directory> -o --debug` with the `--debug` flag and check the debug outputs (logic highlighting, coverage highlighting, uncoverage highlighting)
- Also helpful: `npm link` in fqm-execution on this branch and then `npm link fqm-execution` in fqm-testify to see how the styling looks in a frontend app