### PR TITLE
Fix QueryFilter oarsing on optional Query relationship field

### DIFF
--- a/src/helpers/elm/QueryFilterParser.ts
+++ b/src/helpers/elm/QueryFilterParser.ts
@@ -233,7 +233,7 @@ function replaceAliasesInFilters(filter: AnyFilter, match: string, replace: stri
  */
 function parseSources(query: ELMQuery): SourceInfo[] {
   const sources: SourceInfo[] = [];
-  const querySources = query.source;
+  const querySources = [...query.source];
   if (query.relationship) {
     querySources.push(...query.relationship);
   }

--- a/src/helpers/elm/QueryFilterParser.ts
+++ b/src/helpers/elm/QueryFilterParser.ts
@@ -233,7 +233,10 @@ function replaceAliasesInFilters(filter: AnyFilter, match: string, replace: stri
  */
 function parseSources(query: ELMQuery): SourceInfo[] {
   const sources: SourceInfo[] = [];
-  const querySources = [...query.source, ...query.relationship];
+  const querySources = query.source;
+  if (query.relationship) {
+    querySources.push(...query.relationship);
+  }
 
   querySources.forEach(source => {
     if (source.expression.type == 'Retrieve') {

--- a/src/types/ELMTypes.ts
+++ b/src/types/ELMTypes.ts
@@ -234,7 +234,7 @@ export interface ELMQuery extends ELMExpression {
   type: 'Query';
   source: ELMAliasedQuerySource[];
   let?: ELMLetClause[];
-  relationship: ELMRelationshipClause[];
+  relationship?: ELMRelationshipClause[];
   where?: AnyELMExpression;
   return?: ELMReturnClause;
   sort?: any;


### PR DESCRIPTION
# Summary

Fixes an issue found in CMS816 bundle from May 2024 connectathon. The ELM in one of the libraries has a Query expression that has the `relationship` field not existent instead of as an empty array. This is allowed by the CQL logical specification. This issue can cause the `dataRequirements` operation to fail.

## New behavior

Only copies the relationship info if it actually exists.

## Code changes
- `src/helpers/elm/QueryFilterParser.ts` - Check of existence of the `relationship` field before adding it the list to parse.
- `src/types/ELMTypes.ts` - Update the ELM type for Query to make `relationship` optional.

# Testing guidance
Ensure CMS861 does not error out when doing `dataRequirement`.