### PR TITLE
appliesResult to StratifierResult in detailed results output

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,6 +520,10 @@ fqm-execution reports -m /path/to/measure/bundle.json -p /path/to/patient1/bundl
 
 # Guides and Concepts
 
+## Stratification
+
+For Measures with
+
 ## Measures with Observation Functions
 
 For [Continuous Variable Measures](https://build.fhir.org/ig/HL7/cqf-measures/measure-conformance.html#continuous-variable-measure) and [Ratio Measures](https://build.fhir.org/ig/HL7/cqf-measures/measure-conformance.html#ratio-measures), some of the measure populations can have an associated "measure observation", which is a CQL function that will return some result based on some information present on the data during calculation. In the case of these measures, `fqm-execution` will include an `observations` property on the `populationResult` object for each measure observation population. This `observations` property

--- a/README.md
+++ b/README.md
@@ -522,7 +522,45 @@ fqm-execution reports -m /path/to/measure/bundle.json -p /path/to/patient1/bundl
 
 ## Stratification
 
-For Measures with
+The results for each stratifier on a Measure (if they exist) are reported on the DetailedResults array for each group. The StratifierResult object contains two result attributes: `result` and `appliesResult`. `result` is simply the raw result of the stratifier and `appliesResult` is the same unless that stratifier contains a [cqfm-appliesTo extension](https://hl7.org/fhir/us/cqfmeasures/STU4/StructureDefinition-cqfm-appliesTo.html). In the case that a stratifier applies to a specified population, the `appliesResult` is the result of the stratifier result AND the result of the specified population. The following is an example of what the DetailedResults would look like for a Measure whose single stratifier has a result of `true` but appliesTo the numerator population that has a result of `false`.
+
+```typescript
+[
+  {
+    patientId: 'patient-1',
+    detailedResults: [
+      {
+        groupId: 'group-1',
+        populationResults: [
+          {
+            populationType: 'initial-population',
+            criteriaExpression: 'Initial Population',
+            result: false
+          },
+          {
+            populationType: 'denominator',
+            criteriaExpression: 'Denominator',
+            result: false
+          },
+          {
+            populationType: 'numerator',
+            criteriaExpression: 'Numerator',
+            result: false
+          }
+        ],
+        stratifierResults: [
+          {
+            strataCode: 'strata-1',
+            result: true,
+            appliesResult: false,
+            strataId: 'strata-1'
+          }
+        ]
+      }
+    ]
+  }
+];
+```
 
 ## Measures with Observation Functions
 

--- a/src/calculation/DetailedResultsBuilder.ts
+++ b/src/calculation/DetailedResultsBuilder.ts
@@ -318,11 +318,13 @@ export function createPatientPopulationValues(
             popValue = patientResults[popCode];
           }
         }
-        const result = isStatementValueTruthy(value && popValue);
+        const result = isStatementValueTruthy(value);
+        const appliesResult = isStatementValueTruthy(value && popValue);
 
         stratifierResults?.push({
           strataCode: strata.code?.text ?? strata.id ?? `strata-${strataIndex++}`,
           result,
+          appliesResult,
           ...(strata.id ? { strataId: strata.id } : {})
         });
       }

--- a/src/calculation/DetailedResultsBuilder.ts
+++ b/src/calculation/DetailedResultsBuilder.ts
@@ -354,8 +354,7 @@ export function handleStratificationValues(
               popValue = populationResults.find(pr => pr.populationType === popCode)?.result ?? true;
             }
           }
-          console.log(popValue);
-          strataResult.appliesResult = isStatementValueTruthy(popValue && strataResult.result);
+          strataResult.appliesResult = popValue && strataResult.result;
         }
       }
     });

--- a/src/calculation/DetailedResultsBuilder.ts
+++ b/src/calculation/DetailedResultsBuilder.ts
@@ -482,6 +482,9 @@ export function createEpisodePopulationValues(
       populationGroup,
       measureScoringCode
     );
+    if (episodeResults.stratifierResults) {
+      handleStratificationValues(populationGroup, episodeResults.populationResults, episodeResults.stratifierResults);
+    }
   });
 
   // TODO: Remove any episode that don't fall in any populations or stratifications after the above code

--- a/src/calculation/DetailedResultsBuilder.ts
+++ b/src/calculation/DetailedResultsBuilder.ts
@@ -98,6 +98,7 @@ export function createPopulationValues(
             stratifierResults?.push({
               result: strat.result,
               strataCode: strat.strataCode,
+              appliesResult: strat.result,
               ...(strat.strataId ? { strataId: strat.strataId } : {})
             });
           }
@@ -318,6 +319,7 @@ export function createPatientPopulationValues(
         stratifierResults?.push({
           strataCode: strata.code?.text ?? strata.id ?? `strata-${strataIndex++}`,
           result,
+          appliesResult: result,
           ...(strata.id ? { strataId: strata.id } : {})
         });
       }
@@ -565,7 +567,8 @@ function createOrSetValueOfEpisodes(
               newEpisodeResults.stratifierResults?.push({
                 ...(strataId ? { strataId } : {}),
                 strataCode: newStrataCode,
-                result: newStrataCode === strataCode ? true : false
+                result: newStrataCode === strataCode ? true : false,
+                appliesResult: newStrataCode === strataCode ? true : false
               });
             });
           }

--- a/src/calculation/MeasureReportBuilder.ts
+++ b/src/calculation/MeasureReportBuilder.ts
@@ -140,23 +140,9 @@ export default class MeasureReportBuilder<T extends PopulationGroupResult> exten
           const strat = <fhir4.MeasureReportGroupStratifierStratum>{};
           // use existing populations, but reduce count as appropriate
           // Deep copy population with matching attributes but different interface
-          // if a stratifier has a cqfm-appliesTo extension, then we only want to
-          // include that population. If none is specified, the stratification applies
-          // to all populations in a group
-          const appliesToExtension = s.extension?.find(
-            e => e.url === 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-appliesTo'
+          strat.population = <fhir4.MeasureReportGroupStratifierStratumPopulation[]>(
+            JSON.parse(JSON.stringify(group.population))
           );
-          if (appliesToExtension) {
-            const popCode = appliesToExtension.valueCodeableConcept?.coding?.[0].code;
-            const matchingPop = group.population?.find(p => p.code?.coding?.[0].code === popCode);
-            strat.population = <fhir4.MeasureReportGroupStratifierStratumPopulation[]>(
-              JSON.parse(JSON.stringify([matchingPop]))
-            );
-          } else {
-            strat.population = <fhir4.MeasureReportGroupStratifierStratumPopulation[]>(
-              JSON.parse(JSON.stringify(group.population))
-            );
-          }
 
           reportStratifier.stratum = [strat];
           group.stratifier?.push(reportStratifier);
@@ -278,7 +264,7 @@ export default class MeasureReportBuilder<T extends PopulationGroupResult> exten
         if (group.stratifier) {
           groupResults.stratifierResults?.forEach(stratResults => {
             // only add to results if this patient is in the strata
-            if (stratResults.result) {
+            if (stratResults.appliesResult) {
               // the strataCode has the potential to be a couple of things, either s.code[0].text (previous measures)
               // or s.id (newer measures)
               const strata: MeasureReportGroupStratifier | undefined =

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -236,7 +236,7 @@ export interface StratifierResult {
    * result it appliesTo is true. False if not. Only implemented for
    * patient based measures currently.
    */
-  appliesResult?: boolean;
+  appliesResult: boolean;
   strataId?: string;
 }
 

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -231,6 +231,12 @@ export interface StratifierResult {
    * True if patient or episode is in stratifier. False if not.
    */
   result: boolean;
+  /**
+   * True if patient or episode is in stratifier AND the population
+   * result it appliesTo is true. False if not. Only implemented for
+   * patient based measures currently.
+   */
+  appliesResult?: boolean;
   strataId?: string;
 }
 

--- a/test/unit/DetailedResultsBuilder.test.ts
+++ b/test/unit/DetailedResultsBuilder.test.ts
@@ -1145,7 +1145,7 @@ describe('DetailedResultsBuilder', () => {
         'Denominator Exclusion': false,
         Numerator: false,
         'Numerator Exclusion': false,
-        strata1: true
+        strat1: true
       };
 
       const { stratifierResults } = DetailedResultsBuilder.createPatientPopulationValues(
@@ -1159,7 +1159,8 @@ describe('DetailedResultsBuilder', () => {
         expect.arrayContaining([
           expect.objectContaining({
             strataId: 'example-strata-id',
-            result: false
+            result: true,
+            appliesResult: false
           })
         ])
       );
@@ -1198,7 +1199,8 @@ describe('DetailedResultsBuilder', () => {
         expect.arrayContaining([
           expect.objectContaining({
             strataId: 'example-strata-id-2',
-            result: true
+            result: true,
+            appliesResult: true
           })
         ])
       );

--- a/test/unit/DetailedResultsBuilder.test.ts
+++ b/test/unit/DetailedResultsBuilder.test.ts
@@ -1152,6 +1152,7 @@ describe('DetailedResultsBuilder', () => {
         {
           strataCode: 'example-strata-id',
           result: true,
+          appliesResult: true,
           strataId: 'example-strata-id'
         }
       ];
@@ -1201,6 +1202,7 @@ describe('DetailedResultsBuilder', () => {
         {
           strataCode: 'example-strata-id',
           result: true,
+          appliesResult: true,
           strataId: 'example-strata-id'
         }
       ];

--- a/test/unit/MeasureReportBuilder.test.ts
+++ b/test/unit/MeasureReportBuilder.test.ts
@@ -265,21 +265,25 @@ const propWithStratExecutionResults: ExecutionResult<DetailedPopulationGroupResu
           {
             strataCode: '93f5f1c7-8638-40a4-a596-8b5831599209',
             result: false,
+            appliesResult: false,
             strataId: '93f5f1c7-8638-40a4-a596-8b5831599209'
           },
           {
             strataCode: '5baf37c7-8887-4576-837e-ea20a8938282',
             result: false,
+            appliesResult: false,
             strataId: '5baf37c7-8887-4576-837e-ea20a8938282'
           },
           {
             strataCode: '125b3d95-2d00-455f-8a6e-d53614a2a50e',
             result: false,
+            appliesResult: false,
             strataId: '125b3d95-2d00-455f-8a6e-d53614a2a50e'
           },
           {
             strataCode: 'c06647b9-e134-4189-858d-80cee23c0f8d',
             result: false,
+            appliesResult: false,
             strataId: 'c06647b9-e134-4189-858d-80cee23c0f8d'
           }
         ],
@@ -417,7 +421,7 @@ describe('MeasureReportBuilder Static', () => {
       result!.stratifierResults!.forEach(sr => {
         const stratifierResult = group.stratifier?.find(s => s.id === sr.strataId);
         expect(stratifierResult).toBeDefined();
-        expect(stratifierResult!.stratum?.[0].population?.length).toEqual(1);
+        expect(stratifierResult!.stratum?.[0].population?.length).toEqual(4);
         expect(stratifierResult!.stratum?.[0].measureScore?.value).toEqual(0);
       });
     });
@@ -441,11 +445,13 @@ describe('MeasureReportBuilder Static', () => {
               {
                 strataCode: '93f5f1c7-8638-40a4-a596-8b5831599209',
                 result: false,
+                appliesResult: false,
                 strataId: '93f5f1c7-8638-40a4-a596-8b5831599209'
               },
               {
                 strataCode: '5baf37c7-8887-4576-837e-ea20a8938282',
                 result: false,
+                appliesResult: false,
                 strataId: '5baf37c7-8887-4576-837e-ea20a8938282'
               }
             ]
@@ -462,11 +468,13 @@ describe('MeasureReportBuilder Static', () => {
               {
                 strataCode: '125b3d95-2d00-455f-8a6e-d53614a2a50e',
                 result: false,
+                appliesResult: false,
                 strataId: '125b3d95-2d00-455f-8a6e-d53614a2a50e'
               },
               {
                 strataCode: 'c06647b9-e134-4189-858d-80cee23c0f8d',
                 result: false,
+                appliesResult: false,
                 strataId: 'c06647b9-e134-4189-858d-80cee23c0f8d'
               }
             ]
@@ -475,10 +483,10 @@ describe('MeasureReportBuilder Static', () => {
       });
     });
 
-    test('should generate a summary MeasureReport whose stratifierResults only contain one population in the stratum', () => {
+    test('should generate a summary MeasureReport whose stratifierResults only contain all populations', () => {
       const { report } = builder;
       expect(report).toBeDefined();
-      expect(report.group?.[0].stratifier?.[0].stratum?.[0].population?.length).toEqual(1);
+      expect(report.group?.[0].stratifier?.[0].stratum?.[0].population?.length).toEqual(4);
     });
   });
 

--- a/test/unit/MeasureReportBuilder.test.ts
+++ b/test/unit/MeasureReportBuilder.test.ts
@@ -483,7 +483,7 @@ describe('MeasureReportBuilder Static', () => {
       });
     });
 
-    test('should generate a summary MeasureReport whose stratifierResults only contain all populations', () => {
+    test('should generate a summary MeasureReport whose stratifierResults contain all populations', () => {
       const { report } = builder;
       expect(report).toBeDefined();
       expect(report.group?.[0].stratifier?.[0].stratum?.[0].population?.length).toEqual(4);


### PR DESCRIPTION
# Summary
This PR adds an optional attribute to the `StratifierResult` interface so that we can report the result of a stratifier that includes an `appliesTo` extension for Patient-based Measures only. 

## New behavior
The [`appliesTo`](https://hl7.org/fhir/us/cqfmeasures/STU4/StructureDefinition-cqfm-appliesTo.html) extension indicates which population a stratifier should apply to. If it is included on a Measure.group.stratifier, we now report the result of the stratifier AND the result of the population it applies to on the `appliesResult` attribute on the StratifierResult. The previous `result` attribute remains as it was: simply the result of the stratifier. The DetailedResults now contain the raw stratifier result in result (like before) as well as the result of the stratifier with the population result it applies to taken into consideration in `appliesResult`. 

## Code changes
- `src/calculation/DetailedResultsBuilder.ts` - add AND logic of population result and stratifier result to appliesResult attribute of StratifierResults for patient based measures
- `src/types/Calculator.ts` - add optional appliesResult attribute to `StratifierResult` interface
- `test/unit/DetailedResultsBuilder.test.ts` - unit tests for described changes

# Testing guidance
- Run detailed results with the measure and patient bundles provided in #306 . This can be done in a variety of ways but I personally just the cli: `npm run cli -- detailed -m <path to mb> --p <path to patient bundle (I think the file they provide is in an array so just make sure to get rid of that)> -s 2025-01-01 -e 2025-12-31 --trust-meta-profile true -o --debug`
- Inspect the detailedResults.json. Make sure the stratifierResults.result are the same as before and the stratifierResults.appliesResult are correct based on the population result that stratifier applies to.
