### PR TITLE
Applies to stratifiers

### DIFF
--- a/src/calculation/DetailedResultsBuilder.ts
+++ b/src/calculation/DetailedResultsBuilder.ts
@@ -304,30 +304,7 @@ export function createPatientPopulationValues(
     populationGroup.stratifier.forEach(strata => {
       if (strata.criteria?.expression) {
         const value = patientResults[strata.criteria?.expression];
-
-        // option 1: uncomment the following lines until option 2 to consider the stratifier result
-        // AND populationResult when creating the detailedResults.stratifierResults
-
-        // if the cqfm-appliesTo extension is present, then we want to consider the result of that
-        // population in our stratifier result
-        const appliesToExtension = strata.extension?.find(
-          e => e.url === 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-appliesTo'
-        );
-        let popValue = true;
-        if (appliesToExtension) {
-          const popCode = appliesToExtension.valueCodeableConcept?.coding?.[0].code;
-          if (popCode) {
-            popValue = patientResults[popCode];
-          }
-        }
-        const result = isStatementValueTruthy(value && popValue);
-
-        // // option 2: keep things the way they were before; do not consider both the stratifierResult
-        // // and the populationResult when creating the detailedResults.stratifierResults
-        // const result = isStatementValueTruthy(value);
-
-        // TO DO: in the case where strata.code.text doesn't exist but strata.id does,
-        // is this structure too redundant? Should we rethink the StratifierResult type?
+        const result = isStatementValueTruthy(value);
         stratifierResults?.push({
           strataCode: strata.code?.text ?? strata.id ?? `strata-${strataIndex++}`,
           result,

--- a/src/calculation/DetailedResultsBuilder.ts
+++ b/src/calculation/DetailedResultsBuilder.ts
@@ -304,9 +304,32 @@ export function createPatientPopulationValues(
     populationGroup.stratifier.forEach(strata => {
       if (strata.criteria?.expression) {
         const value = patientResults[strata.criteria?.expression];
-        const result = isStatementValueTruthy(value);
+
+        // option 1: uncomment the following lines until option 2 to consider the stratifier result
+        // AND populationResult when creating the detailedResults.stratifierResults
+
+        // if the cqfm-appliesTo extension is present, then we want to consider the result of that
+        // population in our stratifier result
+        const appliesToExtension = strata.extension?.find(
+          e => e.url === 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-appliesTo'
+        );
+        let popValue = true;
+        if (appliesToExtension) {
+          const popCode = appliesToExtension.valueCodeableConcept?.coding?.[0].code;
+          if (popCode) {
+            popValue = patientResults[popCode];
+          }
+        }
+        const result = isStatementValueTruthy(value && popValue);
+
+        // // option 2: keep things the way they were before; do not consider both the stratifierResult
+        // // and the populationResult when creating the detailedResults.stratifierResults
+        // const result = isStatementValueTruthy(value);
+
+        // TO DO: in the case where strata.code.text doesn't exist but strata.id does,
+        // is this structure too redundant? Should we rethink the StratifierResult type?
         stratifierResults?.push({
-          strataCode: strata.code?.text ?? `strata-${strataIndex++}`,
+          strataCode: strata.code?.text ?? strata.id ?? `strata-${strataIndex++}`,
           result,
           ...(strata.id ? { strataId: strata.id } : {})
         });

--- a/src/calculation/MeasureReportBuilder.ts
+++ b/src/calculation/MeasureReportBuilder.ts
@@ -277,7 +277,8 @@ export default class MeasureReportBuilder<T extends PopulationGroupResult> exten
           groupResults.stratifierResults?.forEach(stratResults => {
             // only add to results if this patient is in the strata
             if (stratResults.result) {
-              // the strataCode has the potential to be a couple of things, either s,code
+              // the strataCode has the potential to be a couple of things, either s.code[0].text (previous measures)
+              // or s.id (newer measures)
               const strata: MeasureReportGroupStratifier | undefined =
                 group.stratifier?.find(s => s.code && s.code[0]?.text === stratResults.strataCode) ||
                 group.stratifier?.find(s => s.id && s.id === stratResults.strataCode);

--- a/src/calculation/MeasureReportBuilder.ts
+++ b/src/calculation/MeasureReportBuilder.ts
@@ -131,8 +131,12 @@ export default class MeasureReportBuilder<T extends PopulationGroupResult> exten
         group.stratifier = [];
         measureGroup.stratifier.forEach(s => {
           const reportStratifier = <fhir4.MeasureReportGroupStratifier>{};
-          reportStratifier.code = s.code ? [s.code] : [];
-          reportStratifier.id = s.id ? s.id : '';
+          if (s.code) {
+            reportStratifier.code = [s.code];
+          }
+          if (s.id) {
+            reportStratifier.id = s.id;
+          }
           const strat = <fhir4.MeasureReportGroupStratifierStratum>{};
           // use existing populations, but reduce count as appropriate
           // Deep copy population with matching attributes but different interface

--- a/src/calculation/MeasureReportBuilder.ts
+++ b/src/calculation/MeasureReportBuilder.ts
@@ -233,10 +233,8 @@ export default class MeasureReportBuilder<T extends PopulationGroupResult> exten
             er.stratifierResults?.forEach(stratResults => {
               // only add to results if this episode is in the strata
               if (stratResults.result) {
-                // THIS IS WHERE THE ERROR IS HAPPENING
-                // measure may not have s.code[0].text, where else can we get this strataCode?
-                // also in the case that s.code.text doesn't exist, the strata code is set to strata-index
-                // in DetailedResultsBuilder.ts so then strata would never be defined and this would error out
+                // the strataCode has the potential to be a couple of things, either s.code[0].text (previous measures)
+                // or s.id (newer measures)
                 const strata: MeasureReportGroupStratifier | undefined =
                   group.stratifier?.find(s => s.code && s.code[0]?.text === stratResults.strataCode) ||
                   group.stratifier?.find(s => s.id && s.id === stratResults.strataCode);
@@ -345,12 +343,6 @@ export default class MeasureReportBuilder<T extends PopulationGroupResult> exten
         if (!pop.count) pop.count = 0;
         pop.count += pr.result ? 1 : 0;
       }
-      // I don't think we need to throw an error here anymore
-      // } else {
-      //   throw new UnexpectedProperty(
-      //     `Population ${pr.populationType} in stratum ${stratum.id} not found in measure report.`
-      //   );
-      // }
     }
   }
 

--- a/src/calculation/MeasureReportBuilder.ts
+++ b/src/calculation/MeasureReportBuilder.ts
@@ -9,6 +9,7 @@ import {
 import { UnexpectedProperty, UnsupportedProperty } from '../types/errors/CustomErrors';
 import { isDetailedResult } from '../helpers/DetailedResultsHelpers';
 import { AbstractMeasureReportBuilder } from './AbstractMeasureReportBuilder';
+import { MeasureReportGroupStratifier } from 'fhir/r4';
 
 export default class MeasureReportBuilder<T extends PopulationGroupResult> extends AbstractMeasureReportBuilder<T> {
   report: fhir4.MeasureReport;
@@ -131,12 +132,27 @@ export default class MeasureReportBuilder<T extends PopulationGroupResult> exten
         measureGroup.stratifier.forEach(s => {
           const reportStratifier = <fhir4.MeasureReportGroupStratifier>{};
           reportStratifier.code = s.code ? [s.code] : [];
+          reportStratifier.id = s.id ? s.id : '';
           const strat = <fhir4.MeasureReportGroupStratifierStratum>{};
           // use existing populations, but reduce count as appropriate
           // Deep copy population with matching attributes but different interface
-          strat.population = <fhir4.MeasureReportGroupStratifierStratumPopulation[]>(
-            JSON.parse(JSON.stringify(group.population))
+          // if a stratifier has a cqfm-appliesTo extension, then we only want to
+          // include that population. If none is specified, the stratification applies
+          // to all populations in a group
+          const appliesToExtension = s.extension?.find(
+            e => e.url === 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-appliesTo'
           );
+          if (appliesToExtension) {
+            const popCode = appliesToExtension.valueCodeableConcept?.coding?.[0].code;
+            const matchingPop = group.population?.find(p => p.code?.coding?.[0].code === popCode);
+            strat.population = <fhir4.MeasureReportGroupStratifierStratumPopulation[]>(
+              JSON.parse(JSON.stringify([matchingPop]))
+            );
+          } else {
+            strat.population = <fhir4.MeasureReportGroupStratifierStratumPopulation[]>(
+              JSON.parse(JSON.stringify(group.population))
+            );
+          }
 
           reportStratifier.stratum = [strat];
           group.stratifier?.push(reportStratifier);
@@ -217,7 +233,13 @@ export default class MeasureReportBuilder<T extends PopulationGroupResult> exten
             er.stratifierResults?.forEach(stratResults => {
               // only add to results if this episode is in the strata
               if (stratResults.result) {
-                const strata = group.stratifier?.find(s => s.code && s.code[0].text === stratResults.strataCode);
+                // THIS IS WHERE THE ERROR IS HAPPENING
+                // measure may not have s.code[0].text, where else can we get this strataCode?
+                // also in the case that s.code.text doesn't exist, the strata code is set to strata-index
+                // in DetailedResultsBuilder.ts so then strata would never be defined and this would error out
+                const strata: MeasureReportGroupStratifier | undefined =
+                  group.stratifier?.find(s => s.code && s.code[0]?.text === stratResults.strataCode) ||
+                  group.stratifier?.find(s => s.id && s.id === stratResults.strataCode);
                 const stratum = strata?.stratum?.[0];
                 if (stratum) {
                   er.populationResults?.forEach(pr => {
@@ -255,7 +277,10 @@ export default class MeasureReportBuilder<T extends PopulationGroupResult> exten
           groupResults.stratifierResults?.forEach(stratResults => {
             // only add to results if this patient is in the strata
             if (stratResults.result) {
-              const strata = group.stratifier?.find(s => s.code && s.code[0].text === stratResults.strataCode);
+              // the strataCode has the potential to be a couple of things, either s,code
+              const strata: MeasureReportGroupStratifier | undefined =
+                group.stratifier?.find(s => s.code && s.code[0]?.text === stratResults.strataCode) ||
+                group.stratifier?.find(s => s.id && s.id === stratResults.strataCode);
               const stratum = strata?.stratum?.[0];
               if (stratum) {
                 groupResults.populationResults?.forEach(pr => {
@@ -318,11 +343,13 @@ export default class MeasureReportBuilder<T extends PopulationGroupResult> exten
         // add to pop count creating it if not already created.
         if (!pop.count) pop.count = 0;
         pop.count += pr.result ? 1 : 0;
-      } else {
-        throw new UnexpectedProperty(
-          `Population ${pr.populationType} in stratum ${stratum.id} not found in measure report.`
-        );
       }
+      // I don't think we need to throw an error here anymore
+      // } else {
+      //   throw new UnexpectedProperty(
+      //     `Population ${pr.populationType} in stratum ${stratum.id} not found in measure report.`
+      //   );
+      // }
     }
   }
 

--- a/src/calculation/MeasureReportBuilder.ts
+++ b/src/calculation/MeasureReportBuilder.ts
@@ -241,7 +241,7 @@ export default class MeasureReportBuilder<T extends PopulationGroupResult> exten
                 // or s.id (newer measures)
                 const strata: MeasureReportGroupStratifier | undefined =
                   group.stratifier?.find(s => s.code && s.code[0]?.text === stratResults.strataCode) ||
-                  group.stratifier?.find(s => s.id && s.id === stratResults.strataCode);
+                  group.stratifier?.find(s => s.id === stratResults.strataCode);
                 const stratum = strata?.stratum?.[0];
                 if (stratum) {
                   er.populationResults?.forEach(pr => {
@@ -283,7 +283,7 @@ export default class MeasureReportBuilder<T extends PopulationGroupResult> exten
               // or s.id (newer measures)
               const strata: MeasureReportGroupStratifier | undefined =
                 group.stratifier?.find(s => s.code && s.code[0]?.text === stratResults.strataCode) ||
-                group.stratifier?.find(s => s.id && s.id === stratResults.strataCode);
+                group.stratifier?.find(s => s.id === stratResults.strataCode);
               const stratum = strata?.stratum?.[0];
               if (stratum) {
                 groupResults.populationResults?.forEach(pr => {

--- a/test/unit/MeasureReportBuilder.test.ts
+++ b/test/unit/MeasureReportBuilder.test.ts
@@ -284,7 +284,126 @@ const propWithStratExecutionResults: ExecutionResult<DetailedPopulationGroupResu
   }
 ];
 
+const propWithStratExecutionResultsTwoPatients: ExecutionResult<DetailedPopulationGroupResult>[] = [
+  {
+    patientId: patient1Id,
+    detailedResults: [
+      {
+        groupId: 'group-1',
+        statementResults: [],
+        populationResults: [
+          {
+            populationType: PopulationType.NUMER,
+            criteriaExpression: 'Numerator',
+            result: false
+          },
+          {
+            populationType: PopulationType.DENOM,
+            criteriaExpression: 'Denominator',
+            result: true
+          },
+          {
+            populationType: PopulationType.IPP,
+            criteriaExpression: 'Initial Population',
+            result: true
+          },
+          {
+            populationType: PopulationType.DENEX,
+            criteriaExpression: 'Denominator Exclusion',
+            result: false
+          }
+        ],
+        stratifierResults: [
+          {
+            strataCode: '93f5f1c7-8638-40a4-a596-8b5831599209',
+            result: false,
+            strataId: '93f5f1c7-8638-40a4-a596-8b5831599209'
+          },
+          {
+            strataCode: '5baf37c7-8887-4576-837e-ea20a8938282',
+            result: false,
+            strataId: '5baf37c7-8887-4576-837e-ea20a8938282'
+          },
+          {
+            strataCode: '125b3d95-2d00-455f-8a6e-d53614a2a50e',
+            result: false,
+            strataId: '125b3d95-2d00-455f-8a6e-d53614a2a50e'
+          },
+          {
+            strataCode: 'c06647b9-e134-4189-858d-80cee23c0f8d',
+            result: false,
+            strataId: 'c06647b9-e134-4189-858d-80cee23c0f8d'
+          }
+        ],
+        html: 'example-html'
+      }
+    ]
+  },
+  {
+    patientId: patient2Id,
+    detailedResults: [
+      {
+        groupId: 'group-1',
+        statementResults: [],
+        populationResults: [
+          {
+            populationType: PopulationType.NUMER,
+            criteriaExpression: 'Numerator',
+            result: false
+          },
+          {
+            populationType: PopulationType.DENOM,
+            criteriaExpression: 'Denominator',
+            result: true
+          },
+          {
+            populationType: PopulationType.IPP,
+            criteriaExpression: 'Initial Population',
+            result: true
+          },
+          {
+            populationType: PopulationType.DENEX,
+            criteriaExpression: 'Denominator Exclusion',
+            result: false
+          }
+        ],
+        stratifierResults: [
+          {
+            strataCode: '93f5f1c7-8638-40a4-a596-8b5831599209',
+            result: false,
+            strataId: '93f5f1c7-8638-40a4-a596-8b5831599209'
+          },
+          {
+            strataCode: '5baf37c7-8887-4576-837e-ea20a8938282',
+            result: false,
+            strataId: '5baf37c7-8887-4576-837e-ea20a8938282'
+          },
+          {
+            strataCode: '125b3d95-2d00-455f-8a6e-d53614a2a50e',
+            result: false,
+            strataId: '125b3d95-2d00-455f-8a6e-d53614a2a50e'
+          },
+          {
+            strataCode: 'c06647b9-e134-4189-858d-80cee23c0f8d',
+            result: false,
+            strataId: 'c06647b9-e134-4189-858d-80cee23c0f8d'
+          }
+        ],
+        html: 'example-html'
+      }
+    ]
+  }
+];
+
 const calculationOptions: CalculationOptions = {
+  measurementPeriodStart: '2021-01-01',
+  measurementPeriodEnd: '2021-12-31',
+  calculateHTML: true,
+  calculateSDEs: true
+};
+
+const calculationOptionsWithSummary: CalculationOptions = {
+  reportType: 'summary',
   measurementPeriodStart: '2021-01-01',
   measurementPeriodEnd: '2021-12-31',
   calculateHTML: true,
@@ -412,6 +531,44 @@ describe('MeasureReportBuilder Static', () => {
       result!.stratifierResults!.forEach(sr => {
         const stratifierResult = group.stratifier?.find(s => s.id === sr.strataId);
         expect(stratifierResult).toBeDefined();
+        expect(stratifierResult!.stratum?.[0].population?.length).toEqual(1);
+        expect(stratifierResult!.stratum?.[0].measureScore?.value).toEqual(0);
+      });
+    });
+  });
+
+  describe('Measure Report from Proportion Measure with stratifiers and two patient results', () => {
+    let measureReports: fhir4.MeasureReport[];
+    beforeAll(() => {
+      measureReports = MeasureReportBuilder.buildMeasureReports(
+        propWithStratMeasureBundle,
+        propWithStratExecutionResultsTwoPatients,
+        calculationOptionsWithSummary
+      );
+    });
+
+    test('should contain proper stratifierResults', () => {
+      const [mr] = measureReports;
+      expect(mr.group).toBeDefined();
+      expect(mr.group).toHaveLength(1);
+
+      const [group] = mr.group!;
+      const result = propWithStratExecutionResults[0].detailedResults?.[0];
+
+      expect(group.id).toEqual(result!.groupId);
+      expect(group.measureScore).toBeDefined();
+      expect(group.population).toBeDefined();
+
+      result!.populationResults!.forEach(pr => {
+        const populationResult = group.population?.find(p => p.code?.coding?.[0].code === pr.populationType);
+        expect(populationResult).toBeDefined();
+        expect(populationResult!.count).toEqual(pr.result === true ? 1 : 0);
+      });
+
+      result!.stratifierResults!.forEach(sr => {
+        const stratifierResult = group.stratifier?.find(s => s.id === sr.strataId);
+        expect(stratifierResult).toBeDefined();
+        expect(stratifierResult!.stratum?.[0].population?.length).toEqual(1);
         expect(stratifierResult!.stratum?.[0].measureScore?.value).toEqual(0);
       });
     });

--- a/test/unit/MeasureReportBuilder.test.ts
+++ b/test/unit/MeasureReportBuilder.test.ts
@@ -3,7 +3,12 @@
 import { PatientSource } from 'cql-exec-fhir';
 import MeasureReportBuilder from '../../src/calculation/MeasureReportBuilder';
 import { getJSONFixture } from './helpers/testHelpers';
-import { ExecutionResult, CalculationOptions, DetailedPopulationGroupResult } from '../../src/types/Calculator';
+import {
+  ExecutionResult,
+  CalculationOptions,
+  DetailedPopulationGroupResult,
+  PopulationGroupResult
+} from '../../src/types/Calculator';
 import { PopulationType } from '../../src/types/Enums';
 
 const patient1 = getJSONFixture(
@@ -284,126 +289,7 @@ const propWithStratExecutionResults: ExecutionResult<DetailedPopulationGroupResu
   }
 ];
 
-const propWithStratExecutionResultsTwoPatients: ExecutionResult<DetailedPopulationGroupResult>[] = [
-  {
-    patientId: patient1Id,
-    detailedResults: [
-      {
-        groupId: 'group-1',
-        statementResults: [],
-        populationResults: [
-          {
-            populationType: PopulationType.NUMER,
-            criteriaExpression: 'Numerator',
-            result: false
-          },
-          {
-            populationType: PopulationType.DENOM,
-            criteriaExpression: 'Denominator',
-            result: true
-          },
-          {
-            populationType: PopulationType.IPP,
-            criteriaExpression: 'Initial Population',
-            result: true
-          },
-          {
-            populationType: PopulationType.DENEX,
-            criteriaExpression: 'Denominator Exclusion',
-            result: false
-          }
-        ],
-        stratifierResults: [
-          {
-            strataCode: '93f5f1c7-8638-40a4-a596-8b5831599209',
-            result: false,
-            strataId: '93f5f1c7-8638-40a4-a596-8b5831599209'
-          },
-          {
-            strataCode: '5baf37c7-8887-4576-837e-ea20a8938282',
-            result: false,
-            strataId: '5baf37c7-8887-4576-837e-ea20a8938282'
-          },
-          {
-            strataCode: '125b3d95-2d00-455f-8a6e-d53614a2a50e',
-            result: false,
-            strataId: '125b3d95-2d00-455f-8a6e-d53614a2a50e'
-          },
-          {
-            strataCode: 'c06647b9-e134-4189-858d-80cee23c0f8d',
-            result: false,
-            strataId: 'c06647b9-e134-4189-858d-80cee23c0f8d'
-          }
-        ],
-        html: 'example-html'
-      }
-    ]
-  },
-  {
-    patientId: patient2Id,
-    detailedResults: [
-      {
-        groupId: 'group-1',
-        statementResults: [],
-        populationResults: [
-          {
-            populationType: PopulationType.NUMER,
-            criteriaExpression: 'Numerator',
-            result: false
-          },
-          {
-            populationType: PopulationType.DENOM,
-            criteriaExpression: 'Denominator',
-            result: true
-          },
-          {
-            populationType: PopulationType.IPP,
-            criteriaExpression: 'Initial Population',
-            result: true
-          },
-          {
-            populationType: PopulationType.DENEX,
-            criteriaExpression: 'Denominator Exclusion',
-            result: false
-          }
-        ],
-        stratifierResults: [
-          {
-            strataCode: '93f5f1c7-8638-40a4-a596-8b5831599209',
-            result: false,
-            strataId: '93f5f1c7-8638-40a4-a596-8b5831599209'
-          },
-          {
-            strataCode: '5baf37c7-8887-4576-837e-ea20a8938282',
-            result: false,
-            strataId: '5baf37c7-8887-4576-837e-ea20a8938282'
-          },
-          {
-            strataCode: '125b3d95-2d00-455f-8a6e-d53614a2a50e',
-            result: false,
-            strataId: '125b3d95-2d00-455f-8a6e-d53614a2a50e'
-          },
-          {
-            strataCode: 'c06647b9-e134-4189-858d-80cee23c0f8d',
-            result: false,
-            strataId: 'c06647b9-e134-4189-858d-80cee23c0f8d'
-          }
-        ],
-        html: 'example-html'
-      }
-    ]
-  }
-];
-
 const calculationOptions: CalculationOptions = {
-  measurementPeriodStart: '2021-01-01',
-  measurementPeriodEnd: '2021-12-31',
-  calculateHTML: true,
-  calculateSDEs: true
-};
-
-const calculationOptionsWithSummary: CalculationOptions = {
-  reportType: 'summary',
   measurementPeriodStart: '2021-01-01',
   measurementPeriodEnd: '2021-12-31',
   calculateHTML: true,
@@ -538,39 +424,61 @@ describe('MeasureReportBuilder Static', () => {
   });
 
   describe('Measure Report from Proportion Measure with stratifiers and two patient results', () => {
-    let measureReports: fhir4.MeasureReport[];
+    let builder: MeasureReportBuilder<PopulationGroupResult>;
     beforeAll(() => {
-      measureReports = MeasureReportBuilder.buildMeasureReports(
-        propWithStratMeasureBundle,
-        propWithStratExecutionResultsTwoPatients,
-        calculationOptionsWithSummary
-      );
+      builder = new MeasureReportBuilder(propWithStratMeasure, {
+        reportType: 'summary',
+        measurementPeriodStart: '2021-01-01',
+        measurementPeriodEnd: '2021-12-31'
+      });
+
+      builder.addPatientResults({
+        patientId: patient1Id,
+        detailedResults: [
+          {
+            groupId: 'group-1',
+            stratifierResults: [
+              {
+                strataCode: '93f5f1c7-8638-40a4-a596-8b5831599209',
+                result: false,
+                strataId: '93f5f1c7-8638-40a4-a596-8b5831599209'
+              },
+              {
+                strataCode: '5baf37c7-8887-4576-837e-ea20a8938282',
+                result: false,
+                strataId: '5baf37c7-8887-4576-837e-ea20a8938282'
+              }
+            ]
+          }
+        ]
+      });
+
+      builder.addPatientResults({
+        patientId: patient2Id,
+        detailedResults: [
+          {
+            groupId: 'group-1',
+            stratifierResults: [
+              {
+                strataCode: '125b3d95-2d00-455f-8a6e-d53614a2a50e',
+                result: false,
+                strataId: '125b3d95-2d00-455f-8a6e-d53614a2a50e'
+              },
+              {
+                strataCode: 'c06647b9-e134-4189-858d-80cee23c0f8d',
+                result: false,
+                strataId: 'c06647b9-e134-4189-858d-80cee23c0f8d'
+              }
+            ]
+          }
+        ]
+      });
     });
 
-    test('should contain proper stratifierResults', () => {
-      const [mr] = measureReports;
-      expect(mr.group).toBeDefined();
-      expect(mr.group).toHaveLength(1);
-
-      const [group] = mr.group!;
-      const result = propWithStratExecutionResults[0].detailedResults?.[0];
-
-      expect(group.id).toEqual(result!.groupId);
-      expect(group.measureScore).toBeDefined();
-      expect(group.population).toBeDefined();
-
-      result!.populationResults!.forEach(pr => {
-        const populationResult = group.population?.find(p => p.code?.coding?.[0].code === pr.populationType);
-        expect(populationResult).toBeDefined();
-        expect(populationResult!.count).toEqual(pr.result === true ? 1 : 0);
-      });
-
-      result!.stratifierResults!.forEach(sr => {
-        const stratifierResult = group.stratifier?.find(s => s.id === sr.strataId);
-        expect(stratifierResult).toBeDefined();
-        expect(stratifierResult!.stratum?.[0].population?.length).toEqual(1);
-        expect(stratifierResult!.stratum?.[0].measureScore?.value).toEqual(0);
-      });
+    test('should generate a summary MeasureReport whose stratifierResults only contain one population in the stratum', () => {
+      const { report } = builder;
+      expect(report).toBeDefined();
+      expect(report.group?.[0].stratifier?.[0].stratum?.[0].population?.length).toEqual(1);
     });
   });
 

--- a/test/unit/MeasureReportBuilder.test.ts
+++ b/test/unit/MeasureReportBuilder.test.ts
@@ -20,6 +20,7 @@ const patient1Id = '3413754c-73f0-4559-9f67-df8e593ce7e1';
 const patient2Id = '08fc9439-b7ff-4309-b409-4d143388594c';
 
 const simpleMeasure = getJSONFixture('measure/simple-measure.json') as fhir4.Measure;
+const propWithStratMeasure = getJSONFixture('measure/proportion-measure-with-stratifiers.json') as fhir4.Measure;
 const ratioMeasure = getJSONFixture('measure/ratio-measure.json') as fhir4.Measure;
 const cvMeasure = getJSONFixture('measure/cv-measure.json') as fhir4.Measure;
 const cvMeasureScoringOnGroup = getJSONFixture('measure/group-score-cv-measure.json');
@@ -36,6 +37,7 @@ function buildTestMeasureBundle(measure: fhir4.Measure): fhir4.Bundle {
   };
 }
 const simpleMeasureBundle = buildTestMeasureBundle(simpleMeasure);
+const propWithStratMeasureBundle = buildTestMeasureBundle(propWithStratMeasure);
 const ratioMeasureBundle = buildTestMeasureBundle(ratioMeasure);
 const cvMeasureBundle = buildTestMeasureBundle(cvMeasure);
 
@@ -225,6 +227,63 @@ const cvExecutionResults: ExecutionResult<DetailedPopulationGroupResult>[] = [
   }
 ];
 
+const propWithStratExecutionResults: ExecutionResult<DetailedPopulationGroupResult>[] = [
+  {
+    patientId: patient1Id,
+    detailedResults: [
+      {
+        groupId: 'group-1',
+        statementResults: [],
+        populationResults: [
+          {
+            populationType: PopulationType.NUMER,
+            criteriaExpression: 'Numerator',
+            result: false
+          },
+          {
+            populationType: PopulationType.DENOM,
+            criteriaExpression: 'Denominator',
+            result: true
+          },
+          {
+            populationType: PopulationType.IPP,
+            criteriaExpression: 'Initial Population',
+            result: true
+          },
+          {
+            populationType: PopulationType.DENEX,
+            criteriaExpression: 'Denominator Exclusion',
+            result: false
+          }
+        ],
+        stratifierResults: [
+          {
+            strataCode: '93f5f1c7-8638-40a4-a596-8b5831599209',
+            result: false,
+            strataId: '93f5f1c7-8638-40a4-a596-8b5831599209'
+          },
+          {
+            strataCode: '5baf37c7-8887-4576-837e-ea20a8938282',
+            result: false,
+            strataId: '5baf37c7-8887-4576-837e-ea20a8938282'
+          },
+          {
+            strataCode: '125b3d95-2d00-455f-8a6e-d53614a2a50e',
+            result: false,
+            strataId: '125b3d95-2d00-455f-8a6e-d53614a2a50e'
+          },
+          {
+            strataCode: 'c06647b9-e134-4189-858d-80cee23c0f8d',
+            result: false,
+            strataId: 'c06647b9-e134-4189-858d-80cee23c0f8d'
+          }
+        ],
+        html: 'example-html'
+      }
+    ]
+  }
+];
+
 const calculationOptions: CalculationOptions = {
   measurementPeriodStart: '2021-01-01',
   measurementPeriodEnd: '2021-12-31',
@@ -312,6 +371,48 @@ describe('MeasureReportBuilder Static', () => {
             display: result!.rawResult.display
           }
         ])
+      });
+    });
+  });
+
+  describe('Measure Report from Proportion Measure with stratifiers', () => {
+    let measureReports: fhir4.MeasureReport[];
+    beforeAll(() => {
+      measureReports = MeasureReportBuilder.buildMeasureReports(
+        propWithStratMeasureBundle,
+        propWithStratExecutionResults,
+        calculationOptions
+      );
+    });
+
+    test('should generate 1 result', () => {
+      expect(measureReports).toBeDefined();
+      expect(measureReports).toHaveLength(1);
+    });
+
+    test('should contain proper stratifierResults', () => {
+      const [mr] = measureReports;
+
+      expect(mr.group).toBeDefined();
+      expect(mr.group).toHaveLength(1);
+
+      const [group] = mr.group!;
+      const result = propWithStratExecutionResults[0].detailedResults?.[0];
+
+      expect(group.id).toEqual(result!.groupId);
+      expect(group.measureScore).toBeDefined();
+      expect(group.population).toBeDefined();
+
+      result!.populationResults!.forEach(pr => {
+        const populationResult = group.population?.find(p => p.code?.coding?.[0].code === pr.populationType);
+        expect(populationResult).toBeDefined();
+        expect(populationResult!.count).toEqual(pr.result === true ? 1 : 0);
+      });
+
+      result!.stratifierResults!.forEach(sr => {
+        const stratifierResult = group.stratifier?.find(s => s.id === sr.strataId);
+        expect(stratifierResult).toBeDefined();
+        expect(stratifierResult!.stratum?.[0].measureScore?.value).toEqual(0);
       });
     });
   });

--- a/test/unit/fixtures/measure/proportion-measure-with-stratifiers.json
+++ b/test/unit/fixtures/measure/proportion-measure-with-stratifiers.json
@@ -1,0 +1,193 @@
+{
+  "resourceType": "Measure",
+  "id": "example",
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis",
+      "valueCode": "boolean"
+    }
+  ],
+  "status": "active",
+  "url": "http://example.com/example",
+  "identifier": [
+    {
+      "system": "http://example.com",
+      "value": "example"
+    }
+  ],
+  "name": "Example Measure",
+  "effectivePeriod": {
+    "start": "2021-01-01",
+    "end": "2021-12-31"
+  },
+  "library": ["Library/example"],
+  "scoring": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/measure-scoring",
+        "code": "proportion"
+      }
+    ]
+  },
+  "improvementNotation": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/measure-improvement-notation",
+        "code": "increase"
+      }
+    ]
+  },
+  "group": [
+    {
+      "id": "group-1",
+      "population": [
+        {
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "initial-population",
+                "display": "Initial Population"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql",
+            "expression": "Initial Population"
+          }
+        },
+        {
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "numerator",
+                "display": "Numerator"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql",
+            "expression": "Numerator"
+          }
+        },
+        {
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "denominator",
+                "display": "Denominator"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql",
+            "expression": "Denominator"
+          }
+        },
+        {
+          "code": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                "code": "denominator-exclusion",
+                "display": "Denominator Exclusion"
+              }
+            ]
+          },
+          "criteria": {
+            "language": "text/cql",
+            "expression": "Denominator Exclusion"
+          }
+        }
+      ],
+      "stratifier": [
+        {
+          "id": "93f5f1c7-8638-40a4-a596-8b5831599209",
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-appliesTo",
+              "valueCodeableConcept": {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                    "code": "initial-population",
+                    "display": "Initial Population"
+                  }
+                ]
+              }
+            }
+          ],
+          "criteria": {
+            "language": "text/cql-identifier",
+            "expression": "Strat1"
+          }
+        },
+        {
+          "id": "5baf37c7-8887-4576-837e-ea20a8938282",
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-appliesTo",
+              "valueCodeableConcept": {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                    "code": "initial-population",
+                    "display": "Initial Population"
+                  }
+                ]
+              }
+            }
+          ],
+          "criteria": {
+            "language": "text/cql-identifier",
+            "expression": "Strat2"
+          }
+        },
+        {
+          "id": "125b3d95-2d00-455f-8a6e-d53614a2a50e",
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-appliesTo",
+              "valueCodeableConcept": {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                    "code": "denominator",
+                    "display": "Denominator"
+                  }
+                ]
+              }
+            }
+          ],
+          "criteria": {
+            "language": "text/cql-identifier",
+            "expression": "Strat1"
+          }
+        },
+        {
+          "id": "c06647b9-e134-4189-858d-80cee23c0f8d",
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-appliesTo",
+              "valueCodeableConcept": {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                    "code": "denominator",
+                    "display": "Denominator"
+                  }
+                ]
+              }
+            }
+          ],
+          "criteria": {
+            "language": "text/cql-identifier",
+            "expression": "Strat2"
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
# Summary
This PR does two things: fixes an error that was occurring when running calculateMeasureReports on measure bundles whose group.stratifiers did not have `code.text` and adds functionality in measure report calculation for stratifiers that have the [cqfm-appliesTo extension](https://hl7.org/fhir/us/cqfmeasures/STU4/StructureDefinition-cqfm-appliesTo.html).

## New behavior
Measure report calculation no longer errors out with the measure bundle provided in the most recent fqm-execution issue- stratifiers are now either identified with `s.code` OR `s.id`. Additionally, if a stratifier has a `cqfm-appliesTo` extension, then only that associated population is included on the `stratifier.population` array in the MeasureReport. If the extension is not present, then the stratifier applies to all populations in the group. This specification is described in the [CQFM Computable Measure Profile](https://hl7.org/fhir/us/cqfmeasures/STU4/StructureDefinition-computable-measure-cqfm.html).

## Code changes
- `src/calculation/DetailedResultsBuilder.ts` - use `strata.id` if `strata.code.text` does not exist
- `src/calculation/MeasureReportBuilder.ts` - use `id` when setting up the population groups in the Measure Report, add `cqfm-appliesTo` extension functionality
- `test/unit/MeasureReportBuilder.test.ts` - unit tests for stratifiers with `cqfm-appliesTo`
- `test/unit/fixtures/measure/proportion-measure-with-stratifiers.json` - test measure with stratifiers that have the `cqfm-appliesTo extension`

# Testing guidance
- `npm run check`
- `npm run test:integration` & regression testing 
- Run MeasureReports with the measure bundle and patient provided in the fqm-execution issue. There are a couple ways to do this, but I use the cli in the following command: `npm run cli -- reports -m <measureBundle> -p <patientBundle> --debug -o -s 2025-01-01 -e 2025-12-31 --trust-meta-profile true`