### PR TITLE
Update cql-execution to 3.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1335,10 +1335,10 @@ The `./regression` directory is organized for internal calculation testing betwe
 -v, --verbose <boolean>                           Use verbose regression. Will print out diffs of failing JSON files with spacing (default: false)
 ```
 
-To run the regression testing script, in the `./regression` directory run:
+To run the regression testing script, in the `fqm-execution` root directory run:
 
 ```bash
-./run-regression
+./regression/run-regression.sh
 ```
 
 ### Data Requirements Testing

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "axios": "^0.21.1",
         "commander": "^6.1.0",
         "cql-exec-fhir": "^2.1.3",
-        "cql-execution": "^3.0.1",
+        "cql-execution": "^3.1.0",
         "handlebars": "^4.7.7",
         "lodash": "^4.17.21",
         "moment": "^2.29.4",
@@ -2163,12 +2163,13 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -2542,9 +2543,10 @@
       }
     },
     "node_modules/cql-execution": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.1.tgz",
-      "integrity": "sha512-RC6uxrzvrJImFvyKvYDNLdumCS7nufJobhz5abfV3ZeFxbPR6E2gqJcn0T2KxVh4y40+BqbSGABwgiFTEITCdQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.1.0.tgz",
+      "integrity": "sha512-49a0XnyKxB0xx7x74Pz2Qzvbhs/phNqYKrf3ezZkeldn44quBS0jQRyyoDQPVNaG0Wx/vP53lnMrSIR2qZbnRA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@lhncbc/ucum-lhc": "^4.1.3",
         "immutable": "^4.1.0",
@@ -3217,10 +3219,11 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -3888,6 +3891,7 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
@@ -6411,6 +6415,7 @@
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -8579,12 +8584,12 @@
       }
     },
     "braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "requires": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       }
     },
     "browserslist": {
@@ -8842,9 +8847,9 @@
       }
     },
     "cql-execution": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.1.tgz",
-      "integrity": "sha512-RC6uxrzvrJImFvyKvYDNLdumCS7nufJobhz5abfV3ZeFxbPR6E2gqJcn0T2KxVh4y40+BqbSGABwgiFTEITCdQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.1.0.tgz",
+      "integrity": "sha512-49a0XnyKxB0xx7x74Pz2Qzvbhs/phNqYKrf3ezZkeldn44quBS0jQRyyoDQPVNaG0Wx/vP53lnMrSIR2qZbnRA==",
       "requires": {
         "@lhncbc/ucum-lhc": "^4.1.3",
         "immutable": "^4.1.0",
@@ -9372,9 +9377,9 @@
       }
     },
     "fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "requires": {
         "to-regex-range": "^5.0.1"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "axios": "^0.21.1",
     "commander": "^6.1.0",
     "cql-exec-fhir": "^2.1.3",
-    "cql-execution": "^3.0.1",
+    "cql-execution": "^3.1.0",
     "handlebars": "^4.7.7",
     "lodash": "^4.17.21",
     "moment": "^2.29.4",
@@ -87,6 +87,10 @@
     {
       "name": "Lauren DiCristofaro",
       "email": "laurend@mitre.org"
+    },
+    {
+      "name": "Elsa Perelli",
+      "email": "eperelli@mitre.org"
     }
   ],
   "license": "Apache-2.0",


### PR DESCRIPTION
# Summary

Updates cql-execution to 3.1.0. Fixes a few npm audit concerns. Adds Elsa as a contributor.

## New behavior

`Implies` operator is now implemented in cql-execution.

## Code changes

None.

# Testing guidance