### PR TITLE
Coverage 3.14.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Library for calculating Electronic Clinical Quality Measures (eCQMs) written in 
 - [Recipes](#recipes)
   - [Displaying Highlighted HTML in a React App](#displaying-highlighted-html-in-a-react-app)
   - [Usage Within a FHIR Server](#usage-within-a-fhir-server)
+  - [Special Testing](#special-testing)
 - [Contributing](#contributing)
 - [License](#license)
 

--- a/src/calculation/ClauseResultsBuilder.ts
+++ b/src/calculation/ClauseResultsBuilder.ts
@@ -315,7 +315,7 @@ export function buildStatementAndClauseResults(
 
     if (includeClauseResults) {
       // create clause results for all localIds in this statement
-      const localIds = ClauseResultsHelpers.findAllLocalIdsInStatementByName(elmLibrary, statementResult.statementName);
+      const localIds = ClauseResultsHelpers.findLocalIdsInStatementByName(elmLibrary, statementResult.statementName);
       for (const localId in localIds) {
         const clause = localIds[localId];
         const rawClauseResult =

--- a/src/helpers/ClauseResultsHelpers.ts
+++ b/src/helpers/ClauseResultsHelpers.ts
@@ -68,13 +68,13 @@ export function findAllLocalIdsInStatementByName(libraryElm: ELM, statementName:
  * @param {object} annotation - all or a subset of the annotation structure to search
  * @return {Array} List of local ids in the annotation.
  */
-function findAnnotationLocalIds(annotation: any): any[] {
+function findAnnotationLocalIds(annotation: any): string[] {
   if (Array.isArray(annotation)) {
     return annotation.flatMap(ent => findAnnotationLocalIds(ent));
   } else if (typeof annotation === 'object') {
     return Object.entries(annotation).flatMap(ent => {
       // if key is r, return value, else recurse
-      if (ent[0] === 'r') return ent[1];
+      if (ent[0] === 'r') return ent[1] as string;
       return findAnnotationLocalIds(ent[1]);
     });
   }

--- a/src/helpers/ClauseResultsHelpers.ts
+++ b/src/helpers/ClauseResultsHelpers.ts
@@ -3,13 +3,13 @@ import { ELMFunctionRef } from '../types/ELMTypes';
 import { ELM, ELMBinaryExpression, ELMStatement } from '../types/ELMTypes';
 
 /**
- * Finds all localIds in a statement by its library and statement name.
+ * Finds all of the localIds that are needed for clause results for a single statement.
  * @public
  * @param {ELM} libraryElm - The library the statement belongs to.
  * @param {string} statementName - The statement name to search for.
- * @return {Hash} List of local ids in the statement.
+ * @return {Hash} List of result-relevant local ids in the statement.
  */
-export function findAllLocalIdsInStatementByName(libraryElm: ELM, statementName: string): any {
+export function findLocalIdsInStatementByName(libraryElm: ELM, statementName: string): any {
   // create place for aliases and their usages to be placed to be filled in later. Aliases and their usages (aka scope)
   // and returns do not have localIds in the elm but do in elm_annotations at a consistent calculable offset.
   // BE WARY of this calculable offset.
@@ -53,7 +53,7 @@ export function findAllLocalIdsInStatementByName(libraryElm: ELM, statementName:
   // find all localids in the annotation
   const allAnnotatedIds = findAnnotationLocalIds(statement?.annotation);
   // filter out local ids that aren't in the annotation
-  const annotatedLocalIds: { [key: string]: any } = {};
+  const annotatedLocalIds: Record<string, any> = {};
   for (const [key, value] of Object.entries(localIds)) {
     if (allAnnotatedIds.includes(key)) {
       annotatedLocalIds[key] = value;
@@ -63,7 +63,7 @@ export function findAllLocalIdsInStatementByName(libraryElm: ELM, statementName:
 }
 
 /**
- * Recursively finds just localIds that are in an annotation structure by pulling out all "r:"-keyed values
+ * Recursively finds localIds that are in an annotation structure by pulling out all "r:"-keyed values
  * @public
  * @param {object} annotation - all or a subset of the annotation structure to search
  * @return {Array} List of local ids in the annotation.

--- a/test/unit/ClauseResultsHelper.test.ts
+++ b/test/unit/ClauseResultsHelper.test.ts
@@ -34,6 +34,20 @@ describe('ClauseResultsHelpers', () => {
       expect(localIds[100]).not.toBeDefined();
     });
 
+    test('finds localIds for an not null operator', () => {
+      // ELM from test/unit/fixtures/cql/NotNull.cql, translated with 3.15.0 translator
+      const libraryElm: ELM = getJSONFixture('elm/3.15.0/NotNull.json');
+
+      const statementName = 'Not Null Clause';
+      const localIds = ClauseResultsHelpers.findAllLocalIdsInStatementByName(libraryElm, statementName);
+
+      // For the fixture loaded for this test it is known that the localId for the IsNull statement
+      // is 237, and the localId for the Not expression is 238. We want 237 to not be included because 238 is
+      // the correct id from the annotation.
+      expect(localIds[238]).toBeDefined();
+      expect(localIds[237]).not.toBeDefined();
+    });
+
     test('finds localIds for an ELM Binary Expression with a comparison operator with a literal', () => {
       // ELM from test/unit/fixtures/cql/comparisonWithLiteral.cql
       const libraryElm: ELM = getJSONFixture('elm/ComparisonWithLiteral.json');

--- a/test/unit/ClauseResultsHelper.test.ts
+++ b/test/unit/ClauseResultsHelper.test.ts
@@ -12,10 +12,10 @@ describe('ClauseResultsHelpers', () => {
       const localIds = ClauseResultsHelpers.findAllLocalIdsInStatementByName(libraryElm, statementName);
 
       // For the fixture loaded for this test it is known that the localId for the Equivalent statement
-      // is 23 and the localId for the Not expression is 24 but we want the Equivalent clause to take
-      // the result of the Not expression
-      expect(localIds[23]).toBeDefined();
-      expect(localIds[23]).toEqual({ localId: '23', sourceLocalId: '24' });
+      // is 23 and the localId for the Not expression is 24. We want 23 to not be included because 24 is
+      // the correct id from the annotation.
+      expect(localIds[23]).not.toBeDefined();
+      expect(localIds[24]).toBeDefined();
     });
 
     test('finds localIds for an Equal comparison operator that is wrapped in a Not expression', () => {
@@ -28,10 +28,10 @@ describe('ClauseResultsHelpers', () => {
       const localIds = ClauseResultsHelpers.findAllLocalIdsInStatementByName(libraryElm, statementName);
 
       // For the fixture loaded for this test it is known that the localId for the Equal statement
-      // is 100 and the localId for the Not expression is 23 but we want the Equal clause to take
-      // the result of the Not expression
-      expect(localIds[100]).toBeDefined();
-      expect(localIds[100]).toEqual({ localId: '100', sourceLocalId: '23' });
+      // is 100, and the localId for the Not expression is 23. We want 100 to not be included because 23 is
+      // the correct id from the annotation.
+      expect(localIds[23]).toBeDefined();
+      expect(localIds[100]).not.toBeDefined();
     });
 
     test('finds localIds for an ELM Binary Expression with a comparison operator with a literal', () => {

--- a/test/unit/ClauseResultsHelper.test.ts
+++ b/test/unit/ClauseResultsHelper.test.ts
@@ -3,13 +3,13 @@ import { ELM } from '../../src/types/ELMTypes';
 import { getJSONFixture } from './helpers/testHelpers';
 
 describe('ClauseResultsHelpers', () => {
-  describe('findAllLocalIdsInStatementByName', () => {
+  describe('findLocalIdsInStatementByName', () => {
     test('finds localIds for an Equivalent comparison operator that is wrapped in a Not expression', () => {
       // ELM from test/unit/fixtures/cql/NotEquivalent.cql
       const libraryElm: ELM = getJSONFixture('elm/NotEquivalent.json');
 
       const statementName = 'Not Equivalent Clause';
-      const localIds = ClauseResultsHelpers.findAllLocalIdsInStatementByName(libraryElm, statementName);
+      const localIds = ClauseResultsHelpers.findLocalIdsInStatementByName(libraryElm, statementName);
 
       // For the fixture loaded for this test it is known that the localId for the Equivalent statement
       // is 23 and the localId for the Not expression is 24. We want 23 to not be included because 24 is
@@ -25,7 +25,7 @@ describe('ClauseResultsHelpers', () => {
       const libraryElm: ELM = getJSONFixture('elm/NotEqual.json');
 
       const statementName = 'Not Equal Clause';
-      const localIds = ClauseResultsHelpers.findAllLocalIdsInStatementByName(libraryElm, statementName);
+      const localIds = ClauseResultsHelpers.findLocalIdsInStatementByName(libraryElm, statementName);
 
       // For the fixture loaded for this test it is known that the localId for the Equal statement
       // is 100, and the localId for the Not expression is 23. We want 100 to not be included because 23 is
@@ -34,12 +34,12 @@ describe('ClauseResultsHelpers', () => {
       expect(localIds[100]).not.toBeDefined();
     });
 
-    test('finds localIds for an not null operator', () => {
+    test('finds localIds for a not null operator', () => {
       // ELM from test/unit/fixtures/cql/NotNull.cql, translated with 3.15.0 translator
       const libraryElm: ELM = getJSONFixture('elm/3.15.0/NotNull.json');
 
       const statementName = 'Not Null Clause';
-      const localIds = ClauseResultsHelpers.findAllLocalIdsInStatementByName(libraryElm, statementName);
+      const localIds = ClauseResultsHelpers.findLocalIdsInStatementByName(libraryElm, statementName);
 
       // For the fixture loaded for this test it is known that the localId for the IsNull statement
       // is 237, and the localId for the Not expression is 238. We want 237 to not be included because 238 is
@@ -53,7 +53,7 @@ describe('ClauseResultsHelpers', () => {
       const libraryElm: ELM = getJSONFixture('elm/ComparisonWithLiteral.json');
 
       const statementName = 'ipop';
-      const localIds = ClauseResultsHelpers.findAllLocalIdsInStatementByName(libraryElm, statementName);
+      const localIds = ClauseResultsHelpers.findLocalIdsInStatementByName(libraryElm, statementName);
 
       // For the fixture loaded for this test it is known that the localId for the literal is 10 and
       // the localId for the comparison expression itself is 11 so the sourceLocalId for the literal
@@ -67,7 +67,7 @@ describe('ClauseResultsHelpers', () => {
       const libraryElm: ELM = getJSONFixture('elm/ComparisonWithoutLiteral.json');
 
       const statementName = 'ipop';
-      const localIds = ClauseResultsHelpers.findAllLocalIdsInStatementByName(libraryElm, statementName);
+      const localIds = ClauseResultsHelpers.findLocalIdsInStatementByName(libraryElm, statementName);
 
       // For the fixture loaded for this test it is known that the ELM Binary Expression does not have a literal
       // so the localId for the right side of the comparison should just be 12 and not have a sourceLocalId
@@ -78,7 +78,7 @@ describe('ClauseResultsHelpers', () => {
     test('finds localIds for case statement items and properly finds sourceLocalId for them', () => {
       // ELM from test/unit/elm/queries/CaseStatement.cql
       const libraryElm: ELM = getJSONFixture('elm/queries/CaseStatement.json');
-      const localIds = ClauseResultsHelpers.findAllLocalIdsInStatementByName(libraryElm, 'Case');
+      const localIds = ClauseResultsHelpers.findLocalIdsInStatementByName(libraryElm, 'Case');
 
       expect(localIds[11]).toEqual({ localId: '11', sourceLocalId: '9' });
       expect(localIds[17]).toEqual({ localId: '17', sourceLocalId: '15' });
@@ -87,7 +87,7 @@ describe('ClauseResultsHelpers', () => {
     test('finds localIds for null literals and properly sets isFalsyLiteral to true', () => {
       // ELM from test/unit/elm/queries/CaseStatement.cql
       const libraryElm: ELM = getJSONFixture('elm/queries/CaseStatement.json');
-      const localIds = ClauseResultsHelpers.findAllLocalIdsInStatementByName(libraryElm, 'Case');
+      const localIds = ClauseResultsHelpers.findLocalIdsInStatementByName(libraryElm, 'Case');
 
       expect(localIds[18]).toEqual({ localId: '18', isFalsyLiteral: true });
     });
@@ -95,7 +95,7 @@ describe('ClauseResultsHelpers', () => {
     test('finds localIds for false literals and properly sets isFalsyLiteral to true', () => {
       // ELM from test/unit/elm/queries/CaseStatement.cql
       const libraryElm: ELM = getJSONFixture('elm/queries/CaseStatement.json');
-      const localIds = ClauseResultsHelpers.findAllLocalIdsInStatementByName(libraryElm, 'Case');
+      const localIds = ClauseResultsHelpers.findLocalIdsInStatementByName(libraryElm, 'Case');
 
       expect(localIds[16]).toEqual({ localId: '16', isFalsyLiteral: true });
     });
@@ -108,7 +108,7 @@ describe('ClauseResultsHelpers', () => {
 
       // Find the localid for the specific statement with the global function ref.
       const statementName = 'Encounter with Principal Diagnosis and Age';
-      const localIds = ClauseResultsHelpers.findAllLocalIdsInStatementByName(libraryElm, statementName);
+      const localIds = ClauseResultsHelpers.findLocalIdsInStatementByName(libraryElm, statementName);
 
       // For the fixture loaded for this test it is known that the library reference is 49 and the functionRef itself is 55.
       expect(localIds[49]).toBeDefined();
@@ -122,7 +122,7 @@ describe('ClauseResultsHelpers', () => {
 
       // Find the localid for the specific statement with the global function ref.
       const statementName = 'Initial Population';
-      const localIds = ClauseResultsHelpers.findAllLocalIdsInStatementByName(libraryElm, statementName);
+      const localIds = ClauseResultsHelpers.findLocalIdsInStatementByName(libraryElm, statementName);
 
       // For the fixture loaded for this test it is known that the library reference is 109 and the functionRef itself is 110.
       expect(localIds[109]).toBeDefined();
@@ -136,7 +136,7 @@ describe('ClauseResultsHelpers', () => {
 
       // Find the localid for the specific statement with the global function ref.
       const statementName = 'Comfort Measures during Hospitalization';
-      const localIds = ClauseResultsHelpers.findAllLocalIdsInStatementByName(libraryElm, statementName);
+      const localIds = ClauseResultsHelpers.findLocalIdsInStatementByName(libraryElm, statementName);
 
       // For the fixture loaded for this test it is known that the library reference is 109 and the functionRef itself is 110.
       expect(localIds[42]).toBeDefined();
@@ -147,7 +147,7 @@ describe('ClauseResultsHelpers', () => {
       const libraryElm: ELM = getJSONFixture('elm/SimpleAliasUsage.json');
       const statementName = 'Some Encounter';
 
-      const localIds = ClauseResultsHelpers.findAllLocalIdsInStatementByName(libraryElm, statementName);
+      const localIds = ClauseResultsHelpers.findLocalIdsInStatementByName(libraryElm, statementName);
 
       // '8' is in the annotations but not in the ELM. We use '9' as the localId from the actual expression and subtract one from it
       expect(localIds['8']).toEqual({ localId: '8', sourceLocalId: '6' });
@@ -157,7 +157,7 @@ describe('ClauseResultsHelpers', () => {
       const libraryElm: ELM = getJSONFixture('elm/SimpleAliasFunctionRef.json');
       const statementName = 'Some Encounter';
 
-      const localIds = ClauseResultsHelpers.findAllLocalIdsInStatementByName(libraryElm, statementName);
+      const localIds = ClauseResultsHelpers.findLocalIdsInStatementByName(libraryElm, statementName);
 
       // '8' is in the annotations but not in the ELM. We use '9' as the localId from the actual expression and subtract one from it
       expect(localIds['8']).toEqual({ localId: '8', sourceLocalId: '6' });
@@ -167,7 +167,7 @@ describe('ClauseResultsHelpers', () => {
       const libraryElm: ELM = getJSONFixture('elm/queries/QICoreQuery.json');
       const statementName = 'Query';
 
-      const localIds = ClauseResultsHelpers.findAllLocalIdsInStatementByName(libraryElm, statementName);
+      const localIds = ClauseResultsHelpers.findLocalIdsInStatementByName(libraryElm, statementName);
 
       // '7' is in the annotations but not in the ELM. We use '8' as the localId from the actual expression and subtract one from it
       expect(localIds[7]).toBeDefined();

--- a/test/unit/fixtures/cql/NotNull.cql
+++ b/test/unit/fixtures/cql/NotNull.cql
@@ -1,0 +1,24 @@
+library Test
+
+using FHIR version '4.0.1'
+
+include FHIRHelpers version '4.0.1'
+include MATGlobalCommonFunctions version '5.0.000' called Global
+
+codesystem "EXAMPLE": 'http://example.com'
+codesystem "EXAMPLE-2": 'http://example.com/2'
+codesystem "ConditionClinicalStatusCodes": 'http://terminology.hl7.org/CodeSystem/condition-clinical'
+
+valueset "test-vs": 'http://example.com/test-vs'
+
+code "Active": 'active' from "ConditionClinicalStatusCodes"
+code "Recurrence": 'recurrence' from "ConditionClinicalStatusCodes"
+code "Relapse": 'relapse' from "ConditionClinicalStatusCodes"
+
+concept "Condition Active": { "Active", "Recurrence", "Relapse" } display 'Active'
+
+context Patient
+
+define "Not Null Clause":
+    [Condition: "test-vs"] C
+        where C.id is not null

--- a/test/unit/fixtures/elm/3.15.0/CaseStatement.json
+++ b/test/unit/fixtures/elm/3.15.0/CaseStatement.json
@@ -1,0 +1,521 @@
+{
+  "library": {
+    "localId": "0",
+    "annotation": [
+      {
+        "translatorVersion": "3.15.0",
+        "translatorOptions": "EnableAnnotations,EnableLocators",
+        "signatureLevel": "None",
+        "type": "CqlToElmInfo"
+      },
+      {
+        "type": "Annotation",
+        "s": {
+          "r": "219",
+          "s": [
+            {
+              "value": [
+                "",
+                "library Test"
+              ]
+            }
+          ]
+        }
+      }
+    ],
+    "identifier": {
+      "id": "Test"
+    },
+    "schemaIdentifier": {
+      "id": "urn:hl7-org:elm",
+      "version": "r1"
+    },
+    "usings": {
+      "def": [
+        {
+          "localId": "1",
+          "localIdentifier": "System",
+          "uri": "urn:hl7-org:elm-types:r1"
+        },
+        {
+          "localId": "206",
+          "locator": "3:1-3:26",
+          "localIdentifier": "FHIR",
+          "uri": "http://hl7.org/fhir",
+          "version": "4.0.1",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "206",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "using "
+                    ]
+                  },
+                  {
+                    "s": [
+                      {
+                        "value": [
+                          "FHIR"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " version '4.0.1'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "includes": {
+      "def": [
+        {
+          "localId": "207",
+          "locator": "5:1-5:35",
+          "localIdentifier": "FHIRHelpers",
+          "path": "FHIRHelpers",
+          "version": "4.0.1",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "207",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "include "
+                    ]
+                  },
+                  {
+                    "s": [
+                      {
+                        "value": [
+                          "FHIRHelpers"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " version ",
+                      "'4.0.1'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "contexts": {
+      "def": [
+        {
+          "localId": "211",
+          "locator": "7:1-7:15",
+          "name": "Patient"
+        }
+      ]
+    },
+    "statements": {
+      "def": [
+        {
+          "localId": "209",
+          "locator": "7:1-7:15",
+          "name": "Patient",
+          "context": "Patient",
+          "expression": {
+            "localId": "210",
+            "type": "SingletonFrom",
+            "signature": [],
+            "operand": {
+              "localId": "208",
+              "locator": "7:1-7:15",
+              "dataType": "{http://hl7.org/fhir}Patient",
+              "templateId": "http://hl7.org/fhir/StructureDefinition/Patient",
+              "type": "Retrieve",
+              "include": [],
+              "codeFilter": [],
+              "dateFilter": [],
+              "otherFilter": []
+            }
+          }
+        },
+        {
+          "localId": "213",
+          "locator": "9:1-10:24",
+          "name": "First Observation",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "213",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"First Observation\"",
+                      ":\n    "
+                    ]
+                  },
+                  {
+                    "r": "217",
+                    "s": [
+                      {
+                        "value": [
+                          "First",
+                          "("
+                        ]
+                      },
+                      {
+                        "r": "214",
+                        "s": [
+                          {
+                            "value": [
+                              "[",
+                              "Observation",
+                              "]"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          ")"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "217",
+            "locator": "10:5-10:24",
+            "type": "First",
+            "signature": [],
+            "source": {
+              "localId": "214",
+              "locator": "10:11-10:23",
+              "dataType": "{http://hl7.org/fhir}Observation",
+              "templateId": "http://hl7.org/fhir/StructureDefinition/Observation",
+              "type": "Retrieve",
+              "include": [],
+              "codeFilter": [],
+              "dateFilter": [],
+              "otherFilter": []
+            }
+          }
+        },
+        {
+          "localId": "219",
+          "locator": "12:1-17:7",
+          "name": "Case",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "219",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Case\"",
+                      ":\n    "
+                    ]
+                  },
+                  {
+                    "r": "220",
+                    "s": [
+                      {
+                        "value": [
+                          "case \n        "
+                        ]
+                      },
+                      {
+                        "r": "221",
+                        "s": [
+                          {
+                            "value": [
+                              "when "
+                            ]
+                          },
+                          {
+                            "r": "222",
+                            "s": [
+                              {
+                                "r": "224",
+                                "s": [
+                                  {
+                                    "r": "223",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "\"First Observation\""
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "."
+                                    ]
+                                  },
+                                  {
+                                    "r": "224",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "value"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "r": "225",
+                                "value": [
+                                  " ",
+                                  ">",
+                                  " ",
+                                  "10"
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "r": "228",
+                            "value": [
+                              " then ",
+                              "true"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "\n        "
+                        ]
+                      },
+                      {
+                        "r": "229",
+                        "s": [
+                          {
+                            "value": [
+                              "when "
+                            ]
+                          },
+                          {
+                            "r": "230",
+                            "s": [
+                              {
+                                "r": "232",
+                                "s": [
+                                  {
+                                    "r": "231",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "\"First Observation\""
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "."
+                                    ]
+                                  },
+                                  {
+                                    "r": "232",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "value"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "r": "233",
+                                "value": [
+                                  " ",
+                                  "<",
+                                  " ",
+                                  "10"
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "r": "236",
+                            "value": [
+                              " then ",
+                              "false"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "r": "237",
+                        "value": [
+                          "\n        else ",
+                          "null",
+                          "\n    end"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "220",
+            "locator": "13:5-17:7",
+            "type": "Case",
+            "caseItem": [
+              {
+                "localId": "221",
+                "locator": "14:9-14:53",
+                "when": {
+                  "localId": "222",
+                  "locator": "14:14-14:43",
+                  "type": "Greater",
+                  "signature": [],
+                  "operand": [
+                    {
+                      "localId": "227",
+                      "name": "ToInteger",
+                      "libraryName": "FHIRHelpers",
+                      "type": "FunctionRef",
+                      "signature": [],
+                      "operand": [
+                        {
+                          "localId": "226",
+                          "asType": "{http://hl7.org/fhir}integer",
+                          "type": "As",
+                          "signature": [],
+                          "operand": {
+                            "localId": "224",
+                            "locator": "14:14-14:38",
+                            "path": "value",
+                            "type": "Property",
+                            "source": {
+                              "localId": "223",
+                              "locator": "14:14-14:32",
+                              "name": "First Observation",
+                              "type": "ExpressionRef"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "localId": "225",
+                      "locator": "14:42-14:43",
+                      "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                      "value": "10",
+                      "type": "Literal"
+                    }
+                  ]
+                },
+                "then": {
+                  "localId": "228",
+                  "locator": "14:50-14:53",
+                  "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+                  "value": "true",
+                  "type": "Literal"
+                }
+              },
+              {
+                "localId": "229",
+                "locator": "15:9-15:54",
+                "when": {
+                  "localId": "230",
+                  "locator": "15:14-15:43",
+                  "type": "Less",
+                  "signature": [],
+                  "operand": [
+                    {
+                      "localId": "235",
+                      "name": "ToInteger",
+                      "libraryName": "FHIRHelpers",
+                      "type": "FunctionRef",
+                      "signature": [],
+                      "operand": [
+                        {
+                          "localId": "234",
+                          "asType": "{http://hl7.org/fhir}integer",
+                          "type": "As",
+                          "signature": [],
+                          "operand": {
+                            "localId": "232",
+                            "locator": "15:14-15:38",
+                            "path": "value",
+                            "type": "Property",
+                            "source": {
+                              "localId": "231",
+                              "locator": "15:14-15:32",
+                              "name": "First Observation",
+                              "type": "ExpressionRef"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "localId": "233",
+                      "locator": "15:42-15:43",
+                      "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                      "value": "10",
+                      "type": "Literal"
+                    }
+                  ]
+                },
+                "then": {
+                  "localId": "236",
+                  "locator": "15:50-15:54",
+                  "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+                  "value": "false",
+                  "type": "Literal"
+                }
+              }
+            ],
+            "else": {
+              "localId": "238",
+              "asType": "{urn:hl7-org:elm-types:r1}Boolean",
+              "type": "As",
+              "signature": [],
+              "operand": {
+                "localId": "237",
+                "locator": "16:14-16:17",
+                "type": "Null"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/test/unit/fixtures/elm/3.15.0/ComplexQueries.json
+++ b/test/unit/fixtures/elm/3.15.0/ComplexQueries.json
@@ -1,0 +1,5553 @@
+{
+  "library": {
+    "localId": "0",
+    "annotation": [
+      {
+        "translatorVersion": "3.15.0",
+        "translatorOptions": "EnableAnnotations,EnableLocators",
+        "signatureLevel": "None",
+        "type": "CqlToElmInfo"
+      },
+      {
+        "message": "The function FHIRHelpers.ToInterval has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToDateTime has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToString has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToInterval has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToDateTime has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToString has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToString has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToString has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToString has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "type": "Annotation",
+        "s": {
+          "r": "603",
+          "s": [
+            {
+              "value": [
+                "",
+                "library ComplexQueries version '0.0.1'"
+              ]
+            }
+          ]
+        }
+      }
+    ],
+    "identifier": {
+      "id": "ComplexQueries",
+      "version": "0.0.1"
+    },
+    "schemaIdentifier": {
+      "id": "urn:hl7-org:elm",
+      "version": "r1"
+    },
+    "usings": {
+      "def": [
+        {
+          "localId": "1",
+          "localIdentifier": "System",
+          "uri": "urn:hl7-org:elm-types:r1"
+        },
+        {
+          "localId": "206",
+          "locator": "3:1-3:26",
+          "localIdentifier": "FHIR",
+          "uri": "http://hl7.org/fhir",
+          "version": "4.0.1",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "206",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "using "
+                    ]
+                  },
+                  {
+                    "s": [
+                      {
+                        "value": [
+                          "FHIR"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " version '4.0.1'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "includes": {
+      "def": [
+        {
+          "localId": "207",
+          "locator": "5:1-5:35",
+          "localIdentifier": "FHIRHelpers",
+          "path": "FHIRHelpers",
+          "version": "4.0.1",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "207",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "include "
+                    ]
+                  },
+                  {
+                    "s": [
+                      {
+                        "value": [
+                          "FHIRHelpers"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " version ",
+                      "'4.0.1'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "localId": "208",
+          "locator": "6:1-6:64",
+          "localIdentifier": "Global",
+          "path": "MATGlobalCommonFunctions",
+          "version": "5.0.000",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "208",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "include "
+                    ]
+                  },
+                  {
+                    "s": [
+                      {
+                        "value": [
+                          "MATGlobalCommonFunctions"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " version ",
+                      "'5.0.000'",
+                      " called ",
+                      "Global"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "parameters": {
+      "def": [
+        {
+          "localId": "232",
+          "locator": "27:1-28:66",
+          "name": "Measurement Period",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "232",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "parameter ",
+                      "\"Measurement Period\"",
+                      " "
+                    ]
+                  },
+                  {
+                    "r": "250",
+                    "s": [
+                      {
+                        "value": [
+                          "Interval<"
+                        ]
+                      },
+                      {
+                        "r": "251",
+                        "s": [
+                          {
+                            "value": [
+                              "DateTime"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          ">"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      "\n  default "
+                    ]
+                  },
+                  {
+                    "r": "249",
+                    "s": [
+                      {
+                        "r": "233",
+                        "value": [
+                          "Interval[",
+                          "@2019-01-01T00:00:00.0",
+                          ", ",
+                          "@2020-01-01T00:00:00.0",
+                          ")"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "default": {
+            "localId": "249",
+            "locator": "28:11-28:66",
+            "lowClosed": true,
+            "highClosed": false,
+            "type": "Interval",
+            "low": {
+              "localId": "233",
+              "locator": "28:20-28:41",
+              "type": "DateTime",
+              "signature": [],
+              "year": {
+                "localId": "234",
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "2019",
+                "type": "Literal"
+              },
+              "month": {
+                "localId": "235",
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "1",
+                "type": "Literal"
+              },
+              "day": {
+                "localId": "236",
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "1",
+                "type": "Literal"
+              },
+              "hour": {
+                "localId": "237",
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "0",
+                "type": "Literal"
+              },
+              "minute": {
+                "localId": "238",
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "0",
+                "type": "Literal"
+              },
+              "second": {
+                "localId": "239",
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "0",
+                "type": "Literal"
+              },
+              "millisecond": {
+                "localId": "240",
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "0",
+                "type": "Literal"
+              }
+            },
+            "high": {
+              "localId": "241",
+              "locator": "28:44-28:65",
+              "type": "DateTime",
+              "signature": [],
+              "year": {
+                "localId": "242",
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "2020",
+                "type": "Literal"
+              },
+              "month": {
+                "localId": "243",
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "1",
+                "type": "Literal"
+              },
+              "day": {
+                "localId": "244",
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "1",
+                "type": "Literal"
+              },
+              "hour": {
+                "localId": "245",
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "0",
+                "type": "Literal"
+              },
+              "minute": {
+                "localId": "246",
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "0",
+                "type": "Literal"
+              },
+              "second": {
+                "localId": "247",
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "0",
+                "type": "Literal"
+              },
+              "millisecond": {
+                "localId": "248",
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "0",
+                "type": "Literal"
+              }
+            }
+          },
+          "parameterTypeSpecifier": {
+            "localId": "250",
+            "locator": "27:32-27:49",
+            "type": "IntervalTypeSpecifier",
+            "pointType": {
+              "localId": "251",
+              "locator": "27:41-27:48",
+              "name": "{urn:hl7-org:elm-types:r1}DateTime",
+              "type": "NamedTypeSpecifier"
+            }
+          }
+        }
+      ]
+    },
+    "codeSystems": {
+      "def": [
+        {
+          "localId": "209",
+          "locator": "8:1-8:42",
+          "name": "EXAMPLE",
+          "id": "http://example.com",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "209",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "codesystem ",
+                      "\"EXAMPLE\"",
+                      ": ",
+                      "'http://example.com'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "localId": "210",
+          "locator": "9:1-9:46",
+          "name": "EXAMPLE-2",
+          "id": "http://example.com/2",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "210",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "codesystem ",
+                      "\"EXAMPLE-2\"",
+                      ": ",
+                      "'http://example.com/2'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "localId": "211",
+          "locator": "10:1-10:101",
+          "name": "ConditionClinicalStatusCodes",
+          "id": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "211",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "codesystem ",
+                      "\"ConditionClinicalStatusCodes\"",
+                      ": ",
+                      "'http://terminology.hl7.org/CodeSystem/condition-clinical'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "valueSets": {
+      "def": [
+        {
+          "localId": "212",
+          "locator": "12:1-12:48",
+          "name": "test-vs",
+          "id": "http://example.com/test-vs",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "212",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "valueset ",
+                      "\"test-vs\"",
+                      ": ",
+                      "'http://example.com/test-vs'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": []
+        },
+        {
+          "localId": "213",
+          "locator": "13:1-13:50",
+          "name": "test-vs2",
+          "id": "http://example.com/test-vs2",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "213",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "valueset ",
+                      "\"test-vs2\"",
+                      ": ",
+                      "'http://example.com/test-vs2'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": []
+        },
+        {
+          "localId": "214",
+          "locator": "14:1-14:50",
+          "name": "test-vs3",
+          "id": "http://example.com/test-vs3",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "214",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "valueset ",
+                      "\"test-vs3\"",
+                      ": ",
+                      "'http://example.com/test-vs3'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": []
+        }
+      ]
+    },
+    "codes": {
+      "def": [
+        {
+          "localId": "215",
+          "locator": "16:1-16:39",
+          "name": "test-code",
+          "id": "test",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "215",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "code ",
+                      "\"test-code\"",
+                      ": ",
+                      "'test'",
+                      " from "
+                    ]
+                  },
+                  {
+                    "r": "216",
+                    "s": [
+                      {
+                        "value": [
+                          "\"EXAMPLE\""
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": {
+            "localId": "216",
+            "locator": "16:31-16:39",
+            "name": "EXAMPLE"
+          }
+        },
+        {
+          "localId": "217",
+          "locator": "17:1-17:45",
+          "name": "test-code-2",
+          "id": "test-2",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "217",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "code ",
+                      "\"test-code-2\"",
+                      ": ",
+                      "'test-2'",
+                      " from "
+                    ]
+                  },
+                  {
+                    "r": "218",
+                    "s": [
+                      {
+                        "value": [
+                          "\"EXAMPLE-2\""
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": {
+            "localId": "218",
+            "locator": "17:35-17:45",
+            "name": "EXAMPLE-2"
+          }
+        },
+        {
+          "localId": "219",
+          "locator": "19:1-19:59",
+          "name": "Active",
+          "id": "active",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "219",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "code ",
+                      "\"Active\"",
+                      ": ",
+                      "'active'",
+                      " from "
+                    ]
+                  },
+                  {
+                    "r": "220",
+                    "s": [
+                      {
+                        "value": [
+                          "\"ConditionClinicalStatusCodes\""
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": {
+            "localId": "220",
+            "locator": "19:30-19:59",
+            "name": "ConditionClinicalStatusCodes"
+          }
+        },
+        {
+          "localId": "221",
+          "locator": "20:1-20:67",
+          "name": "Recurrence",
+          "id": "recurrence",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "221",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "code ",
+                      "\"Recurrence\"",
+                      ": ",
+                      "'recurrence'",
+                      " from "
+                    ]
+                  },
+                  {
+                    "r": "222",
+                    "s": [
+                      {
+                        "value": [
+                          "\"ConditionClinicalStatusCodes\""
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": {
+            "localId": "222",
+            "locator": "20:38-20:67",
+            "name": "ConditionClinicalStatusCodes"
+          }
+        },
+        {
+          "localId": "223",
+          "locator": "21:1-21:61",
+          "name": "Relapse",
+          "id": "relapse",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "223",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "code ",
+                      "\"Relapse\"",
+                      ": ",
+                      "'relapse'",
+                      " from "
+                    ]
+                  },
+                  {
+                    "r": "224",
+                    "s": [
+                      {
+                        "value": [
+                          "\"ConditionClinicalStatusCodes\""
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": {
+            "localId": "224",
+            "locator": "21:32-21:61",
+            "name": "ConditionClinicalStatusCodes"
+          }
+        }
+      ]
+    },
+    "concepts": {
+      "def": [
+        {
+          "localId": "225",
+          "locator": "23:1-23:77",
+          "name": "test-concept",
+          "display": "test-concept",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "225",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "concept ",
+                      "\"test-concept\"",
+                      ": { "
+                    ]
+                  },
+                  {
+                    "r": "226",
+                    "s": [
+                      {
+                        "value": [
+                          "\"test-code\""
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      ", "
+                    ]
+                  },
+                  {
+                    "r": "227",
+                    "s": [
+                      {
+                        "value": [
+                          "\"test-code-2\""
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " } display ",
+                      "'test-concept'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "code": [
+            {
+              "localId": "226",
+              "locator": "23:27-23:37",
+              "name": "test-code"
+            },
+            {
+              "localId": "227",
+              "locator": "23:40-23:52",
+              "name": "test-code-2"
+            }
+          ]
+        },
+        {
+          "localId": "228",
+          "locator": "25:1-25:82",
+          "name": "Condition Active",
+          "display": "Active",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "228",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "concept ",
+                      "\"Condition Active\"",
+                      ": { "
+                    ]
+                  },
+                  {
+                    "r": "229",
+                    "s": [
+                      {
+                        "value": [
+                          "\"Active\""
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      ", "
+                    ]
+                  },
+                  {
+                    "r": "230",
+                    "s": [
+                      {
+                        "value": [
+                          "\"Recurrence\""
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      ", "
+                    ]
+                  },
+                  {
+                    "r": "231",
+                    "s": [
+                      {
+                        "value": [
+                          "\"Relapse\""
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " } display ",
+                      "'Active'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "code": [
+            {
+              "localId": "229",
+              "locator": "25:31-25:38",
+              "name": "Active"
+            },
+            {
+              "localId": "230",
+              "locator": "25:41-25:52",
+              "name": "Recurrence"
+            },
+            {
+              "localId": "231",
+              "locator": "25:55-25:63",
+              "name": "Relapse"
+            }
+          ]
+        }
+      ]
+    },
+    "contexts": {
+      "def": [
+        {
+          "localId": "255",
+          "locator": "30:1-30:15",
+          "name": "Patient"
+        }
+      ]
+    },
+    "statements": {
+      "def": [
+        {
+          "localId": "253",
+          "locator": "30:1-30:15",
+          "name": "Patient",
+          "context": "Patient",
+          "expression": {
+            "localId": "254",
+            "type": "SingletonFrom",
+            "signature": [],
+            "operand": {
+              "localId": "252",
+              "locator": "30:1-30:15",
+              "dataType": "{http://hl7.org/fhir}Patient",
+              "templateId": "http://hl7.org/fhir/StructureDefinition/Patient",
+              "type": "Retrieve",
+              "include": [],
+              "codeFilter": [],
+              "dateFilter": [],
+              "otherFilter": []
+            }
+          }
+        },
+        {
+          "localId": "257",
+          "locator": "32:1-35:45",
+          "name": "Code And Starts During MP",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "257",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Code And Starts During MP\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "279",
+                    "s": [
+                      {
+                        "s": [
+                          {
+                            "r": "258",
+                            "s": [
+                              {
+                                "r": "261",
+                                "s": [
+                                  {
+                                    "r": "261",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "[",
+                                          "Condition",
+                                          ": "
+                                        ]
+                                      },
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"test-vs\""
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "]"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "C"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "\n    "
+                        ]
+                      },
+                      {
+                        "r": "264",
+                        "s": [
+                          {
+                            "value": [
+                              "where "
+                            ]
+                          },
+                          {
+                            "r": "264",
+                            "s": [
+                              {
+                                "r": "265",
+                                "s": [
+                                  {
+                                    "r": "267",
+                                    "s": [
+                                      {
+                                        "r": "266",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "C"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "."
+                                        ]
+                                      },
+                                      {
+                                        "r": "267",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "clinicalStatus"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      " ",
+                                      "~",
+                                      " "
+                                    ]
+                                  },
+                                  {
+                                    "r": "268",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "\"Condition Active\""
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  "\n      and "
+                                ]
+                              },
+                              {
+                                "r": "273",
+                                "s": [
+                                  {
+                                    "r": "271",
+                                    "s": [
+                                      {
+                                        "r": "270",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "C"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "."
+                                        ]
+                                      },
+                                      {
+                                        "r": "271",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "onset"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "r": "273",
+                                    "value": [
+                                      " ",
+                                      "during",
+                                      " "
+                                    ]
+                                  },
+                                  {
+                                    "r": "272",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "\"Measurement Period\""
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "279",
+            "locator": "33:3-35:45",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "258",
+                "locator": "33:3-33:26",
+                "alias": "C",
+                "expression": {
+                  "localId": "261",
+                  "locator": "33:3-33:24",
+                  "dataType": "{http://hl7.org/fhir}Condition",
+                  "templateId": "http://hl7.org/fhir/StructureDefinition/Condition",
+                  "codeProperty": "code",
+                  "codeComparator": "in",
+                  "type": "Retrieve",
+                  "codes": {
+                    "localId": "260",
+                    "locator": "33:15-33:23",
+                    "name": "test-vs",
+                    "preserve": true,
+                    "type": "ValueSetRef"
+                  },
+                  "include": [],
+                  "codeFilter": [],
+                  "dateFilter": [],
+                  "otherFilter": []
+                }
+              }
+            ],
+            "let": [],
+            "relationship": [],
+            "where": {
+              "localId": "264",
+              "locator": "34:5-35:45",
+              "type": "And",
+              "signature": [],
+              "operand": [
+                {
+                  "localId": "265",
+                  "locator": "34:11-34:47",
+                  "type": "Equivalent",
+                  "signature": [],
+                  "operand": [
+                    {
+                      "localId": "269",
+                      "name": "ToConcept",
+                      "libraryName": "FHIRHelpers",
+                      "type": "FunctionRef",
+                      "signature": [],
+                      "operand": [
+                        {
+                          "localId": "267",
+                          "locator": "34:11-34:26",
+                          "path": "clinicalStatus",
+                          "scope": "C",
+                          "type": "Property"
+                        }
+                      ]
+                    },
+                    {
+                      "localId": "268",
+                      "locator": "34:30-34:47",
+                      "name": "Condition Active",
+                      "type": "ConceptRef"
+                    }
+                  ]
+                },
+                {
+                  "localId": "273",
+                  "locator": "35:11-35:45",
+                  "type": "IncludedIn",
+                  "signature": [],
+                  "operand": [
+                    {
+                      "localId": "275",
+                      "name": "ToInterval",
+                      "libraryName": "FHIRHelpers",
+                      "type": "FunctionRef",
+                      "signature": [],
+                      "operand": [
+                        {
+                          "localId": "274",
+                          "asType": "{http://hl7.org/fhir}Period",
+                          "type": "As",
+                          "signature": [],
+                          "operand": {
+                            "localId": "271",
+                            "locator": "35:11-35:17",
+                            "path": "onset",
+                            "scope": "C",
+                            "type": "Property"
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "localId": "272",
+                      "locator": "35:26-35:45",
+                      "name": "Measurement Period",
+                      "type": "ParameterRef"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        {
+          "localId": "281",
+          "locator": "37:1-41:80",
+          "name": "Observation Status Value Exists and During MP",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "281",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Observation Status Value Exists and During MP\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "311",
+                    "s": [
+                      {
+                        "s": [
+                          {
+                            "r": "282",
+                            "s": [
+                              {
+                                "r": "285",
+                                "s": [
+                                  {
+                                    "r": "285",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "[",
+                                          "Observation",
+                                          ": "
+                                        ]
+                                      },
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"test-vs\""
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "]"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "Obs"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "\n    "
+                        ]
+                      },
+                      {
+                        "r": "288",
+                        "s": [
+                          {
+                            "value": [
+                              "where "
+                            ]
+                          },
+                          {
+                            "r": "288",
+                            "s": [
+                              {
+                                "r": "289",
+                                "s": [
+                                  {
+                                    "r": "297",
+                                    "s": [
+                                      {
+                                        "r": "291",
+                                        "s": [
+                                          {
+                                            "r": "290",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "Obs"
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              "."
+                                            ]
+                                          },
+                                          {
+                                            "r": "291",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "status"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          " in "
+                                        ]
+                                      },
+                                      {
+                                        "r": "292",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "{"
+                                            ]
+                                          },
+                                          {
+                                            "r": "293",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "'final'"
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              ", "
+                                            ]
+                                          },
+                                          {
+                                            "r": "294",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "'amended'"
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              ", "
+                                            ]
+                                          },
+                                          {
+                                            "r": "295",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "'corrected'"
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              ", "
+                                            ]
+                                          },
+                                          {
+                                            "r": "296",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "'preliminary'"
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              "}"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "\n      and "
+                                    ]
+                                  },
+                                  {
+                                    "r": "302",
+                                    "s": [
+                                      {
+                                        "r": "300",
+                                        "s": [
+                                          {
+                                            "r": "299",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "Obs"
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              "."
+                                            ]
+                                          },
+                                          {
+                                            "r": "300",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "value"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          " is not null"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  "\n      and "
+                                ]
+                              },
+                              {
+                                "r": "308",
+                                "s": [
+                                  {
+                                    "r": "306",
+                                    "s": [
+                                      {
+                                        "r": "303",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "Global"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "."
+                                        ]
+                                      },
+                                      {
+                                        "r": "306",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"Normalize Interval\"",
+                                              "("
+                                            ]
+                                          },
+                                          {
+                                            "r": "305",
+                                            "s": [
+                                              {
+                                                "r": "304",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "Obs"
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  "."
+                                                ]
+                                              },
+                                              {
+                                                "r": "305",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "effective"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              ")"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "r": "308",
+                                    "value": [
+                                      " ",
+                                      "during",
+                                      " "
+                                    ]
+                                  },
+                                  {
+                                    "r": "307",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "\"Measurement Period\""
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "311",
+            "locator": "38:3-41:80",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "282",
+                "locator": "38:3-38:30",
+                "alias": "Obs",
+                "expression": {
+                  "localId": "285",
+                  "locator": "38:3-38:26",
+                  "dataType": "{http://hl7.org/fhir}Observation",
+                  "templateId": "http://hl7.org/fhir/StructureDefinition/Observation",
+                  "codeProperty": "code",
+                  "codeComparator": "in",
+                  "type": "Retrieve",
+                  "codes": {
+                    "localId": "284",
+                    "locator": "38:17-38:25",
+                    "name": "test-vs",
+                    "preserve": true,
+                    "type": "ValueSetRef"
+                  },
+                  "include": [],
+                  "codeFilter": [],
+                  "dateFilter": [],
+                  "otherFilter": []
+                }
+              }
+            ],
+            "let": [],
+            "relationship": [],
+            "where": {
+              "localId": "288",
+              "locator": "39:5-41:80",
+              "type": "And",
+              "signature": [],
+              "operand": [
+                {
+                  "localId": "289",
+                  "locator": "39:11-40:31",
+                  "type": "And",
+                  "signature": [],
+                  "operand": [
+                    {
+                      "localId": "297",
+                      "locator": "39:11-39:72",
+                      "type": "In",
+                      "signature": [],
+                      "operand": [
+                        {
+                          "localId": "298",
+                          "name": "ToString",
+                          "libraryName": "FHIRHelpers",
+                          "type": "FunctionRef",
+                          "signature": [],
+                          "operand": [
+                            {
+                              "localId": "291",
+                              "locator": "39:11-39:20",
+                              "path": "status",
+                              "scope": "Obs",
+                              "type": "Property"
+                            }
+                          ]
+                        },
+                        {
+                          "localId": "292",
+                          "locator": "39:25-39:72",
+                          "type": "List",
+                          "element": [
+                            {
+                              "localId": "293",
+                              "locator": "39:26-39:32",
+                              "valueType": "{urn:hl7-org:elm-types:r1}String",
+                              "value": "final",
+                              "type": "Literal"
+                            },
+                            {
+                              "localId": "294",
+                              "locator": "39:35-39:43",
+                              "valueType": "{urn:hl7-org:elm-types:r1}String",
+                              "value": "amended",
+                              "type": "Literal"
+                            },
+                            {
+                              "localId": "295",
+                              "locator": "39:46-39:56",
+                              "valueType": "{urn:hl7-org:elm-types:r1}String",
+                              "value": "corrected",
+                              "type": "Literal"
+                            },
+                            {
+                              "localId": "296",
+                              "locator": "39:59-39:71",
+                              "valueType": "{urn:hl7-org:elm-types:r1}String",
+                              "value": "preliminary",
+                              "type": "Literal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "localId": "302",
+                      "locator": "40:11-40:31",
+                      "type": "Not",
+                      "signature": [],
+                      "operand": {
+                        "localId": "301",
+                        "locator": "40:11-40:31",
+                        "type": "IsNull",
+                        "signature": [],
+                        "operand": {
+                          "localId": "300",
+                          "locator": "40:11-40:19",
+                          "path": "value",
+                          "scope": "Obs",
+                          "type": "Property"
+                        }
+                      }
+                    }
+                  ]
+                },
+                {
+                  "localId": "308",
+                  "locator": "41:11-41:80",
+                  "type": "IncludedIn",
+                  "signature": [],
+                  "operand": [
+                    {
+                      "localId": "306",
+                      "locator": "41:11-41:52",
+                      "name": "Normalize Interval",
+                      "libraryName": "Global",
+                      "type": "FunctionRef",
+                      "signature": [],
+                      "operand": [
+                        {
+                          "localId": "305",
+                          "locator": "41:39-41:51",
+                          "path": "effective",
+                          "scope": "Obs",
+                          "type": "Property"
+                        }
+                      ]
+                    },
+                    {
+                      "localId": "307",
+                      "locator": "41:61-41:80",
+                      "name": "Measurement Period",
+                      "type": "ParameterRef"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        {
+          "localId": "313",
+          "locator": "43:1-45:105",
+          "name": "Encounter 2 Years Before End of MP",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "313",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Encounter 2 Years Before End of MP\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "347",
+                    "s": [
+                      {
+                        "s": [
+                          {
+                            "r": "314",
+                            "s": [
+                              {
+                                "r": "317",
+                                "s": [
+                                  {
+                                    "r": "317",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "[",
+                                          "Encounter",
+                                          ": "
+                                        ]
+                                      },
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"test-vs\""
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "]"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "Enc"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "\n    "
+                        ]
+                      },
+                      {
+                        "r": "346",
+                        "s": [
+                          {
+                            "value": [
+                              "where "
+                            ]
+                          },
+                          {
+                            "r": "346",
+                            "s": [
+                              {
+                                "r": "327",
+                                "s": [
+                                  {
+                                    "r": "324",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "Global"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "."
+                                    ]
+                                  },
+                                  {
+                                    "r": "327",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "\"Normalize Interval\"",
+                                          "("
+                                        ]
+                                      },
+                                      {
+                                        "r": "326",
+                                        "s": [
+                                          {
+                                            "r": "325",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "Enc"
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              "."
+                                            ]
+                                          },
+                                          {
+                                            "r": "326",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "period"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          ")"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " "
+                                ]
+                              },
+                              {
+                                "r": "346",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "ends "
+                                    ]
+                                  },
+                                  {
+                                    "r": "340",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "2 ",
+                                          "years"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      " or less before"
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " "
+                                ]
+                              },
+                              {
+                                "r": "337",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "end of "
+                                    ]
+                                  },
+                                  {
+                                    "r": "338",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "\"Measurement Period\""
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "347",
+            "locator": "44:3-45:105",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "314",
+                "locator": "44:3-44:28",
+                "alias": "Enc",
+                "expression": {
+                  "localId": "317",
+                  "locator": "44:3-44:24",
+                  "dataType": "{http://hl7.org/fhir}Encounter",
+                  "templateId": "http://hl7.org/fhir/StructureDefinition/Encounter",
+                  "codeProperty": "type",
+                  "codeComparator": "in",
+                  "type": "Retrieve",
+                  "codes": {
+                    "localId": "316",
+                    "locator": "44:15-44:23",
+                    "name": "test-vs",
+                    "preserve": true,
+                    "type": "ValueSetRef"
+                  },
+                  "include": [],
+                  "codeFilter": [],
+                  "dateFilter": [],
+                  "otherFilter": []
+                }
+              }
+            ],
+            "let": [],
+            "relationship": [],
+            "where": {
+              "localId": "346",
+              "locator": "45:5-45:105",
+              "type": "And",
+              "signature": [],
+              "operand": [
+                {
+                  "localId": "343",
+                  "locator": "45:56-45:70",
+                  "type": "In",
+                  "signature": [],
+                  "operand": [
+                    {
+                      "localId": "339",
+                      "locator": "45:51-45:54",
+                      "type": "End",
+                      "signature": [],
+                      "operand": {
+                        "localId": "327",
+                        "locator": "45:11-45:49",
+                        "name": "Normalize Interval",
+                        "libraryName": "Global",
+                        "type": "FunctionRef",
+                        "signature": [],
+                        "operand": [
+                          {
+                            "localId": "328",
+                            "type": "As",
+                            "signature": [],
+                            "operand": {
+                              "localId": "326",
+                              "locator": "45:39-45:48",
+                              "path": "period",
+                              "scope": "Enc",
+                              "type": "Property"
+                            },
+                            "asTypeSpecifier": {
+                              "localId": "329",
+                              "type": "ChoiceTypeSpecifier",
+                              "choice": [
+                                {
+                                  "localId": "330",
+                                  "name": "{http://hl7.org/fhir}dateTime",
+                                  "type": "NamedTypeSpecifier"
+                                },
+                                {
+                                  "localId": "331",
+                                  "name": "{http://hl7.org/fhir}Period",
+                                  "type": "NamedTypeSpecifier"
+                                },
+                                {
+                                  "localId": "332",
+                                  "name": "{http://hl7.org/fhir}Timing",
+                                  "type": "NamedTypeSpecifier"
+                                },
+                                {
+                                  "localId": "333",
+                                  "name": "{http://hl7.org/fhir}instant",
+                                  "type": "NamedTypeSpecifier"
+                                },
+                                {
+                                  "localId": "334",
+                                  "name": "{http://hl7.org/fhir}string",
+                                  "type": "NamedTypeSpecifier"
+                                },
+                                {
+                                  "localId": "335",
+                                  "name": "{http://hl7.org/fhir}Age",
+                                  "type": "NamedTypeSpecifier"
+                                },
+                                {
+                                  "localId": "336",
+                                  "name": "{http://hl7.org/fhir}Range",
+                                  "type": "NamedTypeSpecifier"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "localId": "342",
+                      "locator": "45:56-45:70",
+                      "lowClosed": true,
+                      "highClosed": false,
+                      "type": "Interval",
+                      "low": {
+                        "localId": "341",
+                        "locator": "45:79-45:105",
+                        "type": "Subtract",
+                        "signature": [],
+                        "operand": [
+                          {
+                            "localId": "337",
+                            "locator": "45:79-45:105",
+                            "type": "End",
+                            "signature": [],
+                            "operand": {
+                              "localId": "338",
+                              "locator": "45:86-45:105",
+                              "name": "Measurement Period",
+                              "type": "ParameterRef"
+                            }
+                          },
+                          {
+                            "localId": "340",
+                            "locator": "45:56-45:62",
+                            "value": 2,
+                            "unit": "years",
+                            "type": "Quantity"
+                          }
+                        ]
+                      },
+                      "high": {
+                        "localId": "337",
+                        "locator": "45:79-45:105",
+                        "type": "End",
+                        "signature": [],
+                        "operand": {
+                          "localId": "338",
+                          "locator": "45:86-45:105",
+                          "name": "Measurement Period",
+                          "type": "ParameterRef"
+                        }
+                      }
+                    }
+                  ]
+                },
+                {
+                  "localId": "345",
+                  "locator": "45:56-45:70",
+                  "type": "Not",
+                  "signature": [],
+                  "operand": {
+                    "localId": "344",
+                    "locator": "45:56-45:70",
+                    "type": "IsNull",
+                    "signature": [],
+                    "operand": {
+                      "localId": "337",
+                      "locator": "45:79-45:105",
+                      "type": "End",
+                      "signature": [],
+                      "operand": {
+                        "localId": "338",
+                        "locator": "45:86-45:105",
+                        "name": "Measurement Period",
+                        "type": "ParameterRef"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "localId": "349",
+          "locator": "47:1-51:32",
+          "name": "Code Active Or Starts During MP Or Abatement is not null",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "349",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Code Active Or Starts During MP Or Abatement is not null\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "376",
+                    "s": [
+                      {
+                        "s": [
+                          {
+                            "r": "350",
+                            "s": [
+                              {
+                                "r": "353",
+                                "s": [
+                                  {
+                                    "r": "353",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "[",
+                                          "Condition",
+                                          ": "
+                                        ]
+                                      },
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"test-vs\""
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "]"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "C"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "\n    "
+                        ]
+                      },
+                      {
+                        "r": "356",
+                        "s": [
+                          {
+                            "value": [
+                              "where "
+                            ]
+                          },
+                          {
+                            "r": "356",
+                            "s": [
+                              {
+                                "r": "357",
+                                "s": [
+                                  {
+                                    "r": "358",
+                                    "s": [
+                                      {
+                                        "r": "360",
+                                        "s": [
+                                          {
+                                            "r": "359",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "C"
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              "."
+                                            ]
+                                          },
+                                          {
+                                            "r": "360",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "clinicalStatus"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          " ",
+                                          "~",
+                                          " "
+                                        ]
+                                      },
+                                      {
+                                        "r": "361",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"Condition Active\""
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "\n      or "
+                                    ]
+                                  },
+                                  {
+                                    "r": "366",
+                                    "s": [
+                                      {
+                                        "r": "364",
+                                        "s": [
+                                          {
+                                            "r": "363",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "C"
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              "."
+                                            ]
+                                          },
+                                          {
+                                            "r": "364",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "onset"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "r": "366",
+                                        "value": [
+                                          " ",
+                                          "during",
+                                          " "
+                                        ]
+                                      },
+                                      {
+                                        "r": "365",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"Measurement Period\""
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  "\n      or "
+                                ]
+                              },
+                              {
+                                "r": "375",
+                                "s": [
+                                  {
+                                    "r": "373",
+                                    "s": [
+                                      {
+                                        "r": "372",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "C"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "."
+                                        ]
+                                      },
+                                      {
+                                        "r": "373",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "abatement"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      " is not null"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "376",
+            "locator": "48:3-51:32",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "350",
+                "locator": "48:3-48:26",
+                "alias": "C",
+                "expression": {
+                  "localId": "353",
+                  "locator": "48:3-48:24",
+                  "dataType": "{http://hl7.org/fhir}Condition",
+                  "templateId": "http://hl7.org/fhir/StructureDefinition/Condition",
+                  "codeProperty": "code",
+                  "codeComparator": "in",
+                  "type": "Retrieve",
+                  "codes": {
+                    "localId": "352",
+                    "locator": "48:15-48:23",
+                    "name": "test-vs",
+                    "preserve": true,
+                    "type": "ValueSetRef"
+                  },
+                  "include": [],
+                  "codeFilter": [],
+                  "dateFilter": [],
+                  "otherFilter": []
+                }
+              }
+            ],
+            "let": [],
+            "relationship": [],
+            "where": {
+              "localId": "356",
+              "locator": "49:5-51:32",
+              "type": "Or",
+              "signature": [],
+              "operand": [
+                {
+                  "localId": "357",
+                  "locator": "49:11-50:44",
+                  "type": "Or",
+                  "signature": [],
+                  "operand": [
+                    {
+                      "localId": "358",
+                      "locator": "49:11-49:47",
+                      "type": "Equivalent",
+                      "signature": [],
+                      "operand": [
+                        {
+                          "localId": "362",
+                          "name": "ToConcept",
+                          "libraryName": "FHIRHelpers",
+                          "type": "FunctionRef",
+                          "signature": [],
+                          "operand": [
+                            {
+                              "localId": "360",
+                              "locator": "49:11-49:26",
+                              "path": "clinicalStatus",
+                              "scope": "C",
+                              "type": "Property"
+                            }
+                          ]
+                        },
+                        {
+                          "localId": "361",
+                          "locator": "49:30-49:47",
+                          "name": "Condition Active",
+                          "type": "ConceptRef"
+                        }
+                      ]
+                    },
+                    {
+                      "localId": "366",
+                      "locator": "50:10-50:44",
+                      "type": "IncludedIn",
+                      "signature": [],
+                      "operand": [
+                        {
+                          "localId": "368",
+                          "name": "ToInterval",
+                          "libraryName": "FHIRHelpers",
+                          "type": "FunctionRef",
+                          "signature": [],
+                          "operand": [
+                            {
+                              "localId": "367",
+                              "asType": "{http://hl7.org/fhir}Period",
+                              "type": "As",
+                              "signature": [],
+                              "operand": {
+                                "localId": "364",
+                                "locator": "50:10-50:16",
+                                "path": "onset",
+                                "scope": "C",
+                                "type": "Property"
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "localId": "365",
+                          "locator": "50:25-50:44",
+                          "name": "Measurement Period",
+                          "type": "ParameterRef"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "localId": "375",
+                  "locator": "51:10-51:32",
+                  "type": "Not",
+                  "signature": [],
+                  "operand": {
+                    "localId": "374",
+                    "locator": "51:10-51:32",
+                    "type": "IsNull",
+                    "signature": [],
+                    "operand": {
+                      "localId": "373",
+                      "locator": "51:10-51:20",
+                      "path": "abatement",
+                      "scope": "C",
+                      "type": "Property"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "localId": "378",
+          "locator": "53:1-56:31",
+          "name": "Observation Status and Value",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "378",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Observation Status and Value\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "399",
+                    "s": [
+                      {
+                        "s": [
+                          {
+                            "r": "379",
+                            "s": [
+                              {
+                                "r": "382",
+                                "s": [
+                                  {
+                                    "r": "382",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "[",
+                                          "Observation",
+                                          ": "
+                                        ]
+                                      },
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"test-vs\""
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "]"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "Obs"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "\n    "
+                        ]
+                      },
+                      {
+                        "r": "385",
+                        "s": [
+                          {
+                            "value": [
+                              "where "
+                            ]
+                          },
+                          {
+                            "r": "385",
+                            "s": [
+                              {
+                                "r": "393",
+                                "s": [
+                                  {
+                                    "r": "387",
+                                    "s": [
+                                      {
+                                        "r": "386",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "Obs"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "."
+                                        ]
+                                      },
+                                      {
+                                        "r": "387",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "status"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      " in "
+                                    ]
+                                  },
+                                  {
+                                    "r": "388",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "{"
+                                        ]
+                                      },
+                                      {
+                                        "r": "389",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "'final'"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          ", "
+                                        ]
+                                      },
+                                      {
+                                        "r": "390",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "'amended'"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          ", "
+                                        ]
+                                      },
+                                      {
+                                        "r": "391",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "'corrected'"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          ", "
+                                        ]
+                                      },
+                                      {
+                                        "r": "392",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "'preliminary'"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "}"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  "\n      and "
+                                ]
+                              },
+                              {
+                                "r": "398",
+                                "s": [
+                                  {
+                                    "r": "396",
+                                    "s": [
+                                      {
+                                        "r": "395",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "Obs"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "."
+                                        ]
+                                      },
+                                      {
+                                        "r": "396",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "value"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      " is not null"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "399",
+            "locator": "54:3-56:31",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "379",
+                "locator": "54:3-54:30",
+                "alias": "Obs",
+                "expression": {
+                  "localId": "382",
+                  "locator": "54:3-54:26",
+                  "dataType": "{http://hl7.org/fhir}Observation",
+                  "templateId": "http://hl7.org/fhir/StructureDefinition/Observation",
+                  "codeProperty": "code",
+                  "codeComparator": "in",
+                  "type": "Retrieve",
+                  "codes": {
+                    "localId": "381",
+                    "locator": "54:17-54:25",
+                    "name": "test-vs",
+                    "preserve": true,
+                    "type": "ValueSetRef"
+                  },
+                  "include": [],
+                  "codeFilter": [],
+                  "dateFilter": [],
+                  "otherFilter": []
+                }
+              }
+            ],
+            "let": [],
+            "relationship": [],
+            "where": {
+              "localId": "385",
+              "locator": "55:5-56:31",
+              "type": "And",
+              "signature": [],
+              "operand": [
+                {
+                  "localId": "393",
+                  "locator": "55:11-55:72",
+                  "type": "In",
+                  "signature": [],
+                  "operand": [
+                    {
+                      "localId": "394",
+                      "name": "ToString",
+                      "libraryName": "FHIRHelpers",
+                      "type": "FunctionRef",
+                      "signature": [],
+                      "operand": [
+                        {
+                          "localId": "387",
+                          "locator": "55:11-55:20",
+                          "path": "status",
+                          "scope": "Obs",
+                          "type": "Property"
+                        }
+                      ]
+                    },
+                    {
+                      "localId": "388",
+                      "locator": "55:25-55:72",
+                      "type": "List",
+                      "element": [
+                        {
+                          "localId": "389",
+                          "locator": "55:26-55:32",
+                          "valueType": "{urn:hl7-org:elm-types:r1}String",
+                          "value": "final",
+                          "type": "Literal"
+                        },
+                        {
+                          "localId": "390",
+                          "locator": "55:35-55:43",
+                          "valueType": "{urn:hl7-org:elm-types:r1}String",
+                          "value": "amended",
+                          "type": "Literal"
+                        },
+                        {
+                          "localId": "391",
+                          "locator": "55:46-55:56",
+                          "valueType": "{urn:hl7-org:elm-types:r1}String",
+                          "value": "corrected",
+                          "type": "Literal"
+                        },
+                        {
+                          "localId": "392",
+                          "locator": "55:59-55:71",
+                          "valueType": "{urn:hl7-org:elm-types:r1}String",
+                          "value": "preliminary",
+                          "type": "Literal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "localId": "398",
+                  "locator": "56:11-56:31",
+                  "type": "Not",
+                  "signature": [],
+                  "operand": {
+                    "localId": "397",
+                    "locator": "56:11-56:31",
+                    "type": "IsNull",
+                    "signature": [],
+                    "operand": {
+                      "localId": "396",
+                      "locator": "56:11-56:19",
+                      "path": "value",
+                      "scope": "Obs",
+                      "type": "Property"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "localId": "401",
+          "locator": "58:1-60:78",
+          "name": "Further Refine Observation With During MP",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "401",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Further Refine Observation With During MP\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "412",
+                    "s": [
+                      {
+                        "s": [
+                          {
+                            "r": "402",
+                            "s": [
+                              {
+                                "r": "403",
+                                "s": [
+                                  {
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "\"Observation Status and Value\""
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "O"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "\n    "
+                        ]
+                      },
+                      {
+                        "r": "409",
+                        "s": [
+                          {
+                            "value": [
+                              "where "
+                            ]
+                          },
+                          {
+                            "r": "409",
+                            "s": [
+                              {
+                                "r": "407",
+                                "s": [
+                                  {
+                                    "r": "404",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "Global"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "."
+                                    ]
+                                  },
+                                  {
+                                    "r": "407",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "\"Normalize Interval\"",
+                                          "("
+                                        ]
+                                      },
+                                      {
+                                        "r": "406",
+                                        "s": [
+                                          {
+                                            "r": "405",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "O"
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              "."
+                                            ]
+                                          },
+                                          {
+                                            "r": "406",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "effective"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          ")"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "r": "409",
+                                "value": [
+                                  " ",
+                                  "during",
+                                  " "
+                                ]
+                              },
+                              {
+                                "r": "408",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "\"Measurement Period\""
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "412",
+            "locator": "59:3-60:78",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "402",
+                "locator": "59:3-59:34",
+                "alias": "O",
+                "expression": {
+                  "localId": "403",
+                  "locator": "59:3-59:32",
+                  "name": "Observation Status and Value",
+                  "type": "ExpressionRef"
+                }
+              }
+            ],
+            "let": [],
+            "relationship": [],
+            "where": {
+              "localId": "409",
+              "locator": "60:5-60:78",
+              "type": "IncludedIn",
+              "signature": [],
+              "operand": [
+                {
+                  "localId": "407",
+                  "locator": "60:11-60:50",
+                  "name": "Normalize Interval",
+                  "libraryName": "Global",
+                  "type": "FunctionRef",
+                  "signature": [],
+                  "operand": [
+                    {
+                      "localId": "406",
+                      "locator": "60:39-60:49",
+                      "path": "effective",
+                      "scope": "O",
+                      "type": "Property"
+                    }
+                  ]
+                },
+                {
+                  "localId": "408",
+                  "locator": "60:59-60:78",
+                  "name": "Measurement Period",
+                  "type": "ParameterRef"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "localId": "414",
+          "locator": "62:1-65:32",
+          "name": "Further Refine Observation With During MP and bodySite",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "414",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Further Refine Observation With During MP and bodySite\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "430",
+                    "s": [
+                      {
+                        "s": [
+                          {
+                            "r": "415",
+                            "s": [
+                              {
+                                "r": "416",
+                                "s": [
+                                  {
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "\"Observation Status and Value\""
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "O"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "\n    "
+                        ]
+                      },
+                      {
+                        "r": "417",
+                        "s": [
+                          {
+                            "value": [
+                              "where "
+                            ]
+                          },
+                          {
+                            "r": "417",
+                            "s": [
+                              {
+                                "r": "423",
+                                "s": [
+                                  {
+                                    "r": "421",
+                                    "s": [
+                                      {
+                                        "r": "418",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "Global"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "."
+                                        ]
+                                      },
+                                      {
+                                        "r": "421",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"Normalize Interval\"",
+                                              "("
+                                            ]
+                                          },
+                                          {
+                                            "r": "420",
+                                            "s": [
+                                              {
+                                                "r": "419",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "O"
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  "."
+                                                ]
+                                              },
+                                              {
+                                                "r": "420",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "effective"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              ")"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "r": "423",
+                                    "value": [
+                                      " ",
+                                      "during",
+                                      " "
+                                    ]
+                                  },
+                                  {
+                                    "r": "422",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "\"Measurement Period\""
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  "\n      and "
+                                ]
+                              },
+                              {
+                                "r": "429",
+                                "s": [
+                                  {
+                                    "r": "427",
+                                    "s": [
+                                      {
+                                        "r": "426",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "O"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "."
+                                        ]
+                                      },
+                                      {
+                                        "r": "427",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "bodySite"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      " is not null"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "430",
+            "locator": "63:3-65:32",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "415",
+                "locator": "63:3-63:34",
+                "alias": "O",
+                "expression": {
+                  "localId": "416",
+                  "locator": "63:3-63:32",
+                  "name": "Observation Status and Value",
+                  "type": "ExpressionRef"
+                }
+              }
+            ],
+            "let": [],
+            "relationship": [],
+            "where": {
+              "localId": "417",
+              "locator": "64:5-65:32",
+              "type": "And",
+              "signature": [],
+              "operand": [
+                {
+                  "localId": "423",
+                  "locator": "64:11-64:78",
+                  "type": "IncludedIn",
+                  "signature": [],
+                  "operand": [
+                    {
+                      "localId": "421",
+                      "locator": "64:11-64:50",
+                      "name": "Normalize Interval",
+                      "libraryName": "Global",
+                      "type": "FunctionRef",
+                      "signature": [],
+                      "operand": [
+                        {
+                          "localId": "420",
+                          "locator": "64:39-64:49",
+                          "path": "effective",
+                          "scope": "O",
+                          "type": "Property"
+                        }
+                      ]
+                    },
+                    {
+                      "localId": "422",
+                      "locator": "64:59-64:78",
+                      "name": "Measurement Period",
+                      "type": "ParameterRef"
+                    }
+                  ]
+                },
+                {
+                  "localId": "429",
+                  "locator": "65:11-65:32",
+                  "type": "Not",
+                  "signature": [],
+                  "operand": {
+                    "localId": "428",
+                    "locator": "65:11-65:32",
+                    "type": "IsNull",
+                    "signature": [],
+                    "operand": {
+                      "localId": "427",
+                      "locator": "65:11-65:20",
+                      "path": "bodySite",
+                      "scope": "O",
+                      "type": "Property"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "localId": "432",
+          "locator": "67:1-69:67",
+          "name": "Query Using With",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "432",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Query Using With\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "455",
+                    "s": [
+                      {
+                        "s": [
+                          {
+                            "r": "433",
+                            "s": [
+                              {
+                                "r": "436",
+                                "s": [
+                                  {
+                                    "r": "436",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "[",
+                                          "Encounter",
+                                          ": "
+                                        ]
+                                      },
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"test-vs\""
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "]"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "Enc"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "\n    "
+                        ]
+                      },
+                      {
+                        "r": "454",
+                        "s": [
+                          {
+                            "value": [
+                              "with "
+                            ]
+                          },
+                          {
+                            "r": "443",
+                            "s": [
+                              {
+                                "r": "446",
+                                "s": [
+                                  {
+                                    "r": "446",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "[",
+                                          "Procedure",
+                                          ": "
+                                        ]
+                                      },
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"test-vs2\""
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "]"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "P"
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              " such that "
+                            ]
+                          },
+                          {
+                            "r": "449",
+                            "s": [
+                              {
+                                "r": "451",
+                                "s": [
+                                  {
+                                    "r": "450",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "P"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "."
+                                    ]
+                                  },
+                                  {
+                                    "r": "451",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "status"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "=",
+                                  " "
+                                ]
+                              },
+                              {
+                                "r": "452",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "'completed'"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "455",
+            "locator": "68:3-69:67",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "433",
+                "locator": "68:3-68:28",
+                "alias": "Enc",
+                "expression": {
+                  "localId": "436",
+                  "locator": "68:3-68:24",
+                  "dataType": "{http://hl7.org/fhir}Encounter",
+                  "templateId": "http://hl7.org/fhir/StructureDefinition/Encounter",
+                  "codeProperty": "type",
+                  "codeComparator": "in",
+                  "type": "Retrieve",
+                  "codes": {
+                    "localId": "435",
+                    "locator": "68:15-68:23",
+                    "name": "test-vs",
+                    "preserve": true,
+                    "type": "ValueSetRef"
+                  },
+                  "include": [],
+                  "codeFilter": [],
+                  "dateFilter": [],
+                  "otherFilter": []
+                }
+              }
+            ],
+            "let": [],
+            "relationship": [
+              {
+                "localId": "454",
+                "locator": "69:5-69:67",
+                "alias": "P",
+                "type": "With",
+                "expression": {
+                  "localId": "446",
+                  "locator": "69:10-69:32",
+                  "dataType": "{http://hl7.org/fhir}Procedure",
+                  "templateId": "http://hl7.org/fhir/StructureDefinition/Procedure",
+                  "codeProperty": "code",
+                  "codeComparator": "in",
+                  "type": "Retrieve",
+                  "codes": {
+                    "localId": "445",
+                    "locator": "69:22-69:31",
+                    "name": "test-vs2",
+                    "preserve": true,
+                    "type": "ValueSetRef"
+                  },
+                  "include": [],
+                  "codeFilter": [],
+                  "dateFilter": [],
+                  "otherFilter": []
+                },
+                "suchThat": {
+                  "localId": "449",
+                  "locator": "69:46-69:67",
+                  "type": "Equal",
+                  "signature": [],
+                  "operand": [
+                    {
+                      "localId": "453",
+                      "name": "ToString",
+                      "libraryName": "FHIRHelpers",
+                      "type": "FunctionRef",
+                      "signature": [],
+                      "operand": [
+                        {
+                          "localId": "451",
+                          "locator": "69:46-69:53",
+                          "path": "status",
+                          "scope": "P",
+                          "type": "Property"
+                        }
+                      ]
+                    },
+                    {
+                      "localId": "452",
+                      "locator": "69:57-69:67",
+                      "valueType": "{urn:hl7-org:elm-types:r1}String",
+                      "value": "completed",
+                      "type": "Literal"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "localId": "457",
+          "locator": "71:1-73:100",
+          "name": "Query Using With and Union",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "457",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Query Using With and Union\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "486",
+                    "s": [
+                      {
+                        "value": [
+                          "("
+                        ]
+                      },
+                      {
+                        "r": "486",
+                        "s": [
+                          {
+                            "s": [
+                              {
+                                "r": "458",
+                                "s": [
+                                  {
+                                    "r": "461",
+                                    "s": [
+                                      {
+                                        "r": "461",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "[",
+                                              "Encounter",
+                                              ": "
+                                            ]
+                                          },
+                                          {
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "\"test-vs\""
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              "]"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      " ",
+                                      "Enc"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              "\n    "
+                            ]
+                          },
+                          {
+                            "r": "485",
+                            "s": [
+                              {
+                                "value": [
+                                  "with "
+                                ]
+                              },
+                              {
+                                "r": "468",
+                                "s": [
+                                  {
+                                    "r": "479",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "("
+                                        ]
+                                      },
+                                      {
+                                        "r": "479",
+                                        "s": [
+                                          {
+                                            "r": "471",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "[",
+                                                  "Procedure",
+                                                  ": "
+                                                ]
+                                              },
+                                              {
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "\"test-vs2\""
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  "]"
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              " union "
+                                            ]
+                                          },
+                                          {
+                                            "r": "476",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "[",
+                                                  "Procedure",
+                                                  ": "
+                                                ]
+                                              },
+                                              {
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "\"test-vs3\""
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  "]"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          ")"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      " ",
+                                      "P"
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " such that "
+                                ]
+                              },
+                              {
+                                "r": "480",
+                                "s": [
+                                  {
+                                    "r": "482",
+                                    "s": [
+                                      {
+                                        "r": "481",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "P"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "."
+                                        ]
+                                      },
+                                      {
+                                        "r": "482",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "status"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      " ",
+                                      "=",
+                                      " "
+                                    ]
+                                  },
+                                  {
+                                    "r": "483",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "'completed'"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          ")"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "486",
+            "locator": "72:3-73:100",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "458",
+                "locator": "72:4-72:29",
+                "alias": "Enc",
+                "expression": {
+                  "localId": "461",
+                  "locator": "72:4-72:25",
+                  "dataType": "{http://hl7.org/fhir}Encounter",
+                  "templateId": "http://hl7.org/fhir/StructureDefinition/Encounter",
+                  "codeProperty": "type",
+                  "codeComparator": "in",
+                  "type": "Retrieve",
+                  "codes": {
+                    "localId": "460",
+                    "locator": "72:16-72:24",
+                    "name": "test-vs",
+                    "preserve": true,
+                    "type": "ValueSetRef"
+                  },
+                  "include": [],
+                  "codeFilter": [],
+                  "dateFilter": [],
+                  "otherFilter": []
+                }
+              }
+            ],
+            "let": [],
+            "relationship": [
+              {
+                "localId": "485",
+                "locator": "73:5-73:99",
+                "alias": "P",
+                "type": "With",
+                "expression": {
+                  "localId": "479",
+                  "locator": "73:10-73:64",
+                  "type": "Union",
+                  "signature": [],
+                  "operand": [
+                    {
+                      "localId": "471",
+                      "locator": "73:11-73:33",
+                      "dataType": "{http://hl7.org/fhir}Procedure",
+                      "templateId": "http://hl7.org/fhir/StructureDefinition/Procedure",
+                      "codeProperty": "code",
+                      "codeComparator": "in",
+                      "type": "Retrieve",
+                      "codes": {
+                        "localId": "470",
+                        "locator": "73:23-73:32",
+                        "name": "test-vs2",
+                        "preserve": true,
+                        "type": "ValueSetRef"
+                      },
+                      "include": [],
+                      "codeFilter": [],
+                      "dateFilter": [],
+                      "otherFilter": []
+                    },
+                    {
+                      "localId": "476",
+                      "locator": "73:41-73:63",
+                      "dataType": "{http://hl7.org/fhir}Procedure",
+                      "templateId": "http://hl7.org/fhir/StructureDefinition/Procedure",
+                      "codeProperty": "code",
+                      "codeComparator": "in",
+                      "type": "Retrieve",
+                      "codes": {
+                        "localId": "475",
+                        "locator": "73:53-73:62",
+                        "name": "test-vs3",
+                        "preserve": true,
+                        "type": "ValueSetRef"
+                      },
+                      "include": [],
+                      "codeFilter": [],
+                      "dateFilter": [],
+                      "otherFilter": []
+                    }
+                  ]
+                },
+                "suchThat": {
+                  "localId": "480",
+                  "locator": "73:78-73:99",
+                  "type": "Equal",
+                  "signature": [],
+                  "operand": [
+                    {
+                      "localId": "484",
+                      "name": "ToString",
+                      "libraryName": "FHIRHelpers",
+                      "type": "FunctionRef",
+                      "signature": [],
+                      "operand": [
+                        {
+                          "localId": "482",
+                          "locator": "73:78-73:85",
+                          "path": "status",
+                          "scope": "P",
+                          "type": "Property"
+                        }
+                      ]
+                    },
+                    {
+                      "localId": "483",
+                      "locator": "73:89-73:99",
+                      "valueType": "{urn:hl7-org:elm-types:r1}String",
+                      "value": "completed",
+                      "type": "Literal"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "localId": "488",
+          "locator": "75:1-77:70",
+          "name": "Query Using Without",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "488",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Query Using Without\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "511",
+                    "s": [
+                      {
+                        "s": [
+                          {
+                            "r": "489",
+                            "s": [
+                              {
+                                "r": "492",
+                                "s": [
+                                  {
+                                    "r": "492",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "[",
+                                          "Encounter",
+                                          ": "
+                                        ]
+                                      },
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"test-vs\""
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "]"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "Enc"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "\n    "
+                        ]
+                      },
+                      {
+                        "r": "510",
+                        "s": [
+                          {
+                            "value": [
+                              "without "
+                            ]
+                          },
+                          {
+                            "r": "499",
+                            "s": [
+                              {
+                                "r": "502",
+                                "s": [
+                                  {
+                                    "r": "502",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "[",
+                                          "Procedure",
+                                          ": "
+                                        ]
+                                      },
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"test-vs2\""
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "]"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "P"
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              " such that "
+                            ]
+                          },
+                          {
+                            "r": "505",
+                            "s": [
+                              {
+                                "r": "507",
+                                "s": [
+                                  {
+                                    "r": "506",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "P"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "."
+                                    ]
+                                  },
+                                  {
+                                    "r": "507",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "status"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "=",
+                                  " "
+                                ]
+                              },
+                              {
+                                "r": "508",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "'completed'"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "511",
+            "locator": "76:3-77:70",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "489",
+                "locator": "76:3-76:28",
+                "alias": "Enc",
+                "expression": {
+                  "localId": "492",
+                  "locator": "76:3-76:24",
+                  "dataType": "{http://hl7.org/fhir}Encounter",
+                  "templateId": "http://hl7.org/fhir/StructureDefinition/Encounter",
+                  "codeProperty": "type",
+                  "codeComparator": "in",
+                  "type": "Retrieve",
+                  "codes": {
+                    "localId": "491",
+                    "locator": "76:15-76:23",
+                    "name": "test-vs",
+                    "preserve": true,
+                    "type": "ValueSetRef"
+                  },
+                  "include": [],
+                  "codeFilter": [],
+                  "dateFilter": [],
+                  "otherFilter": []
+                }
+              }
+            ],
+            "let": [],
+            "relationship": [
+              {
+                "localId": "510",
+                "locator": "77:5-77:70",
+                "alias": "P",
+                "type": "Without",
+                "expression": {
+                  "localId": "502",
+                  "locator": "77:13-77:35",
+                  "dataType": "{http://hl7.org/fhir}Procedure",
+                  "templateId": "http://hl7.org/fhir/StructureDefinition/Procedure",
+                  "codeProperty": "code",
+                  "codeComparator": "in",
+                  "type": "Retrieve",
+                  "codes": {
+                    "localId": "501",
+                    "locator": "77:25-77:34",
+                    "name": "test-vs2",
+                    "preserve": true,
+                    "type": "ValueSetRef"
+                  },
+                  "include": [],
+                  "codeFilter": [],
+                  "dateFilter": [],
+                  "otherFilter": []
+                },
+                "suchThat": {
+                  "localId": "505",
+                  "locator": "77:49-77:70",
+                  "type": "Equal",
+                  "signature": [],
+                  "operand": [
+                    {
+                      "localId": "509",
+                      "name": "ToString",
+                      "libraryName": "FHIRHelpers",
+                      "type": "FunctionRef",
+                      "signature": [],
+                      "operand": [
+                        {
+                          "localId": "507",
+                          "locator": "77:49-77:56",
+                          "path": "status",
+                          "scope": "P",
+                          "type": "Property"
+                        }
+                      ]
+                    },
+                    {
+                      "localId": "508",
+                      "locator": "77:60-77:70",
+                      "valueType": "{urn:hl7-org:elm-types:r1}String",
+                      "value": "completed",
+                      "type": "Literal"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "localId": "513",
+          "locator": "79:1-81:77",
+          "name": "Query Using Such That Retrieve",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "513",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Query Using Such That Retrieve\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "541",
+                    "s": [
+                      {
+                        "s": [
+                          {
+                            "r": "514",
+                            "s": [
+                              {
+                                "r": "517",
+                                "s": [
+                                  {
+                                    "r": "517",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "[",
+                                          "Encounter",
+                                          ": "
+                                        ]
+                                      },
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"test-vs\""
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "]"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "Enc"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "\n    "
+                        ]
+                      },
+                      {
+                        "r": "540",
+                        "s": [
+                          {
+                            "value": [
+                              "with "
+                            ]
+                          },
+                          {
+                            "r": "524",
+                            "s": [
+                              {
+                                "r": "527",
+                                "s": [
+                                  {
+                                    "r": "527",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "[",
+                                          "Procedure",
+                                          ": "
+                                        ]
+                                      },
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"test-vs2\""
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "]"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "P"
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              " such that "
+                            ]
+                          },
+                          {
+                            "r": "530",
+                            "s": [
+                              {
+                                "value": [
+                                  "("
+                                ]
+                              },
+                              {
+                                "r": "530",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "exists "
+                                    ]
+                                  },
+                                  {
+                                    "r": "533",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "[",
+                                          "Encounter",
+                                          ": "
+                                        ]
+                                      },
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"test-vs3\""
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "]"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  ")"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "541",
+            "locator": "80:3-81:77",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "514",
+                "locator": "80:3-80:28",
+                "alias": "Enc",
+                "expression": {
+                  "localId": "517",
+                  "locator": "80:3-80:24",
+                  "dataType": "{http://hl7.org/fhir}Encounter",
+                  "templateId": "http://hl7.org/fhir/StructureDefinition/Encounter",
+                  "codeProperty": "type",
+                  "codeComparator": "in",
+                  "type": "Retrieve",
+                  "codes": {
+                    "localId": "516",
+                    "locator": "80:15-80:23",
+                    "name": "test-vs",
+                    "preserve": true,
+                    "type": "ValueSetRef"
+                  },
+                  "include": [],
+                  "codeFilter": [],
+                  "dateFilter": [],
+                  "otherFilter": []
+                }
+              }
+            ],
+            "let": [],
+            "relationship": [
+              {
+                "localId": "540",
+                "locator": "81:5-81:77",
+                "alias": "P",
+                "type": "With",
+                "expression": {
+                  "localId": "527",
+                  "locator": "81:10-81:32",
+                  "dataType": "{http://hl7.org/fhir}Procedure",
+                  "templateId": "http://hl7.org/fhir/StructureDefinition/Procedure",
+                  "codeProperty": "code",
+                  "codeComparator": "in",
+                  "type": "Retrieve",
+                  "codes": {
+                    "localId": "526",
+                    "locator": "81:22-81:31",
+                    "name": "test-vs2",
+                    "preserve": true,
+                    "type": "ValueSetRef"
+                  },
+                  "include": [],
+                  "codeFilter": [],
+                  "dateFilter": [],
+                  "otherFilter": []
+                },
+                "suchThat": {
+                  "localId": "530",
+                  "locator": "81:46-81:77",
+                  "type": "Exists",
+                  "signature": [],
+                  "operand": {
+                    "localId": "533",
+                    "locator": "81:54-81:76",
+                    "dataType": "{http://hl7.org/fhir}Encounter",
+                    "templateId": "http://hl7.org/fhir/StructureDefinition/Encounter",
+                    "codeProperty": "type",
+                    "codeComparator": "in",
+                    "type": "Retrieve",
+                    "codes": {
+                      "localId": "532",
+                      "locator": "81:66-81:75",
+                      "name": "test-vs3",
+                      "preserve": true,
+                      "type": "ValueSetRef"
+                    },
+                    "include": [],
+                    "codeFilter": [],
+                    "dateFilter": [],
+                    "otherFilter": []
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "localId": "543",
+          "locator": "83:1-84:97",
+          "name": "Query Nested In Where",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "543",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Query Nested In Where\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "571",
+                    "s": [
+                      {
+                        "s": [
+                          {
+                            "r": "544",
+                            "s": [
+                              {
+                                "r": "547",
+                                "s": [
+                                  {
+                                    "r": "547",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "[",
+                                          "Encounter",
+                                          ": "
+                                        ]
+                                      },
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"test-vs\""
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "]"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "E1"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          " "
+                        ]
+                      },
+                      {
+                        "r": "554",
+                        "s": [
+                          {
+                            "value": [
+                              "where "
+                            ]
+                          },
+                          {
+                            "r": "554",
+                            "s": [
+                              {
+                                "value": [
+                                  "("
+                                ]
+                              },
+                              {
+                                "r": "554",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "exists "
+                                    ]
+                                  },
+                                  {
+                                    "r": "570",
+                                    "s": [
+                                      {
+                                        "s": [
+                                          {
+                                            "r": "555",
+                                            "s": [
+                                              {
+                                                "r": "558",
+                                                "s": [
+                                                  {
+                                                    "r": "558",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "[",
+                                                          "Encounter",
+                                                          ": "
+                                                        ]
+                                                      },
+                                                      {
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "\"test-vs2\""
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "value": [
+                                                          "]"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  " ",
+                                                  "E2"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          " "
+                                        ]
+                                      },
+                                      {
+                                        "r": "565",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "where "
+                                            ]
+                                          },
+                                          {
+                                            "r": "565",
+                                            "s": [
+                                              {
+                                                "r": "567",
+                                                "s": [
+                                                  {
+                                                    "r": "566",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "E1"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "value": [
+                                                      "."
+                                                    ]
+                                                  },
+                                                  {
+                                                    "r": "567",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "status"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  " ",
+                                                  "=",
+                                                  " "
+                                                ]
+                                              },
+                                              {
+                                                "r": "569",
+                                                "s": [
+                                                  {
+                                                    "r": "568",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "E2"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "value": [
+                                                      "."
+                                                    ]
+                                                  },
+                                                  {
+                                                    "r": "569",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "status"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  ")"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "571",
+            "locator": "84:3-84:97",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "544",
+                "locator": "84:3-84:27",
+                "alias": "E1",
+                "expression": {
+                  "localId": "547",
+                  "locator": "84:3-84:24",
+                  "dataType": "{http://hl7.org/fhir}Encounter",
+                  "templateId": "http://hl7.org/fhir/StructureDefinition/Encounter",
+                  "codeProperty": "type",
+                  "codeComparator": "in",
+                  "type": "Retrieve",
+                  "codes": {
+                    "localId": "546",
+                    "locator": "84:15-84:23",
+                    "name": "test-vs",
+                    "preserve": true,
+                    "type": "ValueSetRef"
+                  },
+                  "include": [],
+                  "codeFilter": [],
+                  "dateFilter": [],
+                  "otherFilter": []
+                }
+              }
+            ],
+            "let": [],
+            "relationship": [],
+            "where": {
+              "localId": "554",
+              "locator": "84:29-84:97",
+              "type": "Exists",
+              "signature": [],
+              "operand": {
+                "localId": "570",
+                "locator": "84:43-84:96",
+                "type": "Query",
+                "source": [
+                  {
+                    "localId": "555",
+                    "locator": "84:43-84:68",
+                    "alias": "E2",
+                    "expression": {
+                      "localId": "558",
+                      "locator": "84:43-84:65",
+                      "dataType": "{http://hl7.org/fhir}Encounter",
+                      "templateId": "http://hl7.org/fhir/StructureDefinition/Encounter",
+                      "codeProperty": "type",
+                      "codeComparator": "in",
+                      "type": "Retrieve",
+                      "codes": {
+                        "localId": "557",
+                        "locator": "84:55-84:64",
+                        "name": "test-vs2",
+                        "preserve": true,
+                        "type": "ValueSetRef"
+                      },
+                      "include": [],
+                      "codeFilter": [],
+                      "dateFilter": [],
+                      "otherFilter": []
+                    }
+                  }
+                ],
+                "let": [],
+                "relationship": [],
+                "where": {
+                  "localId": "565",
+                  "locator": "84:70-84:96",
+                  "type": "Equal",
+                  "signature": [],
+                  "operand": [
+                    {
+                      "localId": "567",
+                      "locator": "84:76-84:84",
+                      "path": "status",
+                      "scope": "E1",
+                      "type": "Property"
+                    },
+                    {
+                      "localId": "569",
+                      "locator": "84:88-84:96",
+                      "path": "status",
+                      "scope": "E2",
+                      "type": "Property"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        {
+          "localId": "573",
+          "locator": "86:1-91:3",
+          "name": "Query Using Let",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "573",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Query Using Let\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "601",
+                    "s": [
+                      {
+                        "s": [
+                          {
+                            "r": "574",
+                            "s": [
+                              {
+                                "r": "577",
+                                "s": [
+                                  {
+                                    "r": "577",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "[",
+                                          "Encounter",
+                                          ": "
+                                        ]
+                                      },
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"test-vs\""
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "]"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "E1"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "\n  "
+                        ]
+                      },
+                      {
+                        "s": [
+                          {
+                            "value": [
+                              "let "
+                            ]
+                          },
+                          {
+                            "r": "584",
+                            "s": [
+                              {
+                                "value": [
+                                  "E2",
+                                  ": "
+                                ]
+                              },
+                              {
+                                "r": "596",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "First",
+                                      "("
+                                    ]
+                                  },
+                                  {
+                                    "r": "587",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "[",
+                                          "Encounter",
+                                          ": "
+                                        ]
+                                      },
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"test-vs2\""
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "]"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      ")"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "\n  "
+                        ]
+                      },
+                      {
+                        "r": "597",
+                        "s": [
+                          {
+                            "value": [
+                              "return "
+                            ]
+                          },
+                          {
+                            "r": "598",
+                            "s": [
+                              {
+                                "value": [
+                                  "{\n    "
+                                ]
+                              },
+                              {
+                                "s": [
+                                  {
+                                    "value": [
+                                      "id",
+                                      ": "
+                                    ]
+                                  },
+                                  {
+                                    "r": "600",
+                                    "s": [
+                                      {
+                                        "r": "599",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "E2"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "."
+                                        ]
+                                      },
+                                      {
+                                        "r": "600",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "id"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  "\n  }"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "601",
+            "locator": "87:3-91:3",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "574",
+                "locator": "87:3-87:27",
+                "alias": "E1",
+                "expression": {
+                  "localId": "577",
+                  "locator": "87:3-87:24",
+                  "dataType": "{http://hl7.org/fhir}Encounter",
+                  "templateId": "http://hl7.org/fhir/StructureDefinition/Encounter",
+                  "codeProperty": "type",
+                  "codeComparator": "in",
+                  "type": "Retrieve",
+                  "codes": {
+                    "localId": "576",
+                    "locator": "87:15-87:23",
+                    "name": "test-vs",
+                    "preserve": true,
+                    "type": "ValueSetRef"
+                  },
+                  "include": [],
+                  "codeFilter": [],
+                  "dateFilter": [],
+                  "otherFilter": []
+                }
+              }
+            ],
+            "let": [
+              {
+                "localId": "584",
+                "locator": "88:7-88:40",
+                "identifier": "E2",
+                "expression": {
+                  "localId": "596",
+                  "locator": "88:11-88:40",
+                  "type": "First",
+                  "signature": [],
+                  "source": {
+                    "localId": "587",
+                    "locator": "88:17-88:39",
+                    "dataType": "{http://hl7.org/fhir}Encounter",
+                    "templateId": "http://hl7.org/fhir/StructureDefinition/Encounter",
+                    "codeProperty": "type",
+                    "codeComparator": "in",
+                    "type": "Retrieve",
+                    "codes": {
+                      "localId": "586",
+                      "locator": "88:29-88:38",
+                      "name": "test-vs2",
+                      "preserve": true,
+                      "type": "ValueSetRef"
+                    },
+                    "include": [],
+                    "codeFilter": [],
+                    "dateFilter": [],
+                    "otherFilter": []
+                  }
+                }
+              }
+            ],
+            "relationship": [],
+            "return": {
+              "localId": "597",
+              "locator": "89:3-91:3",
+              "expression": {
+                "localId": "598",
+                "locator": "89:10-91:3",
+                "type": "Tuple",
+                "element": [
+                  {
+                    "name": "id",
+                    "value": {
+                      "localId": "600",
+                      "locator": "90:9-90:13",
+                      "path": "id",
+                      "type": "Property",
+                      "source": {
+                        "localId": "599",
+                        "locator": "90:9-90:10",
+                        "name": "E2",
+                        "type": "QueryLetRef"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "localId": "603",
+          "locator": "93:1-97:3",
+          "name": "Query Returning Retrieve",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "603",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Query Returning Retrieve\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "625",
+                    "s": [
+                      {
+                        "s": [
+                          {
+                            "r": "604",
+                            "s": [
+                              {
+                                "r": "607",
+                                "s": [
+                                  {
+                                    "r": "607",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "[",
+                                          "Encounter",
+                                          ": "
+                                        ]
+                                      },
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"test-vs\""
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "]"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "E1"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "\n  "
+                        ]
+                      },
+                      {
+                        "r": "614",
+                        "s": [
+                          {
+                            "value": [
+                              "return "
+                            ]
+                          },
+                          {
+                            "r": "615",
+                            "s": [
+                              {
+                                "value": [
+                                  "{\n    "
+                                ]
+                              },
+                              {
+                                "s": [
+                                  {
+                                    "value": [
+                                      "E2",
+                                      ": "
+                                    ]
+                                  },
+                                  {
+                                    "r": "618",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "[",
+                                          "Encounter",
+                                          ": "
+                                        ]
+                                      },
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"test-vs2\""
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "]"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  "\n  }"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "625",
+            "locator": "94:3-97:3",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "604",
+                "locator": "94:3-94:27",
+                "alias": "E1",
+                "expression": {
+                  "localId": "607",
+                  "locator": "94:3-94:24",
+                  "dataType": "{http://hl7.org/fhir}Encounter",
+                  "templateId": "http://hl7.org/fhir/StructureDefinition/Encounter",
+                  "codeProperty": "type",
+                  "codeComparator": "in",
+                  "type": "Retrieve",
+                  "codes": {
+                    "localId": "606",
+                    "locator": "94:15-94:23",
+                    "name": "test-vs",
+                    "preserve": true,
+                    "type": "ValueSetRef"
+                  },
+                  "include": [],
+                  "codeFilter": [],
+                  "dateFilter": [],
+                  "otherFilter": []
+                }
+              }
+            ],
+            "let": [],
+            "relationship": [],
+            "return": {
+              "localId": "614",
+              "locator": "95:3-97:3",
+              "expression": {
+                "localId": "615",
+                "locator": "95:10-97:3",
+                "type": "Tuple",
+                "element": [
+                  {
+                    "name": "E2",
+                    "value": {
+                      "localId": "618",
+                      "locator": "96:9-96:31",
+                      "dataType": "{http://hl7.org/fhir}Encounter",
+                      "templateId": "http://hl7.org/fhir/StructureDefinition/Encounter",
+                      "codeProperty": "type",
+                      "codeComparator": "in",
+                      "type": "Retrieve",
+                      "codes": {
+                        "localId": "617",
+                        "locator": "96:21-96:30",
+                        "name": "test-vs2",
+                        "preserve": true,
+                        "type": "ValueSetRef"
+                      },
+                      "include": [],
+                      "codeFilter": [],
+                      "dateFilter": [],
+                      "otherFilter": []
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/test/unit/fixtures/elm/3.15.0/ExampleMeasure.json
+++ b/test/unit/fixtures/elm/3.15.0/ExampleMeasure.json
@@ -1,0 +1,289 @@
+{
+  "library": {
+    "localId": "0",
+    "annotation": [
+      {
+        "translatorVersion": "3.15.0",
+        "translatorOptions": "EnableAnnotations,EnableLocators",
+        "signatureLevel": "None",
+        "type": "CqlToElmInfo"
+      },
+      {
+        "type": "Annotation",
+        "s": {
+          "r": "223",
+          "s": [
+            {
+              "value": [
+                "",
+                "library ExampleMeasure version '1'"
+              ]
+            }
+          ]
+        }
+      }
+    ],
+    "identifier": {
+      "id": "ExampleMeasure",
+      "version": "1"
+    },
+    "schemaIdentifier": {
+      "id": "urn:hl7-org:elm",
+      "version": "r1"
+    },
+    "usings": {
+      "def": [
+        {
+          "localId": "1",
+          "localIdentifier": "System",
+          "uri": "urn:hl7-org:elm-types:r1"
+        },
+        {
+          "localId": "206",
+          "locator": "3:1-3:26",
+          "localIdentifier": "FHIR",
+          "uri": "http://hl7.org/fhir",
+          "version": "4.0.1",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "206",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "using "
+                    ]
+                  },
+                  {
+                    "s": [
+                      {
+                        "value": [
+                          "FHIR"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " version '4.0.1'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "statements": {
+      "def": [
+        {
+          "localId": "208",
+          "locator": "5:1-5:33",
+          "name": "Initial Population",
+          "context": "Unfiltered",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "208",
+                "s": [
+                  {
+                    "r": "209",
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Initial Population\"",
+                      ": ",
+                      "true"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "209",
+            "locator": "5:30-5:33",
+            "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+            "value": "true",
+            "type": "Literal"
+          }
+        },
+        {
+          "localId": "211",
+          "locator": "6:1-6:26",
+          "name": "Denominator",
+          "context": "Unfiltered",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "211",
+                "s": [
+                  {
+                    "r": "212",
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Denominator\"",
+                      ": ",
+                      "true"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "212",
+            "locator": "6:23-6:26",
+            "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+            "value": "true",
+            "type": "Literal"
+          }
+        },
+        {
+          "localId": "214",
+          "locator": "7:1-7:24",
+          "name": "Numerator",
+          "context": "Unfiltered",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "214",
+                "s": [
+                  {
+                    "r": "215",
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Numerator\"",
+                      ": ",
+                      "true"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "215",
+            "locator": "7:21-7:24",
+            "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+            "value": "true",
+            "type": "Literal"
+          }
+        },
+        {
+          "localId": "217",
+          "locator": "8:1-8:35",
+          "name": "Numerator Exclusion",
+          "context": "Unfiltered",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "217",
+                "s": [
+                  {
+                    "r": "218",
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Numerator Exclusion\"",
+                      ": ",
+                      "false"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "218",
+            "locator": "8:31-8:35",
+            "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+            "value": "false",
+            "type": "Literal"
+          }
+        },
+        {
+          "localId": "220",
+          "locator": "9:1-9:37",
+          "name": "Denominator Exclusion",
+          "context": "Unfiltered",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "220",
+                "s": [
+                  {
+                    "r": "221",
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Denominator Exclusion\"",
+                      ": ",
+                      "false"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "221",
+            "locator": "9:33-9:37",
+            "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+            "value": "false",
+            "type": "Literal"
+          }
+        },
+        {
+          "localId": "223",
+          "locator": "10:1-10:18",
+          "name": "SDE",
+          "context": "Unfiltered",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "223",
+                "s": [
+                  {
+                    "r": "224",
+                    "value": [
+                      "",
+                      "define ",
+                      "\"SDE\"",
+                      ": ",
+                      "true"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "224",
+            "locator": "10:15-10:18",
+            "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+            "value": "true",
+            "type": "Literal"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/test/unit/fixtures/elm/3.15.0/ExtraQueries.json
+++ b/test/unit/fixtures/elm/3.15.0/ExtraQueries.json
@@ -1,0 +1,4980 @@
+{
+  "library": {
+    "localId": "0",
+    "annotation": [
+      {
+        "translatorVersion": "3.15.0",
+        "translatorOptions": "EnableAnnotations,EnableLocators",
+        "signatureLevel": "None",
+        "type": "CqlToElmInfo"
+      },
+      {
+        "message": "The function FHIRHelpers.ToInterval has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToInterval has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToDateTime has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToInterval has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToDateTime has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToInterval has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "type": "Annotation",
+        "s": {
+          "r": "520",
+          "s": [
+            {
+              "value": [
+                "/* Extra queries that may have ELM chunks used for QueryFilterParsing tests. */\n",
+                "library ExtraQueries version '0.0.1'"
+              ]
+            }
+          ]
+        }
+      }
+    ],
+    "identifier": {
+      "id": "ExtraQueries",
+      "version": "0.0.1"
+    },
+    "schemaIdentifier": {
+      "id": "urn:hl7-org:elm",
+      "version": "r1"
+    },
+    "usings": {
+      "def": [
+        {
+          "localId": "1",
+          "localIdentifier": "System",
+          "uri": "urn:hl7-org:elm-types:r1"
+        },
+        {
+          "localId": "206",
+          "locator": "4:1-4:26",
+          "localIdentifier": "FHIR",
+          "uri": "http://hl7.org/fhir",
+          "version": "4.0.1",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "206",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "using "
+                    ]
+                  },
+                  {
+                    "s": [
+                      {
+                        "value": [
+                          "FHIR"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " version '4.0.1'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "includes": {
+      "def": [
+        {
+          "localId": "207",
+          "locator": "6:1-6:35",
+          "localIdentifier": "FHIRHelpers",
+          "path": "FHIRHelpers",
+          "version": "4.0.1",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "207",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "include "
+                    ]
+                  },
+                  {
+                    "s": [
+                      {
+                        "value": [
+                          "FHIRHelpers"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " version ",
+                      "'4.0.1'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "localId": "208",
+          "locator": "7:1-7:64",
+          "localIdentifier": "Global",
+          "path": "MATGlobalCommonFunctions",
+          "version": "5.0.000",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "208",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "include "
+                    ]
+                  },
+                  {
+                    "s": [
+                      {
+                        "value": [
+                          "MATGlobalCommonFunctions"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " version ",
+                      "'5.0.000'",
+                      " called ",
+                      "Global"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "parameters": {
+      "def": [
+        {
+          "localId": "230",
+          "locator": "24:1-24:114",
+          "name": "Measurement Period",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "230",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "parameter ",
+                      "\"Measurement Period\"",
+                      " "
+                    ]
+                  },
+                  {
+                    "r": "248",
+                    "s": [
+                      {
+                        "value": [
+                          "Interval<"
+                        ]
+                      },
+                      {
+                        "r": "249",
+                        "s": [
+                          {
+                            "value": [
+                              "DateTime"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          ">"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      "default "
+                    ]
+                  },
+                  {
+                    "r": "247",
+                    "s": [
+                      {
+                        "r": "231",
+                        "value": [
+                          "Interval[",
+                          "@2019-01-01T00:00:00.0",
+                          ", ",
+                          "@2020-01-01T00:00:00.0",
+                          " )"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "default": {
+            "localId": "247",
+            "locator": "24:58-24:114",
+            "lowClosed": true,
+            "highClosed": false,
+            "type": "Interval",
+            "low": {
+              "localId": "231",
+              "locator": "24:67-24:88",
+              "type": "DateTime",
+              "signature": [],
+              "year": {
+                "localId": "232",
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "2019",
+                "type": "Literal"
+              },
+              "month": {
+                "localId": "233",
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "1",
+                "type": "Literal"
+              },
+              "day": {
+                "localId": "234",
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "1",
+                "type": "Literal"
+              },
+              "hour": {
+                "localId": "235",
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "0",
+                "type": "Literal"
+              },
+              "minute": {
+                "localId": "236",
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "0",
+                "type": "Literal"
+              },
+              "second": {
+                "localId": "237",
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "0",
+                "type": "Literal"
+              },
+              "millisecond": {
+                "localId": "238",
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "0",
+                "type": "Literal"
+              }
+            },
+            "high": {
+              "localId": "239",
+              "locator": "24:91-24:112",
+              "type": "DateTime",
+              "signature": [],
+              "year": {
+                "localId": "240",
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "2020",
+                "type": "Literal"
+              },
+              "month": {
+                "localId": "241",
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "1",
+                "type": "Literal"
+              },
+              "day": {
+                "localId": "242",
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "1",
+                "type": "Literal"
+              },
+              "hour": {
+                "localId": "243",
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "0",
+                "type": "Literal"
+              },
+              "minute": {
+                "localId": "244",
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "0",
+                "type": "Literal"
+              },
+              "second": {
+                "localId": "245",
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "0",
+                "type": "Literal"
+              },
+              "millisecond": {
+                "localId": "246",
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "0",
+                "type": "Literal"
+              }
+            }
+          },
+          "parameterTypeSpecifier": {
+            "localId": "248",
+            "locator": "24:32-24:49",
+            "type": "IntervalTypeSpecifier",
+            "pointType": {
+              "localId": "249",
+              "locator": "24:41-24:48",
+              "name": "{urn:hl7-org:elm-types:r1}DateTime",
+              "type": "NamedTypeSpecifier"
+            }
+          }
+        },
+        {
+          "localId": "250",
+          "locator": "25:1-25:41",
+          "name": "Index Date",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "250",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "parameter ",
+                      "\"Index Date\"",
+                      " "
+                    ]
+                  },
+                  {
+                    "r": "251",
+                    "s": [
+                      {
+                        "value": [
+                          "Interval<"
+                        ]
+                      },
+                      {
+                        "r": "252",
+                        "s": [
+                          {
+                            "value": [
+                              "DateTime"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          ">"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "parameterTypeSpecifier": {
+            "localId": "251",
+            "locator": "25:24-25:41",
+            "type": "IntervalTypeSpecifier",
+            "pointType": {
+              "localId": "252",
+              "locator": "25:33-25:40",
+              "name": "{urn:hl7-org:elm-types:r1}DateTime",
+              "type": "NamedTypeSpecifier"
+            }
+          }
+        }
+      ]
+    },
+    "codeSystems": {
+      "def": [
+        {
+          "localId": "209",
+          "locator": "9:1-9:42",
+          "name": "EXAMPLE",
+          "id": "http://example.com",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "209",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "codesystem ",
+                      "\"EXAMPLE\"",
+                      ": ",
+                      "'http://example.com'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "localId": "210",
+          "locator": "10:1-10:46",
+          "name": "EXAMPLE-2",
+          "id": "http://example.com/2",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "210",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "codesystem ",
+                      "\"EXAMPLE-2\"",
+                      ": ",
+                      "'http://example.com/2'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "localId": "211",
+          "locator": "11:1-11:101",
+          "name": "ConditionClinicalStatusCodes",
+          "id": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "211",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "codesystem ",
+                      "\"ConditionClinicalStatusCodes\"",
+                      ": ",
+                      "'http://terminology.hl7.org/CodeSystem/condition-clinical'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "valueSets": {
+      "def": [
+        {
+          "localId": "212",
+          "locator": "13:1-13:48",
+          "name": "test-vs",
+          "id": "http://example.com/test-vs",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "212",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "valueset ",
+                      "\"test-vs\"",
+                      ": ",
+                      "'http://example.com/test-vs'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": []
+        }
+      ]
+    },
+    "codes": {
+      "def": [
+        {
+          "localId": "213",
+          "locator": "15:1-15:39",
+          "name": "test-code",
+          "id": "test",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "213",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "code ",
+                      "\"test-code\"",
+                      ": ",
+                      "'test'",
+                      " from "
+                    ]
+                  },
+                  {
+                    "r": "214",
+                    "s": [
+                      {
+                        "value": [
+                          "\"EXAMPLE\""
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": {
+            "localId": "214",
+            "locator": "15:31-15:39",
+            "name": "EXAMPLE"
+          }
+        },
+        {
+          "localId": "215",
+          "locator": "16:1-16:45",
+          "name": "test-code-2",
+          "id": "test-2",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "215",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "code ",
+                      "\"test-code-2\"",
+                      ": ",
+                      "'test-2'",
+                      " from "
+                    ]
+                  },
+                  {
+                    "r": "216",
+                    "s": [
+                      {
+                        "value": [
+                          "\"EXAMPLE-2\""
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": {
+            "localId": "216",
+            "locator": "16:35-16:45",
+            "name": "EXAMPLE-2"
+          }
+        },
+        {
+          "localId": "217",
+          "locator": "17:1-17:59",
+          "name": "Active",
+          "id": "active",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "217",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "code ",
+                      "\"Active\"",
+                      ": ",
+                      "'active'",
+                      " from "
+                    ]
+                  },
+                  {
+                    "r": "218",
+                    "s": [
+                      {
+                        "value": [
+                          "\"ConditionClinicalStatusCodes\""
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": {
+            "localId": "218",
+            "locator": "17:30-17:59",
+            "name": "ConditionClinicalStatusCodes"
+          }
+        },
+        {
+          "localId": "219",
+          "locator": "18:1-18:67",
+          "name": "Recurrence",
+          "id": "recurrence",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "219",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "code ",
+                      "\"Recurrence\"",
+                      ": ",
+                      "'recurrence'",
+                      " from "
+                    ]
+                  },
+                  {
+                    "r": "220",
+                    "s": [
+                      {
+                        "value": [
+                          "\"ConditionClinicalStatusCodes\""
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": {
+            "localId": "220",
+            "locator": "18:38-18:67",
+            "name": "ConditionClinicalStatusCodes"
+          }
+        },
+        {
+          "localId": "221",
+          "locator": "19:1-19:61",
+          "name": "Relapse",
+          "id": "relapse",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "221",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "code ",
+                      "\"Relapse\"",
+                      ": ",
+                      "'relapse'",
+                      " from "
+                    ]
+                  },
+                  {
+                    "r": "222",
+                    "s": [
+                      {
+                        "value": [
+                          "\"ConditionClinicalStatusCodes\""
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": {
+            "localId": "222",
+            "locator": "19:32-19:61",
+            "name": "ConditionClinicalStatusCodes"
+          }
+        }
+      ]
+    },
+    "concepts": {
+      "def": [
+        {
+          "localId": "223",
+          "locator": "21:1-21:77",
+          "name": "test-concept",
+          "display": "test-concept",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "223",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "concept ",
+                      "\"test-concept\"",
+                      ": { "
+                    ]
+                  },
+                  {
+                    "r": "224",
+                    "s": [
+                      {
+                        "value": [
+                          "\"test-code\""
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      ", "
+                    ]
+                  },
+                  {
+                    "r": "225",
+                    "s": [
+                      {
+                        "value": [
+                          "\"test-code-2\""
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " } display ",
+                      "'test-concept'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "code": [
+            {
+              "localId": "224",
+              "locator": "21:27-21:37",
+              "name": "test-code"
+            },
+            {
+              "localId": "225",
+              "locator": "21:40-21:52",
+              "name": "test-code-2"
+            }
+          ]
+        },
+        {
+          "localId": "226",
+          "locator": "22:1-22:82",
+          "name": "Condition Active",
+          "display": "Active",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "226",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "concept ",
+                      "\"Condition Active\"",
+                      ": { "
+                    ]
+                  },
+                  {
+                    "r": "227",
+                    "s": [
+                      {
+                        "value": [
+                          "\"Active\""
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      ", "
+                    ]
+                  },
+                  {
+                    "r": "228",
+                    "s": [
+                      {
+                        "value": [
+                          "\"Recurrence\""
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      ", "
+                    ]
+                  },
+                  {
+                    "r": "229",
+                    "s": [
+                      {
+                        "value": [
+                          "\"Relapse\""
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " } display ",
+                      "'Active'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "code": [
+            {
+              "localId": "227",
+              "locator": "22:31-22:38",
+              "name": "Active"
+            },
+            {
+              "localId": "228",
+              "locator": "22:41-22:52",
+              "name": "Recurrence"
+            },
+            {
+              "localId": "229",
+              "locator": "22:55-22:63",
+              "name": "Relapse"
+            }
+          ]
+        }
+      ]
+    },
+    "contexts": {
+      "def": [
+        {
+          "localId": "256",
+          "locator": "27:1-27:15",
+          "name": "Patient"
+        }
+      ]
+    },
+    "statements": {
+      "def": [
+        {
+          "localId": "254",
+          "locator": "27:1-27:15",
+          "name": "Patient",
+          "context": "Patient",
+          "expression": {
+            "localId": "255",
+            "type": "SingletonFrom",
+            "signature": [],
+            "operand": {
+              "localId": "253",
+              "locator": "27:1-27:15",
+              "dataType": "{http://hl7.org/fhir}Patient",
+              "templateId": "http://hl7.org/fhir/StructureDefinition/Patient",
+              "type": "Retrieve",
+              "include": [],
+              "codeFilter": [],
+              "dateFilter": [],
+              "otherFilter": []
+            }
+          }
+        },
+        {
+          "localId": "258",
+          "locator": "29:1-31:65",
+          "name": "Function Result is not null",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "258",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Function Result is not null\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "271",
+                    "s": [
+                      {
+                        "s": [
+                          {
+                            "r": "259",
+                            "s": [
+                              {
+                                "r": "262",
+                                "s": [
+                                  {
+                                    "r": "262",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "[",
+                                          "Condition",
+                                          ": "
+                                        ]
+                                      },
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"test-vs\""
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "]"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "C"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "\n    "
+                        ]
+                      },
+                      {
+                        "r": "270",
+                        "s": [
+                          {
+                            "value": [
+                              "where "
+                            ]
+                          },
+                          {
+                            "r": "270",
+                            "s": [
+                              {
+                                "r": "268",
+                                "s": [
+                                  {
+                                    "r": "265",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "Global"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "."
+                                    ]
+                                  },
+                                  {
+                                    "r": "268",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "\"Normalize Interval\"",
+                                          " ( "
+                                        ]
+                                      },
+                                      {
+                                        "r": "267",
+                                        "s": [
+                                          {
+                                            "r": "266",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "C"
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              "."
+                                            ]
+                                          },
+                                          {
+                                            "r": "267",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "abatement"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          " )"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " is not null"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "271",
+            "locator": "30:3-31:65",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "259",
+                "locator": "30:3-30:26",
+                "alias": "C",
+                "expression": {
+                  "localId": "262",
+                  "locator": "30:3-30:24",
+                  "dataType": "{http://hl7.org/fhir}Condition",
+                  "templateId": "http://hl7.org/fhir/StructureDefinition/Condition",
+                  "codeProperty": "code",
+                  "codeComparator": "in",
+                  "type": "Retrieve",
+                  "codes": {
+                    "localId": "261",
+                    "locator": "30:15-30:23",
+                    "name": "test-vs",
+                    "preserve": true,
+                    "type": "ValueSetRef"
+                  },
+                  "include": [],
+                  "codeFilter": [],
+                  "dateFilter": [],
+                  "otherFilter": []
+                }
+              }
+            ],
+            "let": [],
+            "relationship": [],
+            "where": {
+              "localId": "270",
+              "locator": "31:5-31:65",
+              "type": "Not",
+              "signature": [],
+              "operand": {
+                "localId": "269",
+                "locator": "31:11-31:65",
+                "type": "IsNull",
+                "signature": [],
+                "operand": {
+                  "localId": "268",
+                  "locator": "31:11-31:53",
+                  "name": "Normalize Interval",
+                  "libraryName": "Global",
+                  "type": "FunctionRef",
+                  "signature": [],
+                  "operand": [
+                    {
+                      "localId": "267",
+                      "locator": "31:41-31:51",
+                      "path": "abatement",
+                      "scope": "C",
+                      "type": "Property"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        {
+          "localId": "273",
+          "locator": "33:1-35:41",
+          "name": "Random Interval Param end is not null",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "273",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Random Interval Param end is not null\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "284",
+                    "s": [
+                      {
+                        "s": [
+                          {
+                            "r": "274",
+                            "s": [
+                              {
+                                "r": "277",
+                                "s": [
+                                  {
+                                    "r": "277",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "[",
+                                          "Condition",
+                                          ": "
+                                        ]
+                                      },
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"test-vs\""
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "]"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "C"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "\n    "
+                        ]
+                      },
+                      {
+                        "r": "283",
+                        "s": [
+                          {
+                            "value": [
+                              "where "
+                            ]
+                          },
+                          {
+                            "r": "283",
+                            "s": [
+                              {
+                                "r": "280",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "end of "
+                                    ]
+                                  },
+                                  {
+                                    "r": "281",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "\"Index Date\""
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " is not null"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "284",
+            "locator": "34:3-35:41",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "274",
+                "locator": "34:3-34:26",
+                "alias": "C",
+                "expression": {
+                  "localId": "277",
+                  "locator": "34:3-34:24",
+                  "dataType": "{http://hl7.org/fhir}Condition",
+                  "templateId": "http://hl7.org/fhir/StructureDefinition/Condition",
+                  "codeProperty": "code",
+                  "codeComparator": "in",
+                  "type": "Retrieve",
+                  "codes": {
+                    "localId": "276",
+                    "locator": "34:15-34:23",
+                    "name": "test-vs",
+                    "preserve": true,
+                    "type": "ValueSetRef"
+                  },
+                  "include": [],
+                  "codeFilter": [],
+                  "dateFilter": [],
+                  "otherFilter": []
+                }
+              }
+            ],
+            "let": [],
+            "relationship": [],
+            "where": {
+              "localId": "283",
+              "locator": "35:5-35:41",
+              "type": "Not",
+              "signature": [],
+              "operand": {
+                "localId": "282",
+                "locator": "35:11-35:41",
+                "type": "IsNull",
+                "signature": [],
+                "operand": {
+                  "localId": "280",
+                  "locator": "35:11-35:29",
+                  "type": "End",
+                  "signature": [],
+                  "operand": {
+                    "localId": "281",
+                    "locator": "35:18-35:29",
+                    "name": "Index Date",
+                    "type": "ParameterRef"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "localId": "286",
+          "locator": "37:1-38:10",
+          "name": "Not True",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "286",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Not True\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "287",
+                    "s": [
+                      {
+                        "r": "288",
+                        "value": [
+                          "not ",
+                          "true"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "287",
+            "locator": "38:3-38:10",
+            "type": "Not",
+            "signature": [],
+            "operand": {
+              "localId": "288",
+              "locator": "38:7-38:10",
+              "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+              "value": "true",
+              "type": "Literal"
+            }
+          }
+        },
+        {
+          "localId": "301",
+          "locator": "82:1-83:17",
+          "name": "A Function",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "301",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define function \"A Function\"(period Interval<DateTime>):\n  "
+                    ]
+                  },
+                  {
+                    "r": "566",
+                    "s": [
+                      {
+                        "r": "566",
+                        "s": [
+                          {
+                            "value": [
+                              "start of "
+                            ]
+                          },
+                          {
+                            "r": "567",
+                            "s": [
+                              {
+                                "value": [
+                                  "period"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "566",
+            "locator": "83:3-83:17",
+            "type": "Start",
+            "signature": [],
+            "operand": {
+              "localId": "567",
+              "locator": "83:12-83:17",
+              "name": "period",
+              "type": "OperandRef"
+            }
+          },
+          "operand": [
+            {
+              "localId": "304",
+              "name": "period",
+              "operandTypeSpecifier": {
+                "localId": "302",
+                "locator": "82:37-82:54",
+                "type": "IntervalTypeSpecifier",
+                "pointType": {
+                  "localId": "303",
+                  "locator": "82:46-82:53",
+                  "name": "{urn:hl7-org:elm-types:r1}DateTime",
+                  "type": "NamedTypeSpecifier"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "localId": "290",
+          "locator": "40:1-42:92",
+          "name": "FunctionRef In Same library",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "290",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"FunctionRef In Same library\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "311",
+                    "s": [
+                      {
+                        "s": [
+                          {
+                            "r": "291",
+                            "s": [
+                              {
+                                "r": "294",
+                                "s": [
+                                  {
+                                    "r": "294",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "[",
+                                          "Condition",
+                                          ": "
+                                        ]
+                                      },
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"test-vs\""
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "]"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "C"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "\n    "
+                        ]
+                      },
+                      {
+                        "r": "310",
+                        "s": [
+                          {
+                            "value": [
+                              "where "
+                            ]
+                          },
+                          {
+                            "r": "310",
+                            "s": [
+                              {
+                                "r": "305",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "\"A Function\"",
+                                      "("
+                                    ]
+                                  },
+                                  {
+                                    "r": "300",
+                                    "s": [
+                                      {
+                                        "r": "297",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "Global"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "."
+                                        ]
+                                      },
+                                      {
+                                        "r": "300",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"Normalize Interval\"",
+                                              "("
+                                            ]
+                                          },
+                                          {
+                                            "r": "299",
+                                            "s": [
+                                              {
+                                                "r": "298",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "C"
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  "."
+                                                ]
+                                              },
+                                              {
+                                                "r": "299",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "abatement"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              ")"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      ")"
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "r": "310",
+                                "value": [
+                                  " ",
+                                  "during",
+                                  " "
+                                ]
+                              },
+                              {
+                                "r": "308",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "\"Measurement Period\""
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "311",
+            "locator": "41:3-42:92",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "291",
+                "locator": "41:3-41:26",
+                "alias": "C",
+                "expression": {
+                  "localId": "294",
+                  "locator": "41:3-41:24",
+                  "dataType": "{http://hl7.org/fhir}Condition",
+                  "templateId": "http://hl7.org/fhir/StructureDefinition/Condition",
+                  "codeProperty": "code",
+                  "codeComparator": "in",
+                  "type": "Retrieve",
+                  "codes": {
+                    "localId": "293",
+                    "locator": "41:15-41:23",
+                    "name": "test-vs",
+                    "preserve": true,
+                    "type": "ValueSetRef"
+                  },
+                  "include": [],
+                  "codeFilter": [],
+                  "dateFilter": [],
+                  "otherFilter": []
+                }
+              }
+            ],
+            "let": [],
+            "relationship": [],
+            "where": {
+              "localId": "310",
+              "locator": "42:5-42:92",
+              "type": "In",
+              "signature": [],
+              "operand": [
+                {
+                  "localId": "305",
+                  "locator": "42:11-42:64",
+                  "name": "A Function",
+                  "type": "FunctionRef",
+                  "signature": [],
+                  "operand": [
+                    {
+                      "localId": "300",
+                      "locator": "42:24-42:63",
+                      "name": "Normalize Interval",
+                      "libraryName": "Global",
+                      "type": "FunctionRef",
+                      "signature": [],
+                      "operand": [
+                        {
+                          "localId": "299",
+                          "locator": "42:52-42:62",
+                          "path": "abatement",
+                          "scope": "C",
+                          "type": "Property"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "localId": "308",
+                  "locator": "42:73-42:92",
+                  "name": "Measurement Period",
+                  "type": "ParameterRef"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "localId": "322",
+          "locator": "85:1-86:6",
+          "name": "Passthrough",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "322",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define function \"Passthrough\"(cond Condition):\n  "
+                    ]
+                  },
+                  {
+                    "r": "568",
+                    "s": [
+                      {
+                        "r": "568",
+                        "s": [
+                          {
+                            "value": [
+                              "cond"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "568",
+            "locator": "86:3-86:6",
+            "name": "cond",
+            "type": "OperandRef"
+          },
+          "operand": [
+            {
+              "localId": "324",
+              "name": "cond",
+              "operandTypeSpecifier": {
+                "localId": "323",
+                "locator": "85:36-85:44",
+                "name": "{http://hl7.org/fhir}Condition",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "localId": "313",
+          "locator": "44:1-46:96",
+          "name": "FunctionRef With More Complexity in parameter",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "313",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"FunctionRef With More Complexity in parameter\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "333",
+                    "s": [
+                      {
+                        "s": [
+                          {
+                            "r": "314",
+                            "s": [
+                              {
+                                "r": "317",
+                                "s": [
+                                  {
+                                    "r": "317",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "[",
+                                          "Condition",
+                                          ": "
+                                        ]
+                                      },
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"test-vs\""
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "]"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "C"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "\n    "
+                        ]
+                      },
+                      {
+                        "r": "330",
+                        "s": [
+                          {
+                            "value": [
+                              "where "
+                            ]
+                          },
+                          {
+                            "r": "330",
+                            "s": [
+                              {
+                                "r": "328",
+                                "s": [
+                                  {
+                                    "r": "320",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "Global"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "."
+                                    ]
+                                  },
+                                  {
+                                    "r": "328",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "\"Normalize Interval\"",
+                                          " ( "
+                                        ]
+                                      },
+                                      {
+                                        "r": "327",
+                                        "s": [
+                                          {
+                                            "r": "325",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "\"Passthrough\"",
+                                                  "("
+                                                ]
+                                              },
+                                              {
+                                                "r": "321",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "C"
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  ")"
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              "."
+                                            ]
+                                          },
+                                          {
+                                            "r": "327",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "abatement"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          " )"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "r": "330",
+                                "value": [
+                                  " ",
+                                  "during",
+                                  " "
+                                ]
+                              },
+                              {
+                                "r": "329",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "\"Measurement Period\""
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "333",
+            "locator": "45:3-46:96",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "314",
+                "locator": "45:3-45:26",
+                "alias": "C",
+                "expression": {
+                  "localId": "317",
+                  "locator": "45:3-45:24",
+                  "dataType": "{http://hl7.org/fhir}Condition",
+                  "templateId": "http://hl7.org/fhir/StructureDefinition/Condition",
+                  "codeProperty": "code",
+                  "codeComparator": "in",
+                  "type": "Retrieve",
+                  "codes": {
+                    "localId": "316",
+                    "locator": "45:15-45:23",
+                    "name": "test-vs",
+                    "preserve": true,
+                    "type": "ValueSetRef"
+                  },
+                  "include": [],
+                  "codeFilter": [],
+                  "dateFilter": [],
+                  "otherFilter": []
+                }
+              }
+            ],
+            "let": [],
+            "relationship": [],
+            "where": {
+              "localId": "330",
+              "locator": "46:5-46:96",
+              "type": "IncludedIn",
+              "signature": [],
+              "operand": [
+                {
+                  "localId": "328",
+                  "locator": "46:11-46:68",
+                  "name": "Normalize Interval",
+                  "libraryName": "Global",
+                  "type": "FunctionRef",
+                  "signature": [],
+                  "operand": [
+                    {
+                      "localId": "327",
+                      "locator": "46:41-46:66",
+                      "path": "abatement",
+                      "type": "Property",
+                      "source": {
+                        "localId": "325",
+                        "locator": "46:41-46:56",
+                        "name": "Passthrough",
+                        "type": "FunctionRef",
+                        "signature": [],
+                        "operand": [
+                          {
+                            "localId": "321",
+                            "locator": "46:55",
+                            "name": "C",
+                            "type": "AliasRef"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                {
+                  "localId": "329",
+                  "locator": "46:77-46:96",
+                  "name": "Measurement Period",
+                  "type": "ParameterRef"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "localId": "335",
+          "locator": "48:1-50:40",
+          "name": "Equivalent with Parameter",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "335",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Equivalent with Parameter\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "348",
+                    "s": [
+                      {
+                        "s": [
+                          {
+                            "r": "336",
+                            "s": [
+                              {
+                                "r": "339",
+                                "s": [
+                                  {
+                                    "r": "339",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "[",
+                                          "Condition",
+                                          ": "
+                                        ]
+                                      },
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"test-vs\""
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "]"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "C"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "\n    "
+                        ]
+                      },
+                      {
+                        "r": "342",
+                        "s": [
+                          {
+                            "value": [
+                              "where "
+                            ]
+                          },
+                          {
+                            "r": "342",
+                            "s": [
+                              {
+                                "r": "344",
+                                "s": [
+                                  {
+                                    "r": "343",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "C"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "."
+                                    ]
+                                  },
+                                  {
+                                    "r": "344",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "onset"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "~",
+                                  " "
+                                ]
+                              },
+                              {
+                                "r": "345",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "\"Measurement Period\""
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "348",
+            "locator": "49:3-50:40",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "336",
+                "locator": "49:3-49:26",
+                "alias": "C",
+                "expression": {
+                  "localId": "339",
+                  "locator": "49:3-49:24",
+                  "dataType": "{http://hl7.org/fhir}Condition",
+                  "templateId": "http://hl7.org/fhir/StructureDefinition/Condition",
+                  "codeProperty": "code",
+                  "codeComparator": "in",
+                  "type": "Retrieve",
+                  "codes": {
+                    "localId": "338",
+                    "locator": "49:15-49:23",
+                    "name": "test-vs",
+                    "preserve": true,
+                    "type": "ValueSetRef"
+                  },
+                  "include": [],
+                  "codeFilter": [],
+                  "dateFilter": [],
+                  "otherFilter": []
+                }
+              }
+            ],
+            "let": [],
+            "relationship": [],
+            "where": {
+              "localId": "342",
+              "locator": "50:5-50:40",
+              "type": "Equivalent",
+              "signature": [],
+              "operand": [
+                {
+                  "localId": "347",
+                  "name": "ToInterval",
+                  "libraryName": "FHIRHelpers",
+                  "type": "FunctionRef",
+                  "signature": [],
+                  "operand": [
+                    {
+                      "localId": "346",
+                      "asType": "{http://hl7.org/fhir}Period",
+                      "type": "As",
+                      "signature": [],
+                      "operand": {
+                        "localId": "344",
+                        "locator": "50:11-50:17",
+                        "path": "onset",
+                        "scope": "C",
+                        "type": "Property"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "localId": "345",
+                  "locator": "50:21-50:40",
+                  "name": "Measurement Period",
+                  "type": "ParameterRef"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "localId": "350",
+          "locator": "52:1-54:110",
+          "name": "Encounter Starts 2 Years Or Less Before MP",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "350",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Encounter Starts 2 Years Or Less Before MP\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "384",
+                    "s": [
+                      {
+                        "s": [
+                          {
+                            "r": "351",
+                            "s": [
+                              {
+                                "r": "354",
+                                "s": [
+                                  {
+                                    "r": "354",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "[",
+                                          "Encounter",
+                                          ": "
+                                        ]
+                                      },
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"test-vs\""
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "]"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "Enc"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "\n    "
+                        ]
+                      },
+                      {
+                        "r": "383",
+                        "s": [
+                          {
+                            "value": [
+                              "where "
+                            ]
+                          },
+                          {
+                            "r": "383",
+                            "s": [
+                              {
+                                "r": "364",
+                                "s": [
+                                  {
+                                    "r": "361",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "Global"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "."
+                                    ]
+                                  },
+                                  {
+                                    "r": "364",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "\"Normalize Interval\"",
+                                          " ( "
+                                        ]
+                                      },
+                                      {
+                                        "r": "363",
+                                        "s": [
+                                          {
+                                            "r": "362",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "Enc"
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              "."
+                                            ]
+                                          },
+                                          {
+                                            "r": "363",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "period"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          " )"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " "
+                                ]
+                              },
+                              {
+                                "r": "383",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "starts "
+                                    ]
+                                  },
+                                  {
+                                    "r": "377",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "2 ",
+                                          "years"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      " or less before"
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " "
+                                ]
+                              },
+                              {
+                                "r": "374",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "end of "
+                                    ]
+                                  },
+                                  {
+                                    "r": "375",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "\"Measurement Period\""
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "384",
+            "locator": "53:3-54:110",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "351",
+                "locator": "53:3-53:28",
+                "alias": "Enc",
+                "expression": {
+                  "localId": "354",
+                  "locator": "53:3-53:24",
+                  "dataType": "{http://hl7.org/fhir}Encounter",
+                  "templateId": "http://hl7.org/fhir/StructureDefinition/Encounter",
+                  "codeProperty": "type",
+                  "codeComparator": "in",
+                  "type": "Retrieve",
+                  "codes": {
+                    "localId": "353",
+                    "locator": "53:15-53:23",
+                    "name": "test-vs",
+                    "preserve": true,
+                    "type": "ValueSetRef"
+                  },
+                  "include": [],
+                  "codeFilter": [],
+                  "dateFilter": [],
+                  "otherFilter": []
+                }
+              }
+            ],
+            "let": [],
+            "relationship": [],
+            "where": {
+              "localId": "383",
+              "locator": "54:5-54:110",
+              "type": "And",
+              "signature": [],
+              "operand": [
+                {
+                  "localId": "380",
+                  "locator": "54:61-54:75",
+                  "type": "In",
+                  "signature": [],
+                  "operand": [
+                    {
+                      "localId": "376",
+                      "locator": "54:54-54:59",
+                      "type": "Start",
+                      "signature": [],
+                      "operand": {
+                        "localId": "364",
+                        "locator": "54:11-54:52",
+                        "name": "Normalize Interval",
+                        "libraryName": "Global",
+                        "type": "FunctionRef",
+                        "signature": [],
+                        "operand": [
+                          {
+                            "localId": "365",
+                            "type": "As",
+                            "signature": [],
+                            "operand": {
+                              "localId": "363",
+                              "locator": "54:41-54:50",
+                              "path": "period",
+                              "scope": "Enc",
+                              "type": "Property"
+                            },
+                            "asTypeSpecifier": {
+                              "localId": "366",
+                              "type": "ChoiceTypeSpecifier",
+                              "choice": [
+                                {
+                                  "localId": "367",
+                                  "name": "{http://hl7.org/fhir}dateTime",
+                                  "type": "NamedTypeSpecifier"
+                                },
+                                {
+                                  "localId": "368",
+                                  "name": "{http://hl7.org/fhir}Period",
+                                  "type": "NamedTypeSpecifier"
+                                },
+                                {
+                                  "localId": "369",
+                                  "name": "{http://hl7.org/fhir}Timing",
+                                  "type": "NamedTypeSpecifier"
+                                },
+                                {
+                                  "localId": "370",
+                                  "name": "{http://hl7.org/fhir}instant",
+                                  "type": "NamedTypeSpecifier"
+                                },
+                                {
+                                  "localId": "371",
+                                  "name": "{http://hl7.org/fhir}string",
+                                  "type": "NamedTypeSpecifier"
+                                },
+                                {
+                                  "localId": "372",
+                                  "name": "{http://hl7.org/fhir}Age",
+                                  "type": "NamedTypeSpecifier"
+                                },
+                                {
+                                  "localId": "373",
+                                  "name": "{http://hl7.org/fhir}Range",
+                                  "type": "NamedTypeSpecifier"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "localId": "379",
+                      "locator": "54:61-54:75",
+                      "lowClosed": true,
+                      "highClosed": false,
+                      "type": "Interval",
+                      "low": {
+                        "localId": "378",
+                        "locator": "54:84-54:110",
+                        "type": "Subtract",
+                        "signature": [],
+                        "operand": [
+                          {
+                            "localId": "374",
+                            "locator": "54:84-54:110",
+                            "type": "End",
+                            "signature": [],
+                            "operand": {
+                              "localId": "375",
+                              "locator": "54:91-54:110",
+                              "name": "Measurement Period",
+                              "type": "ParameterRef"
+                            }
+                          },
+                          {
+                            "localId": "377",
+                            "locator": "54:61-54:67",
+                            "value": 2,
+                            "unit": "years",
+                            "type": "Quantity"
+                          }
+                        ]
+                      },
+                      "high": {
+                        "localId": "374",
+                        "locator": "54:84-54:110",
+                        "type": "End",
+                        "signature": [],
+                        "operand": {
+                          "localId": "375",
+                          "locator": "54:91-54:110",
+                          "name": "Measurement Period",
+                          "type": "ParameterRef"
+                        }
+                      }
+                    }
+                  ]
+                },
+                {
+                  "localId": "382",
+                  "locator": "54:61-54:75",
+                  "type": "Not",
+                  "signature": [],
+                  "operand": {
+                    "localId": "381",
+                    "locator": "54:61-54:75",
+                    "type": "IsNull",
+                    "signature": [],
+                    "operand": {
+                      "localId": "374",
+                      "locator": "54:84-54:110",
+                      "type": "End",
+                      "signature": [],
+                      "operand": {
+                        "localId": "375",
+                        "locator": "54:91-54:110",
+                        "name": "Measurement Period",
+                        "type": "ParameterRef"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "localId": "386",
+          "locator": "56:1-58:76",
+          "name": "Encounter In MP",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "386",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Encounter In MP\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "413",
+                    "s": [
+                      {
+                        "s": [
+                          {
+                            "r": "387",
+                            "s": [
+                              {
+                                "r": "390",
+                                "s": [
+                                  {
+                                    "r": "390",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "[",
+                                          "Encounter",
+                                          ": "
+                                        ]
+                                      },
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"test-vs\""
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "]"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "Enc"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "\n    "
+                        ]
+                      },
+                      {
+                        "r": "411",
+                        "s": [
+                          {
+                            "value": [
+                              "where "
+                            ]
+                          },
+                          {
+                            "r": "411",
+                            "s": [
+                              {
+                                "r": "400",
+                                "s": [
+                                  {
+                                    "r": "397",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "Global"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "."
+                                    ]
+                                  },
+                                  {
+                                    "r": "400",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "\"Normalize Interval\"",
+                                          " ( "
+                                        ]
+                                      },
+                                      {
+                                        "r": "399",
+                                        "s": [
+                                          {
+                                            "r": "398",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "Enc"
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              "."
+                                            ]
+                                          },
+                                          {
+                                            "r": "399",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "period"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          " )"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " in "
+                                ]
+                              },
+                              {
+                                "r": "410",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "\"Measurement Period\""
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "413",
+            "locator": "57:3-58:76",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "387",
+                "locator": "57:3-57:28",
+                "alias": "Enc",
+                "expression": {
+                  "localId": "390",
+                  "locator": "57:3-57:24",
+                  "dataType": "{http://hl7.org/fhir}Encounter",
+                  "templateId": "http://hl7.org/fhir/StructureDefinition/Encounter",
+                  "codeProperty": "type",
+                  "codeComparator": "in",
+                  "type": "Retrieve",
+                  "codes": {
+                    "localId": "389",
+                    "locator": "57:15-57:23",
+                    "name": "test-vs",
+                    "preserve": true,
+                    "type": "ValueSetRef"
+                  },
+                  "include": [],
+                  "codeFilter": [],
+                  "dateFilter": [],
+                  "otherFilter": []
+                }
+              }
+            ],
+            "let": [],
+            "relationship": [],
+            "where": {
+              "localId": "411",
+              "locator": "58:5-58:76",
+              "type": "In",
+              "signature": [],
+              "operand": [
+                {
+                  "localId": "400",
+                  "locator": "58:11-58:52",
+                  "name": "Normalize Interval",
+                  "libraryName": "Global",
+                  "type": "FunctionRef",
+                  "signature": [],
+                  "operand": [
+                    {
+                      "localId": "401",
+                      "type": "As",
+                      "signature": [],
+                      "operand": {
+                        "localId": "399",
+                        "locator": "58:41-58:50",
+                        "path": "period",
+                        "scope": "Enc",
+                        "type": "Property"
+                      },
+                      "asTypeSpecifier": {
+                        "localId": "402",
+                        "type": "ChoiceTypeSpecifier",
+                        "choice": [
+                          {
+                            "localId": "403",
+                            "name": "{http://hl7.org/fhir}dateTime",
+                            "type": "NamedTypeSpecifier"
+                          },
+                          {
+                            "localId": "404",
+                            "name": "{http://hl7.org/fhir}Period",
+                            "type": "NamedTypeSpecifier"
+                          },
+                          {
+                            "localId": "405",
+                            "name": "{http://hl7.org/fhir}Timing",
+                            "type": "NamedTypeSpecifier"
+                          },
+                          {
+                            "localId": "406",
+                            "name": "{http://hl7.org/fhir}instant",
+                            "type": "NamedTypeSpecifier"
+                          },
+                          {
+                            "localId": "407",
+                            "name": "{http://hl7.org/fhir}string",
+                            "type": "NamedTypeSpecifier"
+                          },
+                          {
+                            "localId": "408",
+                            "name": "{http://hl7.org/fhir}Age",
+                            "type": "NamedTypeSpecifier"
+                          },
+                          {
+                            "localId": "409",
+                            "name": "{http://hl7.org/fhir}Range",
+                            "type": "NamedTypeSpecifier"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                {
+                  "localId": "412",
+                  "type": "ToList",
+                  "signature": [],
+                  "operand": {
+                    "localId": "410",
+                    "locator": "58:57-58:76",
+                    "name": "Measurement Period",
+                    "type": "ParameterRef"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "localId": "428",
+          "locator": "88:1-89:40",
+          "name": "Interval From Period",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "428",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define function \"Interval From Period\"(period FHIR.Period):\n  "
+                    ]
+                  },
+                  {
+                    "r": "571",
+                    "s": [
+                      {
+                        "r": "571",
+                        "s": [
+                          {
+                            "r": "569",
+                            "s": [
+                              {
+                                "value": [
+                                  "Global"
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              "."
+                            ]
+                          },
+                          {
+                            "r": "571",
+                            "s": [
+                              {
+                                "value": [
+                                  "\"Normalize Interval\"",
+                                  " ( "
+                                ]
+                              },
+                              {
+                                "r": "570",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "period"
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " )"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "571",
+            "locator": "89:3-89:40",
+            "name": "Normalize Interval",
+            "libraryName": "Global",
+            "type": "FunctionRef",
+            "signature": [],
+            "operand": [
+              {
+                "localId": "572",
+                "type": "As",
+                "signature": [],
+                "operand": {
+                  "localId": "570",
+                  "locator": "89:33-89:38",
+                  "name": "period",
+                  "type": "OperandRef"
+                },
+                "asTypeSpecifier": {
+                  "localId": "573",
+                  "type": "ChoiceTypeSpecifier",
+                  "choice": [
+                    {
+                      "localId": "574",
+                      "name": "{http://hl7.org/fhir}dateTime",
+                      "type": "NamedTypeSpecifier"
+                    },
+                    {
+                      "localId": "575",
+                      "name": "{http://hl7.org/fhir}Period",
+                      "type": "NamedTypeSpecifier"
+                    },
+                    {
+                      "localId": "576",
+                      "name": "{http://hl7.org/fhir}Timing",
+                      "type": "NamedTypeSpecifier"
+                    },
+                    {
+                      "localId": "577",
+                      "name": "{http://hl7.org/fhir}instant",
+                      "type": "NamedTypeSpecifier"
+                    },
+                    {
+                      "localId": "578",
+                      "name": "{http://hl7.org/fhir}string",
+                      "type": "NamedTypeSpecifier"
+                    },
+                    {
+                      "localId": "579",
+                      "name": "{http://hl7.org/fhir}Age",
+                      "type": "NamedTypeSpecifier"
+                    },
+                    {
+                      "localId": "580",
+                      "name": "{http://hl7.org/fhir}Range",
+                      "type": "NamedTypeSpecifier"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "operand": [
+            {
+              "localId": "430",
+              "name": "period",
+              "operandTypeSpecifier": {
+                "localId": "429",
+                "locator": "88:47-88:57",
+                "name": "{http://hl7.org/fhir}Period",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "localId": "415",
+          "locator": "60:1-62:105",
+          "name": "Function call in Interval",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "415",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Function call in Interval\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "463",
+                    "s": [
+                      {
+                        "s": [
+                          {
+                            "r": "416",
+                            "s": [
+                              {
+                                "r": "419",
+                                "s": [
+                                  {
+                                    "r": "419",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "[",
+                                          "Encounter",
+                                          ": "
+                                        ]
+                                      },
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"test-vs\""
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "]"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "Enc"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "\n    "
+                        ]
+                      },
+                      {
+                        "r": "461",
+                        "s": [
+                          {
+                            "value": [
+                              "where "
+                            ]
+                          },
+                          {
+                            "r": "461",
+                            "s": [
+                              {
+                                "r": "431",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "\"Interval From Period\"",
+                                      "("
+                                    ]
+                                  },
+                                  {
+                                    "r": "427",
+                                    "s": [
+                                      {
+                                        "r": "426",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "Enc"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "."
+                                        ]
+                                      },
+                                      {
+                                        "r": "427",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "period"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      ")"
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " in "
+                                ]
+                              },
+                              {
+                                "r": "460",
+                                "s": [
+                                  {
+                                    "r": "444",
+                                    "value": [
+                                      "Interval[",
+                                      "@2019-01-01T00:00:00.0",
+                                      ", ",
+                                      "@2020-01-01T00:00:00.0",
+                                      " )"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "463",
+            "locator": "61:3-62:105",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "416",
+                "locator": "61:3-61:28",
+                "alias": "Enc",
+                "expression": {
+                  "localId": "419",
+                  "locator": "61:3-61:24",
+                  "dataType": "{http://hl7.org/fhir}Encounter",
+                  "templateId": "http://hl7.org/fhir/StructureDefinition/Encounter",
+                  "codeProperty": "type",
+                  "codeComparator": "in",
+                  "type": "Retrieve",
+                  "codes": {
+                    "localId": "418",
+                    "locator": "61:15-61:23",
+                    "name": "test-vs",
+                    "preserve": true,
+                    "type": "ValueSetRef"
+                  },
+                  "include": [],
+                  "codeFilter": [],
+                  "dateFilter": [],
+                  "otherFilter": []
+                }
+              }
+            ],
+            "let": [],
+            "relationship": [],
+            "where": {
+              "localId": "461",
+              "locator": "62:5-62:105",
+              "type": "In",
+              "signature": [],
+              "operand": [
+                {
+                  "localId": "431",
+                  "locator": "62:11-62:44",
+                  "name": "Interval From Period",
+                  "type": "FunctionRef",
+                  "signature": [],
+                  "operand": [
+                    {
+                      "localId": "427",
+                      "locator": "62:34-62:43",
+                      "path": "period",
+                      "scope": "Enc",
+                      "type": "Property"
+                    }
+                  ]
+                },
+                {
+                  "localId": "462",
+                  "type": "ToList",
+                  "signature": [],
+                  "operand": {
+                    "localId": "460",
+                    "locator": "62:49-62:105",
+                    "lowClosed": true,
+                    "highClosed": false,
+                    "type": "Interval",
+                    "low": {
+                      "localId": "444",
+                      "locator": "62:58-62:79",
+                      "type": "DateTime",
+                      "signature": [],
+                      "year": {
+                        "localId": "445",
+                        "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                        "value": "2019",
+                        "type": "Literal"
+                      },
+                      "month": {
+                        "localId": "446",
+                        "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                        "value": "1",
+                        "type": "Literal"
+                      },
+                      "day": {
+                        "localId": "447",
+                        "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                        "value": "1",
+                        "type": "Literal"
+                      },
+                      "hour": {
+                        "localId": "448",
+                        "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                        "value": "0",
+                        "type": "Literal"
+                      },
+                      "minute": {
+                        "localId": "449",
+                        "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                        "value": "0",
+                        "type": "Literal"
+                      },
+                      "second": {
+                        "localId": "450",
+                        "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                        "value": "0",
+                        "type": "Literal"
+                      },
+                      "millisecond": {
+                        "localId": "451",
+                        "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                        "value": "0",
+                        "type": "Literal"
+                      }
+                    },
+                    "high": {
+                      "localId": "452",
+                      "locator": "62:82-62:103",
+                      "type": "DateTime",
+                      "signature": [],
+                      "year": {
+                        "localId": "453",
+                        "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                        "value": "2020",
+                        "type": "Literal"
+                      },
+                      "month": {
+                        "localId": "454",
+                        "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                        "value": "1",
+                        "type": "Literal"
+                      },
+                      "day": {
+                        "localId": "455",
+                        "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                        "value": "1",
+                        "type": "Literal"
+                      },
+                      "hour": {
+                        "localId": "456",
+                        "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                        "value": "0",
+                        "type": "Literal"
+                      },
+                      "minute": {
+                        "localId": "457",
+                        "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                        "value": "0",
+                        "type": "Literal"
+                      },
+                      "second": {
+                        "localId": "458",
+                        "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                        "value": "0",
+                        "type": "Literal"
+                      },
+                      "millisecond": {
+                        "localId": "459",
+                        "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                        "value": "0",
+                        "type": "Literal"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "localId": "465",
+          "locator": "64:1-66:150",
+          "name": "GreaterThanOrEqual Birthdate at start of Observation",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "465",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"GreaterThanOrEqual Birthdate at start of Observation\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "487",
+                    "s": [
+                      {
+                        "s": [
+                          {
+                            "r": "466",
+                            "s": [
+                              {
+                                "r": "469",
+                                "s": [
+                                  {
+                                    "r": "469",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "[",
+                                          "Observation",
+                                          ": "
+                                        ]
+                                      },
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"test-vs\""
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "]"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "HPVTest"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "\n    "
+                        ]
+                      },
+                      {
+                        "r": "472",
+                        "s": [
+                          {
+                            "value": [
+                              "where "
+                            ]
+                          },
+                          {
+                            "r": "472",
+                            "s": [
+                              {
+                                "r": "483",
+                                "s": [
+                                  {
+                                    "r": "473",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "Global"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "."
+                                    ]
+                                  },
+                                  {
+                                    "r": "483",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "\"CalendarAgeInYearsAt\"",
+                                          " ( "
+                                        ]
+                                      },
+                                      {
+                                        "r": "477",
+                                        "s": [
+                                          {
+                                            "r": "474",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "FHIRHelpers"
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              "."
+                                            ]
+                                          },
+                                          {
+                                            "r": "477",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "ToDate",
+                                                  " ( "
+                                                ]
+                                              },
+                                              {
+                                                "r": "476",
+                                                "s": [
+                                                  {
+                                                    "r": "475",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "Patient"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "value": [
+                                                      "."
+                                                    ]
+                                                  },
+                                                  {
+                                                    "r": "476",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "birthDate"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  " )"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          ", "
+                                        ]
+                                      },
+                                      {
+                                        "r": "478",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "start of "
+                                            ]
+                                          },
+                                          {
+                                            "r": "482",
+                                            "s": [
+                                              {
+                                                "r": "479",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "Global"
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  "."
+                                                ]
+                                              },
+                                              {
+                                                "r": "482",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "\"Normalize Interval\"",
+                                                      " ( "
+                                                    ]
+                                                  },
+                                                  {
+                                                    "r": "481",
+                                                    "s": [
+                                                      {
+                                                        "r": "480",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "HPVTest"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "value": [
+                                                          "."
+                                                        ]
+                                                      },
+                                                      {
+                                                        "r": "481",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "effective"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "value": [
+                                                      " )"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          " )"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "r": "486",
+                                "value": [
+                                  " ",
+                                  ">=",
+                                  " ",
+                                  "30"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "487",
+            "locator": "65:3-66:150",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "466",
+                "locator": "65:3-65:34",
+                "alias": "HPVTest",
+                "expression": {
+                  "localId": "469",
+                  "locator": "65:3-65:26",
+                  "dataType": "{http://hl7.org/fhir}Observation",
+                  "templateId": "http://hl7.org/fhir/StructureDefinition/Observation",
+                  "codeProperty": "code",
+                  "codeComparator": "in",
+                  "type": "Retrieve",
+                  "codes": {
+                    "localId": "468",
+                    "locator": "65:17-65:25",
+                    "name": "test-vs",
+                    "preserve": true,
+                    "type": "ValueSetRef"
+                  },
+                  "include": [],
+                  "codeFilter": [],
+                  "dateFilter": [],
+                  "otherFilter": []
+                }
+              }
+            ],
+            "let": [],
+            "relationship": [],
+            "where": {
+              "localId": "472",
+              "locator": "66:5-66:150",
+              "type": "GreaterOrEqual",
+              "signature": [],
+              "operand": [
+                {
+                  "localId": "483",
+                  "locator": "66:11-66:144",
+                  "name": "CalendarAgeInYearsAt",
+                  "libraryName": "Global",
+                  "type": "FunctionRef",
+                  "signature": [],
+                  "operand": [
+                    {
+                      "localId": "485",
+                      "type": "ToDateTime",
+                      "signature": [],
+                      "operand": {
+                        "localId": "477",
+                        "locator": "66:43-66:82",
+                        "name": "ToDate",
+                        "libraryName": "FHIRHelpers",
+                        "type": "FunctionRef",
+                        "signature": [],
+                        "operand": [
+                          {
+                            "localId": "476",
+                            "locator": "66:64-66:80",
+                            "path": "birthDate",
+                            "type": "Property",
+                            "source": {
+                              "localId": "475",
+                              "locator": "66:64-66:70",
+                              "name": "Patient",
+                              "type": "ExpressionRef"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "localId": "478",
+                      "locator": "66:85-66:142",
+                      "type": "Start",
+                      "signature": [],
+                      "operand": {
+                        "localId": "482",
+                        "locator": "66:94-66:142",
+                        "name": "Normalize Interval",
+                        "libraryName": "Global",
+                        "type": "FunctionRef",
+                        "signature": [],
+                        "operand": [
+                          {
+                            "localId": "481",
+                            "locator": "66:124-66:140",
+                            "path": "effective",
+                            "scope": "HPVTest",
+                            "type": "Property"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                {
+                  "localId": "486",
+                  "locator": "66:149-66:150",
+                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                  "value": "30",
+                  "type": "Literal"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "localId": "489",
+          "locator": "68:1-70:30",
+          "name": "GreaterThanOrEqual Observation Value",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "489",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"GreaterThanOrEqual Observation Value\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "502",
+                    "s": [
+                      {
+                        "s": [
+                          {
+                            "r": "490",
+                            "s": [
+                              {
+                                "r": "493",
+                                "s": [
+                                  {
+                                    "r": "493",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "[",
+                                          "Observation",
+                                          ": "
+                                        ]
+                                      },
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"test-vs\""
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "]"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "Test"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "\n    "
+                        ]
+                      },
+                      {
+                        "r": "496",
+                        "s": [
+                          {
+                            "value": [
+                              "where "
+                            ]
+                          },
+                          {
+                            "r": "496",
+                            "s": [
+                              {
+                                "r": "498",
+                                "s": [
+                                  {
+                                    "r": "497",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "Test"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "."
+                                    ]
+                                  },
+                                  {
+                                    "r": "498",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "value"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  ">=",
+                                  " "
+                                ]
+                              },
+                              {
+                                "r": "499",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "2 ",
+                                      "'mg'"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "502",
+            "locator": "69:3-70:30",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "490",
+                "locator": "69:3-69:31",
+                "alias": "Test",
+                "expression": {
+                  "localId": "493",
+                  "locator": "69:3-69:26",
+                  "dataType": "{http://hl7.org/fhir}Observation",
+                  "templateId": "http://hl7.org/fhir/StructureDefinition/Observation",
+                  "codeProperty": "code",
+                  "codeComparator": "in",
+                  "type": "Retrieve",
+                  "codes": {
+                    "localId": "492",
+                    "locator": "69:17-69:25",
+                    "name": "test-vs",
+                    "preserve": true,
+                    "type": "ValueSetRef"
+                  },
+                  "include": [],
+                  "codeFilter": [],
+                  "dateFilter": [],
+                  "otherFilter": []
+                }
+              }
+            ],
+            "let": [],
+            "relationship": [],
+            "where": {
+              "localId": "496",
+              "locator": "70:5-70:30",
+              "type": "GreaterOrEqual",
+              "signature": [],
+              "operand": [
+                {
+                  "localId": "501",
+                  "name": "ToQuantity",
+                  "libraryName": "FHIRHelpers",
+                  "type": "FunctionRef",
+                  "signature": [],
+                  "operand": [
+                    {
+                      "localId": "500",
+                      "asType": "{http://hl7.org/fhir}Quantity",
+                      "type": "As",
+                      "signature": [],
+                      "operand": {
+                        "localId": "498",
+                        "locator": "70:11-70:20",
+                        "path": "value",
+                        "scope": "Test",
+                        "type": "Property"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "localId": "499",
+                  "locator": "70:25-70:30",
+                  "value": 2,
+                  "unit": "mg",
+                  "type": "Quantity"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "localId": "520",
+          "locator": "91:1-92:19",
+          "name": "startTime",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "fluent": true,
+          "type": "FunctionDef",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "520",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define fluent function \"startTime\"(e FHIR.Encounter):\n  "
+                    ]
+                  },
+                  {
+                    "r": "581",
+                    "s": [
+                      {
+                        "r": "581",
+                        "s": [
+                          {
+                            "value": [
+                              "start of "
+                            ]
+                          },
+                          {
+                            "r": "583",
+                            "s": [
+                              {
+                                "r": "582",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "e"
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  "."
+                                ]
+                              },
+                              {
+                                "r": "583",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "period"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "581",
+            "locator": "92:3-92:19",
+            "type": "Start",
+            "signature": [],
+            "operand": {
+              "localId": "584",
+              "name": "ToInterval",
+              "libraryName": "FHIRHelpers",
+              "type": "FunctionRef",
+              "signature": [],
+              "operand": [
+                {
+                  "localId": "583",
+                  "locator": "92:12-92:19",
+                  "path": "period",
+                  "type": "Property",
+                  "source": {
+                    "localId": "582",
+                    "locator": "92:12",
+                    "name": "e",
+                    "type": "OperandRef"
+                  }
+                }
+              ]
+            }
+          },
+          "operand": [
+            {
+              "localId": "522",
+              "name": "e",
+              "operandTypeSpecifier": {
+                "localId": "521",
+                "locator": "91:38-91:51",
+                "name": "{http://hl7.org/fhir}Encounter",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "localId": "504",
+          "locator": "72:1-75:91",
+          "name": "Observation Issued During First 10 min of Encounter",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "504",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Observation Issued During First 10 min of Encounter\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "537",
+                    "s": [
+                      {
+                        "s": [
+                          {
+                            "r": "505",
+                            "s": [
+                              {
+                                "r": "506",
+                                "s": [
+                                  {
+                                    "r": "506",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "[",
+                                          "Observation",
+                                          "]"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "Obs"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "\n    "
+                        ]
+                      },
+                      {
+                        "r": "536",
+                        "s": [
+                          {
+                            "value": [
+                              "with "
+                            ]
+                          },
+                          {
+                            "r": "507",
+                            "s": [
+                              {
+                                "r": "510",
+                                "s": [
+                                  {
+                                    "r": "510",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "[",
+                                          "Encounter",
+                                          ": "
+                                        ]
+                                      },
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"test-vs\""
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "]"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "Enc"
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              "\n      such that "
+                            ]
+                          },
+                          {
+                            "r": "534",
+                            "s": [
+                              {
+                                "r": "518",
+                                "s": [
+                                  {
+                                    "r": "517",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "Obs"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "."
+                                    ]
+                                  },
+                                  {
+                                    "r": "518",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "issued"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "r": "534",
+                                "value": [
+                                  " ",
+                                  "during",
+                                  " "
+                                ]
+                              },
+                              {
+                                "r": "532",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "Interval["
+                                    ]
+                                  },
+                                  {
+                                    "r": "523",
+                                    "s": [
+                                      {
+                                        "r": "519",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "Enc"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "."
+                                        ]
+                                      },
+                                      {
+                                        "r": "523",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "startTime",
+                                              " ( )"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      ", "
+                                    ]
+                                  },
+                                  {
+                                    "r": "528",
+                                    "s": [
+                                      {
+                                        "r": "530",
+                                        "s": [
+                                          {
+                                            "r": "529",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "Enc"
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              "."
+                                            ]
+                                          },
+                                          {
+                                            "r": "530",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "startTime",
+                                                  " ( )"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          " + "
+                                        ]
+                                      },
+                                      {
+                                        "r": "531",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "10 ",
+                                              "'min'"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "]"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "537",
+            "locator": "73:3-75:91",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "505",
+                "locator": "73:3-73:19",
+                "alias": "Obs",
+                "expression": {
+                  "localId": "506",
+                  "locator": "73:3-73:15",
+                  "dataType": "{http://hl7.org/fhir}Observation",
+                  "templateId": "http://hl7.org/fhir/StructureDefinition/Observation",
+                  "type": "Retrieve",
+                  "include": [],
+                  "codeFilter": [],
+                  "dateFilter": [],
+                  "otherFilter": []
+                }
+              }
+            ],
+            "let": [],
+            "relationship": [
+              {
+                "localId": "536",
+                "locator": "74:5-75:91",
+                "alias": "Enc",
+                "type": "With",
+                "expression": {
+                  "localId": "510",
+                  "locator": "74:10-74:31",
+                  "dataType": "{http://hl7.org/fhir}Encounter",
+                  "templateId": "http://hl7.org/fhir/StructureDefinition/Encounter",
+                  "codeProperty": "type",
+                  "codeComparator": "in",
+                  "type": "Retrieve",
+                  "codes": {
+                    "localId": "509",
+                    "locator": "74:22-74:30",
+                    "name": "test-vs",
+                    "preserve": true,
+                    "type": "ValueSetRef"
+                  },
+                  "include": [],
+                  "codeFilter": [],
+                  "dateFilter": [],
+                  "otherFilter": []
+                },
+                "suchThat": {
+                  "localId": "534",
+                  "locator": "75:17-75:91",
+                  "type": "In",
+                  "signature": [],
+                  "operand": [
+                    {
+                      "localId": "535",
+                      "name": "ToDateTime",
+                      "libraryName": "FHIRHelpers",
+                      "type": "FunctionRef",
+                      "signature": [],
+                      "operand": [
+                        {
+                          "localId": "518",
+                          "locator": "75:17-75:26",
+                          "path": "issued",
+                          "scope": "Obs",
+                          "type": "Property"
+                        }
+                      ]
+                    },
+                    {
+                      "localId": "532",
+                      "locator": "75:35-75:91",
+                      "lowClosed": true,
+                      "highClosed": true,
+                      "type": "Interval",
+                      "low": {
+                        "localId": "523",
+                        "locator": "75:44-75:60",
+                        "name": "startTime",
+                        "type": "FunctionRef",
+                        "signature": [],
+                        "operand": [
+                          {
+                            "localId": "519",
+                            "locator": "75:44-75:46",
+                            "name": "Enc",
+                            "type": "AliasRef"
+                          }
+                        ]
+                      },
+                      "high": {
+                        "localId": "528",
+                        "locator": "75:63-75:90",
+                        "type": "Add",
+                        "signature": [],
+                        "operand": [
+                          {
+                            "localId": "530",
+                            "locator": "75:63-75:79",
+                            "name": "startTime",
+                            "type": "FunctionRef",
+                            "signature": [],
+                            "operand": [
+                              {
+                                "localId": "529",
+                                "locator": "75:63-75:65",
+                                "name": "Enc",
+                                "type": "AliasRef"
+                              }
+                            ]
+                          },
+                          {
+                            "localId": "531",
+                            "locator": "75:83-75:90",
+                            "value": 10,
+                            "unit": "min",
+                            "type": "Quantity"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "localId": "539",
+          "locator": "77:1-80:94",
+          "name": "Observation Issued Between Start of MP and Encounter",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "539",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Observation Issued Between Start of MP and Encounter\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "565",
+                    "s": [
+                      {
+                        "s": [
+                          {
+                            "r": "540",
+                            "s": [
+                              {
+                                "r": "541",
+                                "s": [
+                                  {
+                                    "r": "541",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "[",
+                                          "Observation",
+                                          "]"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "Obs"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "\n    "
+                        ]
+                      },
+                      {
+                        "r": "564",
+                        "s": [
+                          {
+                            "value": [
+                              "with "
+                            ]
+                          },
+                          {
+                            "r": "542",
+                            "s": [
+                              {
+                                "r": "545",
+                                "s": [
+                                  {
+                                    "r": "545",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "[",
+                                          "Encounter",
+                                          ": "
+                                        ]
+                                      },
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"test-vs\""
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "]"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "Enc"
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              "\n      such that "
+                            ]
+                          },
+                          {
+                            "r": "562",
+                            "s": [
+                              {
+                                "r": "553",
+                                "s": [
+                                  {
+                                    "r": "552",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "Obs"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "."
+                                    ]
+                                  },
+                                  {
+                                    "r": "553",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "issued"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "r": "562",
+                                "value": [
+                                  " ",
+                                  "during",
+                                  " "
+                                ]
+                              },
+                              {
+                                "r": "560",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "Interval["
+                                    ]
+                                  },
+                                  {
+                                    "r": "554",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "start of "
+                                        ]
+                                      },
+                                      {
+                                        "r": "555",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"Measurement Period\""
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      ", "
+                                    ]
+                                  },
+                                  {
+                                    "r": "556",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "start of "
+                                        ]
+                                      },
+                                      {
+                                        "r": "558",
+                                        "s": [
+                                          {
+                                            "r": "557",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "Enc"
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              "."
+                                            ]
+                                          },
+                                          {
+                                            "r": "558",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "period"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "]"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "565",
+            "locator": "78:3-80:94",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "540",
+                "locator": "78:3-78:19",
+                "alias": "Obs",
+                "expression": {
+                  "localId": "541",
+                  "locator": "78:3-78:15",
+                  "dataType": "{http://hl7.org/fhir}Observation",
+                  "templateId": "http://hl7.org/fhir/StructureDefinition/Observation",
+                  "type": "Retrieve",
+                  "include": [],
+                  "codeFilter": [],
+                  "dateFilter": [],
+                  "otherFilter": []
+                }
+              }
+            ],
+            "let": [],
+            "relationship": [
+              {
+                "localId": "564",
+                "locator": "79:5-80:94",
+                "alias": "Enc",
+                "type": "With",
+                "expression": {
+                  "localId": "545",
+                  "locator": "79:10-79:31",
+                  "dataType": "{http://hl7.org/fhir}Encounter",
+                  "templateId": "http://hl7.org/fhir/StructureDefinition/Encounter",
+                  "codeProperty": "type",
+                  "codeComparator": "in",
+                  "type": "Retrieve",
+                  "codes": {
+                    "localId": "544",
+                    "locator": "79:22-79:30",
+                    "name": "test-vs",
+                    "preserve": true,
+                    "type": "ValueSetRef"
+                  },
+                  "include": [],
+                  "codeFilter": [],
+                  "dateFilter": [],
+                  "otherFilter": []
+                },
+                "suchThat": {
+                  "localId": "562",
+                  "locator": "80:17-80:94",
+                  "type": "In",
+                  "signature": [],
+                  "operand": [
+                    {
+                      "localId": "563",
+                      "name": "ToDateTime",
+                      "libraryName": "FHIRHelpers",
+                      "type": "FunctionRef",
+                      "signature": [],
+                      "operand": [
+                        {
+                          "localId": "553",
+                          "locator": "80:17-80:26",
+                          "path": "issued",
+                          "scope": "Obs",
+                          "type": "Property"
+                        }
+                      ]
+                    },
+                    {
+                      "localId": "560",
+                      "locator": "80:35-80:94",
+                      "lowClosed": true,
+                      "highClosed": true,
+                      "type": "Interval",
+                      "low": {
+                        "localId": "554",
+                        "locator": "80:44-80:72",
+                        "type": "Start",
+                        "signature": [],
+                        "operand": {
+                          "localId": "555",
+                          "locator": "80:53-80:72",
+                          "name": "Measurement Period",
+                          "type": "ParameterRef"
+                        }
+                      },
+                      "high": {
+                        "localId": "556",
+                        "locator": "80:75-80:93",
+                        "type": "Start",
+                        "signature": [],
+                        "operand": {
+                          "localId": "559",
+                          "name": "ToInterval",
+                          "libraryName": "FHIRHelpers",
+                          "type": "FunctionRef",
+                          "signature": [],
+                          "operand": [
+                            {
+                              "localId": "558",
+                              "locator": "80:84-80:93",
+                              "path": "period",
+                              "scope": "Enc",
+                              "type": "Property"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/test/unit/fixtures/elm/3.15.0/MATGlobalCommonFunctions.json
+++ b/test/unit/fixtures/elm/3.15.0/MATGlobalCommonFunctions.json
@@ -1,0 +1,17877 @@
+{
+  "library": {
+    "localId": "0",
+    "annotation": [
+      {
+        "translatorVersion": "3.15.0",
+        "translatorOptions": "EnableAnnotations,EnableLocators",
+        "signatureLevel": "None",
+        "type": "CqlToElmInfo"
+      },
+      {
+        "message": "The function FHIRHelpers.ToString has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToInterval has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToInterval has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToString has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToInterval has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToInterval has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToInterval has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToInterval has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToInterval has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToInterval has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToInterval has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToInterval has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToInterval has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToInterval has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToInterval has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToInterval has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToInterval has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToInterval has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToInterval has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToInterval has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToInterval has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToDateTime has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToDateTime has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToInterval has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToDateTime has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToDateTime has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToDateTime has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToDateTime has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToInterval has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToDateTime has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToString has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToString has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToString has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToString has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToString has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToString has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToString has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function MATGlobalCommonFunctions.GetExtensions has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToString has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function MATGlobalCommonFunctions.GetExtensions has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToString has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "libraryId": "MATGlobalCommonFunctions",
+        "libraryVersion": "5.0.000",
+        "startLine": 277,
+        "startChar": 19,
+        "endLine": 277,
+        "endChar": 53,
+        "message": "Could not resolve membership operator for terminology target of the retrieve.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToString has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToString has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "type": "Annotation",
+        "s": {
+          "r": "1136",
+          "s": [
+            {
+              "value": [
+                "",
+                "library MATGlobalCommonFunctions version '5.0.000'"
+              ]
+            }
+          ]
+        }
+      }
+    ],
+    "identifier": {
+      "id": "MATGlobalCommonFunctions",
+      "version": "5.0.000"
+    },
+    "schemaIdentifier": {
+      "id": "urn:hl7-org:elm",
+      "version": "r1"
+    },
+    "usings": {
+      "def": [
+        {
+          "localId": "1",
+          "localIdentifier": "System",
+          "uri": "urn:hl7-org:elm-types:r1"
+        },
+        {
+          "localId": "206",
+          "locator": "3:1-3:26",
+          "localIdentifier": "FHIR",
+          "uri": "http://hl7.org/fhir",
+          "version": "4.0.1",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "206",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "using "
+                    ]
+                  },
+                  {
+                    "s": [
+                      {
+                        "value": [
+                          "FHIR"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " version '4.0.1'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "includes": {
+      "def": [
+        {
+          "localId": "207",
+          "locator": "5:1-5:54",
+          "localIdentifier": "FHIRHelpers",
+          "path": "FHIRHelpers",
+          "version": "4.0.1",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "207",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "include "
+                    ]
+                  },
+                  {
+                    "s": [
+                      {
+                        "value": [
+                          "FHIRHelpers"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " version ",
+                      "'4.0.1'",
+                      " called ",
+                      "FHIRHelpers"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "parameters": {
+      "def": [
+        {
+          "localId": "271",
+          "locator": "57:1-58:66",
+          "name": "Measurement Period",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "271",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "parameter ",
+                      "\"Measurement Period\"",
+                      " "
+                    ]
+                  },
+                  {
+                    "r": "289",
+                    "s": [
+                      {
+                        "value": [
+                          "Interval<"
+                        ]
+                      },
+                      {
+                        "r": "290",
+                        "s": [
+                          {
+                            "value": [
+                              "DateTime"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          ">"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      "\n  default "
+                    ]
+                  },
+                  {
+                    "r": "288",
+                    "s": [
+                      {
+                        "r": "272",
+                        "value": [
+                          "Interval[",
+                          "@2019-01-01T00:00:00.0",
+                          ", ",
+                          "@2020-01-01T00:00:00.0",
+                          ")"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "default": {
+            "localId": "288",
+            "locator": "58:11-58:66",
+            "lowClosed": true,
+            "highClosed": false,
+            "type": "Interval",
+            "low": {
+              "localId": "272",
+              "locator": "58:20-58:41",
+              "type": "DateTime",
+              "signature": [],
+              "year": {
+                "localId": "273",
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "2019",
+                "type": "Literal"
+              },
+              "month": {
+                "localId": "274",
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "1",
+                "type": "Literal"
+              },
+              "day": {
+                "localId": "275",
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "1",
+                "type": "Literal"
+              },
+              "hour": {
+                "localId": "276",
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "0",
+                "type": "Literal"
+              },
+              "minute": {
+                "localId": "277",
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "0",
+                "type": "Literal"
+              },
+              "second": {
+                "localId": "278",
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "0",
+                "type": "Literal"
+              },
+              "millisecond": {
+                "localId": "279",
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "0",
+                "type": "Literal"
+              }
+            },
+            "high": {
+              "localId": "280",
+              "locator": "58:44-58:65",
+              "type": "DateTime",
+              "signature": [],
+              "year": {
+                "localId": "281",
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "2020",
+                "type": "Literal"
+              },
+              "month": {
+                "localId": "282",
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "1",
+                "type": "Literal"
+              },
+              "day": {
+                "localId": "283",
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "1",
+                "type": "Literal"
+              },
+              "hour": {
+                "localId": "284",
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "0",
+                "type": "Literal"
+              },
+              "minute": {
+                "localId": "285",
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "0",
+                "type": "Literal"
+              },
+              "second": {
+                "localId": "286",
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "0",
+                "type": "Literal"
+              },
+              "millisecond": {
+                "localId": "287",
+                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                "value": "0",
+                "type": "Literal"
+              }
+            }
+          },
+          "parameterTypeSpecifier": {
+            "localId": "289",
+            "locator": "57:32-57:49",
+            "type": "IntervalTypeSpecifier",
+            "pointType": {
+              "localId": "290",
+              "locator": "57:41-57:48",
+              "name": "{urn:hl7-org:elm-types:r1}DateTime",
+              "type": "NamedTypeSpecifier"
+            }
+          }
+        }
+      ]
+    },
+    "codeSystems": {
+      "def": [
+        {
+          "localId": "208",
+          "locator": "7:1-7:38",
+          "name": "LOINC",
+          "id": "http://loinc.org",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "208",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "codesystem ",
+                      "\"LOINC\"",
+                      ": ",
+                      "'http://loinc.org'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "localId": "209",
+          "locator": "8:1-8:60",
+          "name": "SNOMEDCT",
+          "id": "http://snomed.info/sct/731000124108",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "209",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "codesystem ",
+                      "\"SNOMEDCT\"",
+                      ": ",
+                      "'http://snomed.info/sct/731000124108'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "localId": "210",
+          "locator": "9:1-9:56",
+          "name": "RoleCode",
+          "id": "http://hl7.org/fhir/v3/RoleCode",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "210",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "codesystem ",
+                      "\"RoleCode\"",
+                      ": ",
+                      "'http://hl7.org/fhir/v3/RoleCode'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "localId": "211",
+          "locator": "10:1-10:83",
+          "name": "Diagnosis Role",
+          "id": "http://terminology.hl7.org/CodeSystem/diagnosis-role",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "211",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "codesystem ",
+                      "\"Diagnosis Role\"",
+                      ": ",
+                      "'http://terminology.hl7.org/CodeSystem/diagnosis-role'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "localId": "212",
+          "locator": "11:1-11:82",
+          "name": "RequestIntent",
+          "id": "http://terminology.hl7.org/CodeSystem/request-intent",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "212",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "codesystem ",
+                      "\"RequestIntent\"",
+                      ": ",
+                      "'http://terminology.hl7.org/CodeSystem/request-intent'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "localId": "213",
+          "locator": "12:1-12:106",
+          "name": "MedicationRequestCategory",
+          "id": "http://terminology.hl7.org/CodeSystem/medicationrequest-category",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "213",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "codesystem ",
+                      "\"MedicationRequestCategory\"",
+                      ": ",
+                      "'http://terminology.hl7.org/CodeSystem/medicationrequest-category'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "localId": "214",
+          "locator": "13:1-13:101",
+          "name": "ConditionClinicalStatusCodes",
+          "id": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "214",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "codesystem ",
+                      "\"ConditionClinicalStatusCodes\"",
+                      ": ",
+                      "'http://terminology.hl7.org/CodeSystem/condition-clinical'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "localId": "215",
+          "locator": "14:1-14:109",
+          "name": "ConditionVerificationStatusCodes",
+          "id": "http://terminology.hl7.org/CodeSystem/condition-verification",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "215",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "codesystem ",
+                      "\"ConditionVerificationStatusCodes\"",
+                      ": ",
+                      "'http://terminology.hl7.org/CodeSystem/condition-verification'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "localId": "216",
+          "locator": "15:1-15:119",
+          "name": "AllergyIntoleranceClinicalStatusCodes",
+          "id": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "216",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "codesystem ",
+                      "\"AllergyIntoleranceClinicalStatusCodes\"",
+                      ": ",
+                      "'http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "localId": "217",
+          "locator": "16:1-16:127",
+          "name": "AllergyIntoleranceVerificationStatusCodes",
+          "id": "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "217",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "codesystem ",
+                      "\"AllergyIntoleranceVerificationStatusCodes\"",
+                      ": ",
+                      "'http://terminology.hl7.org/CodeSystem/allergyintolerance-verification'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "valueSets": {
+      "def": [
+        {
+          "localId": "218",
+          "locator": "18:1-18:100",
+          "name": "Encounter Inpatient",
+          "id": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "218",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "valueset ",
+                      "\"Encounter Inpatient\"",
+                      ": ",
+                      "'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": []
+        },
+        {
+          "localId": "219",
+          "locator": "19:1-19:111",
+          "name": "Emergency Department Visit",
+          "id": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "219",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "valueset ",
+                      "\"Emergency Department Visit\"",
+                      ": ",
+                      "'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": []
+        },
+        {
+          "localId": "220",
+          "locator": "20:1-20:102",
+          "name": "Observation Services",
+          "id": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "220",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "valueset ",
+                      "\"Observation Services\"",
+                      ": ",
+                      "'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": []
+        }
+      ]
+    },
+    "codes": {
+      "def": [
+        {
+          "localId": "221",
+          "locator": "22:1-22:61",
+          "name": "Birthdate",
+          "id": "21112-8",
+          "display": "Birth date",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "221",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "code ",
+                      "\"Birthdate\"",
+                      ": ",
+                      "'21112-8'",
+                      " from "
+                    ]
+                  },
+                  {
+                    "r": "222",
+                    "s": [
+                      {
+                        "value": [
+                          "\"LOINC\""
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " display ",
+                      "'Birth date'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": {
+            "localId": "222",
+            "locator": "22:34-22:40",
+            "name": "LOINC"
+          }
+        },
+        {
+          "localId": "223",
+          "locator": "23:1-23:55",
+          "name": "Dead",
+          "id": "419099009",
+          "display": "Dead",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "223",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "code ",
+                      "\"Dead\"",
+                      ": ",
+                      "'419099009'",
+                      " from "
+                    ]
+                  },
+                  {
+                    "r": "224",
+                    "s": [
+                      {
+                        "value": [
+                          "\"SNOMEDCT\""
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " display ",
+                      "'Dead'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": {
+            "localId": "224",
+            "locator": "23:31-23:40",
+            "name": "SNOMEDCT"
+          }
+        },
+        {
+          "localId": "225",
+          "locator": "24:1-24:56",
+          "name": "ER",
+          "id": "ER",
+          "display": "Emergency room",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "225",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "code ",
+                      "\"ER\"",
+                      ": ",
+                      "'ER'",
+                      " from "
+                    ]
+                  },
+                  {
+                    "r": "226",
+                    "s": [
+                      {
+                        "value": [
+                          "\"RoleCode\""
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " display ",
+                      "'Emergency room'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": {
+            "localId": "226",
+            "locator": "24:22-24:31",
+            "name": "RoleCode"
+          }
+        },
+        {
+          "localId": "227",
+          "locator": "25:1-25:63",
+          "name": "ICU",
+          "id": "ICU",
+          "display": "Intensive care unit",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "227",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "code ",
+                      "\"ICU\"",
+                      ": ",
+                      "'ICU'",
+                      " from "
+                    ]
+                  },
+                  {
+                    "r": "228",
+                    "s": [
+                      {
+                        "value": [
+                          "\"RoleCode\""
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " display ",
+                      "'Intensive care unit'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": {
+            "localId": "228",
+            "locator": "25:24-25:33",
+            "name": "RoleCode"
+          }
+        },
+        {
+          "localId": "229",
+          "locator": "26:1-26:65",
+          "name": "Billing",
+          "id": "billing",
+          "display": "Billing",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "229",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "code ",
+                      "\"Billing\"",
+                      ": ",
+                      "'billing'",
+                      " from "
+                    ]
+                  },
+                  {
+                    "r": "230",
+                    "s": [
+                      {
+                        "value": [
+                          "\"Diagnosis Role\""
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " display ",
+                      "'Billing'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": {
+            "localId": "230",
+            "locator": "26:32-26:47",
+            "name": "Diagnosis Role"
+          }
+        },
+        {
+          "localId": "231",
+          "locator": "29:1-29:59",
+          "name": "active",
+          "id": "active",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "231",
+                "s": [
+                  {
+                    "value": [
+                      "// Condition Clinical Status Codes - Consider value sets for these\n",
+                      "code ",
+                      "\"active\"",
+                      ": ",
+                      "'active'",
+                      " from "
+                    ]
+                  },
+                  {
+                    "r": "232",
+                    "s": [
+                      {
+                        "value": [
+                          "\"ConditionClinicalStatusCodes\""
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": {
+            "localId": "232",
+            "locator": "29:30-29:59",
+            "name": "ConditionClinicalStatusCodes"
+          }
+        },
+        {
+          "localId": "233",
+          "locator": "30:1-30:67",
+          "name": "recurrence",
+          "id": "recurrence",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "233",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "code ",
+                      "\"recurrence\"",
+                      ": ",
+                      "'recurrence'",
+                      " from "
+                    ]
+                  },
+                  {
+                    "r": "234",
+                    "s": [
+                      {
+                        "value": [
+                          "\"ConditionClinicalStatusCodes\""
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": {
+            "localId": "234",
+            "locator": "30:38-30:67",
+            "name": "ConditionClinicalStatusCodes"
+          }
+        },
+        {
+          "localId": "235",
+          "locator": "31:1-31:61",
+          "name": "relapse",
+          "id": "relapse",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "235",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "code ",
+                      "\"relapse\"",
+                      ": ",
+                      "'relapse'",
+                      " from "
+                    ]
+                  },
+                  {
+                    "r": "236",
+                    "s": [
+                      {
+                        "value": [
+                          "\"ConditionClinicalStatusCodes\""
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": {
+            "localId": "236",
+            "locator": "31:32-31:61",
+            "name": "ConditionClinicalStatusCodes"
+          }
+        },
+        {
+          "localId": "237",
+          "locator": "32:1-32:63",
+          "name": "inactive",
+          "id": "inactive",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "237",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "code ",
+                      "\"inactive\"",
+                      ": ",
+                      "'inactive'",
+                      " from "
+                    ]
+                  },
+                  {
+                    "r": "238",
+                    "s": [
+                      {
+                        "value": [
+                          "\"ConditionClinicalStatusCodes\""
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": {
+            "localId": "238",
+            "locator": "32:34-32:63",
+            "name": "ConditionClinicalStatusCodes"
+          }
+        },
+        {
+          "localId": "239",
+          "locator": "33:1-33:65",
+          "name": "remission",
+          "id": "remission",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "239",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "code ",
+                      "\"remission\"",
+                      ": ",
+                      "'remission'",
+                      " from "
+                    ]
+                  },
+                  {
+                    "r": "240",
+                    "s": [
+                      {
+                        "value": [
+                          "\"ConditionClinicalStatusCodes\""
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": {
+            "localId": "240",
+            "locator": "33:36-33:65",
+            "name": "ConditionClinicalStatusCodes"
+          }
+        },
+        {
+          "localId": "241",
+          "locator": "34:1-34:63",
+          "name": "resolved",
+          "id": "resolved",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "241",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "code ",
+                      "\"resolved\"",
+                      ": ",
+                      "'resolved'",
+                      " from "
+                    ]
+                  },
+                  {
+                    "r": "242",
+                    "s": [
+                      {
+                        "value": [
+                          "\"ConditionClinicalStatusCodes\""
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": {
+            "localId": "242",
+            "locator": "34:34-34:63",
+            "name": "ConditionClinicalStatusCodes"
+          }
+        },
+        {
+          "localId": "243",
+          "locator": "37:1-37:71",
+          "name": "unconfirmed",
+          "id": "unconfirmed",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "243",
+                "s": [
+                  {
+                    "value": [
+                      "// Condition Verification Status Codes - Consider value sets for these\n",
+                      "code ",
+                      "\"unconfirmed\"",
+                      ": ",
+                      "'unconfirmed'",
+                      " from "
+                    ]
+                  },
+                  {
+                    "r": "244",
+                    "s": [
+                      {
+                        "value": [
+                          "ConditionVerificationStatusCodes"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": {
+            "localId": "244",
+            "locator": "37:40-37:71",
+            "name": "ConditionVerificationStatusCodes"
+          }
+        },
+        {
+          "localId": "245",
+          "locator": "38:1-38:71",
+          "name": "provisional",
+          "id": "provisional",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "245",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "code ",
+                      "\"provisional\"",
+                      ": ",
+                      "'provisional'",
+                      " from "
+                    ]
+                  },
+                  {
+                    "r": "246",
+                    "s": [
+                      {
+                        "value": [
+                          "ConditionVerificationStatusCodes"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": {
+            "localId": "246",
+            "locator": "38:40-38:71",
+            "name": "ConditionVerificationStatusCodes"
+          }
+        },
+        {
+          "localId": "247",
+          "locator": "39:1-39:73",
+          "name": "differential",
+          "id": "differential",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "247",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "code ",
+                      "\"differential\"",
+                      ": ",
+                      "'differential'",
+                      " from "
+                    ]
+                  },
+                  {
+                    "r": "248",
+                    "s": [
+                      {
+                        "value": [
+                          "ConditionVerificationStatusCodes"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": {
+            "localId": "248",
+            "locator": "39:42-39:73",
+            "name": "ConditionVerificationStatusCodes"
+          }
+        },
+        {
+          "localId": "249",
+          "locator": "40:1-40:67",
+          "name": "confirmed",
+          "id": "confirmed",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "249",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "code ",
+                      "\"confirmed\"",
+                      ": ",
+                      "'confirmed'",
+                      " from "
+                    ]
+                  },
+                  {
+                    "r": "250",
+                    "s": [
+                      {
+                        "value": [
+                          "ConditionVerificationStatusCodes"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": {
+            "localId": "250",
+            "locator": "40:36-40:67",
+            "name": "ConditionVerificationStatusCodes"
+          }
+        },
+        {
+          "localId": "251",
+          "locator": "41:1-41:63",
+          "name": "refuted",
+          "id": "refuted",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "251",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "code ",
+                      "\"refuted\"",
+                      ": ",
+                      "'refuted'",
+                      " from "
+                    ]
+                  },
+                  {
+                    "r": "252",
+                    "s": [
+                      {
+                        "value": [
+                          "ConditionVerificationStatusCodes"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": {
+            "localId": "252",
+            "locator": "41:32-41:63",
+            "name": "ConditionVerificationStatusCodes"
+          }
+        },
+        {
+          "localId": "253",
+          "locator": "42:1-42:81",
+          "name": "entered-in-error",
+          "id": "entered-in-error",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "253",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "code ",
+                      "\"entered-in-error\"",
+                      ": ",
+                      "'entered-in-error'",
+                      " from "
+                    ]
+                  },
+                  {
+                    "r": "254",
+                    "s": [
+                      {
+                        "value": [
+                          "ConditionVerificationStatusCodes"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": {
+            "localId": "254",
+            "locator": "42:50-42:81",
+            "name": "ConditionVerificationStatusCodes"
+          }
+        },
+        {
+          "localId": "255",
+          "locator": "44:1-44:76",
+          "name": "allergy-active",
+          "id": "active",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "255",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "code ",
+                      "\"allergy-active\"",
+                      ": ",
+                      "'active'",
+                      " from "
+                    ]
+                  },
+                  {
+                    "r": "256",
+                    "s": [
+                      {
+                        "value": [
+                          "\"AllergyIntoleranceClinicalStatusCodes\""
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": {
+            "localId": "256",
+            "locator": "44:38-44:76",
+            "name": "AllergyIntoleranceClinicalStatusCodes"
+          }
+        },
+        {
+          "localId": "257",
+          "locator": "45:1-45:80",
+          "name": "allergy-inactive",
+          "id": "inactive",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "257",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "code ",
+                      "\"allergy-inactive\"",
+                      ": ",
+                      "'inactive'",
+                      " from "
+                    ]
+                  },
+                  {
+                    "r": "258",
+                    "s": [
+                      {
+                        "value": [
+                          "\"AllergyIntoleranceClinicalStatusCodes\""
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": {
+            "localId": "258",
+            "locator": "45:42-45:80",
+            "name": "AllergyIntoleranceClinicalStatusCodes"
+          }
+        },
+        {
+          "localId": "259",
+          "locator": "46:1-46:80",
+          "name": "allergy-resolved",
+          "id": "resolved",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "259",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "code ",
+                      "\"allergy-resolved\"",
+                      ": ",
+                      "'resolved'",
+                      " from "
+                    ]
+                  },
+                  {
+                    "r": "260",
+                    "s": [
+                      {
+                        "value": [
+                          "\"AllergyIntoleranceClinicalStatusCodes\""
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": {
+            "localId": "260",
+            "locator": "46:42-46:80",
+            "name": "AllergyIntoleranceClinicalStatusCodes"
+          }
+        },
+        {
+          "localId": "261",
+          "locator": "49:1-49:88",
+          "name": "allergy-unconfirmed",
+          "id": "unconfirmed",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "261",
+                "s": [
+                  {
+                    "value": [
+                      "// Allergy/Intolerance Verification Status Codes - Consider value sets for these\n",
+                      "code ",
+                      "\"allergy-unconfirmed\"",
+                      ": ",
+                      "'unconfirmed'",
+                      " from "
+                    ]
+                  },
+                  {
+                    "r": "262",
+                    "s": [
+                      {
+                        "value": [
+                          "AllergyIntoleranceVerificationStatusCodes"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": {
+            "localId": "262",
+            "locator": "49:48-49:88",
+            "name": "AllergyIntoleranceVerificationStatusCodes"
+          }
+        },
+        {
+          "localId": "263",
+          "locator": "50:1-50:84",
+          "name": "allergy-confirmed",
+          "id": "confirmed",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "263",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "code ",
+                      "\"allergy-confirmed\"",
+                      ": ",
+                      "'confirmed'",
+                      " from "
+                    ]
+                  },
+                  {
+                    "r": "264",
+                    "s": [
+                      {
+                        "value": [
+                          "AllergyIntoleranceVerificationStatusCodes"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": {
+            "localId": "264",
+            "locator": "50:44-50:84",
+            "name": "AllergyIntoleranceVerificationStatusCodes"
+          }
+        },
+        {
+          "localId": "265",
+          "locator": "51:1-51:80",
+          "name": "allergy-refuted",
+          "id": "refuted",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "265",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "code ",
+                      "\"allergy-refuted\"",
+                      ": ",
+                      "'refuted'",
+                      " from "
+                    ]
+                  },
+                  {
+                    "r": "266",
+                    "s": [
+                      {
+                        "value": [
+                          "AllergyIntoleranceVerificationStatusCodes"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": {
+            "localId": "266",
+            "locator": "51:40-51:80",
+            "name": "AllergyIntoleranceVerificationStatusCodes"
+          }
+        },
+        {
+          "localId": "267",
+          "locator": "54:1-54:82",
+          "name": "Community",
+          "id": "community",
+          "display": "Community",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "267",
+                "s": [
+                  {
+                    "value": [
+                      "// MedicationRequest Category Codes\n",
+                      "code ",
+                      "\"Community\"",
+                      ": ",
+                      "'community'",
+                      " from "
+                    ]
+                  },
+                  {
+                    "r": "268",
+                    "s": [
+                      {
+                        "value": [
+                          "\"MedicationRequestCategory\""
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " display ",
+                      "'Community'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": {
+            "localId": "268",
+            "locator": "54:36-54:62",
+            "name": "MedicationRequestCategory"
+          }
+        },
+        {
+          "localId": "269",
+          "locator": "55:1-55:82",
+          "name": "Discharge",
+          "id": "discharge",
+          "display": "Discharge",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "269",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "code ",
+                      "\"Discharge\"",
+                      ": ",
+                      "'discharge'",
+                      " from "
+                    ]
+                  },
+                  {
+                    "r": "270",
+                    "s": [
+                      {
+                        "value": [
+                          "\"MedicationRequestCategory\""
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " display ",
+                      "'Discharge'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": {
+            "localId": "270",
+            "locator": "55:36-55:62",
+            "name": "MedicationRequestCategory"
+          }
+        }
+      ]
+    },
+    "contexts": {
+      "def": [
+        {
+          "localId": "294",
+          "locator": "60:1-60:15",
+          "name": "Patient"
+        }
+      ]
+    },
+    "statements": {
+      "def": [
+        {
+          "localId": "292",
+          "locator": "60:1-60:15",
+          "name": "Patient",
+          "context": "Patient",
+          "expression": {
+            "localId": "293",
+            "type": "SingletonFrom",
+            "signature": [],
+            "operand": {
+              "localId": "291",
+              "locator": "60:1-60:15",
+              "dataType": "{http://hl7.org/fhir}Patient",
+              "templateId": "http://hl7.org/fhir/StructureDefinition/Patient",
+              "type": "Retrieve",
+              "include": [],
+              "codeFilter": [],
+              "dateFilter": [],
+              "otherFilter": []
+            }
+          }
+        },
+        {
+          "localId": "317",
+          "locator": "89:1-90:59",
+          "name": "LengthInDays",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "317",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define function \"LengthInDays\"(Value Interval<DateTime>):\n\t"
+                    ]
+                  },
+                  {
+                    "r": "414",
+                    "s": [
+                      {
+                        "r": "414",
+                        "s": [
+                          {
+                            "value": [
+                              "difference in days between "
+                            ]
+                          },
+                          {
+                            "r": "415",
+                            "s": [
+                              {
+                                "value": [
+                                  "start of "
+                                ]
+                              },
+                              {
+                                "r": "416",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "Value"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              " and "
+                            ]
+                          },
+                          {
+                            "r": "417",
+                            "s": [
+                              {
+                                "value": [
+                                  "end of "
+                                ]
+                              },
+                              {
+                                "r": "418",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "Value"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "414",
+            "locator": "90:2-90:59",
+            "precision": "Day",
+            "type": "DifferenceBetween",
+            "signature": [],
+            "operand": [
+              {
+                "localId": "415",
+                "locator": "90:29-90:42",
+                "type": "Start",
+                "signature": [],
+                "operand": {
+                  "localId": "416",
+                  "locator": "90:38-90:42",
+                  "name": "Value",
+                  "type": "OperandRef"
+                }
+              },
+              {
+                "localId": "417",
+                "locator": "90:48-90:59",
+                "type": "End",
+                "signature": [],
+                "operand": {
+                  "localId": "418",
+                  "locator": "90:55-90:59",
+                  "name": "Value",
+                  "type": "OperandRef"
+                }
+              }
+            ]
+          },
+          "operand": [
+            {
+              "localId": "320",
+              "name": "Value",
+              "operandTypeSpecifier": {
+                "localId": "318",
+                "locator": "89:38-89:55",
+                "type": "IntervalTypeSpecifier",
+                "pointType": {
+                  "localId": "319",
+                  "locator": "89:47-89:54",
+                  "name": "{urn:hl7-org:elm-types:r1}DateTime",
+                  "type": "NamedTypeSpecifier"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "localId": "296",
+          "locator": "62:1-66:65",
+          "name": "Inpatient Encounter",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "296",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Inpatient Encounter\"",
+                      ":\n\t"
+                    ]
+                  },
+                  {
+                    "r": "335",
+                    "s": [
+                      {
+                        "s": [
+                          {
+                            "r": "297",
+                            "s": [
+                              {
+                                "r": "300",
+                                "s": [
+                                  {
+                                    "r": "300",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "[",
+                                          "Encounter",
+                                          ": "
+                                        ]
+                                      },
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"Encounter Inpatient\""
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "]"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "EncounterInpatient"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "\n\t\t"
+                        ]
+                      },
+                      {
+                        "r": "307",
+                        "s": [
+                          {
+                            "value": [
+                              "where "
+                            ]
+                          },
+                          {
+                            "r": "307",
+                            "s": [
+                              {
+                                "r": "308",
+                                "s": [
+                                  {
+                                    "r": "309",
+                                    "s": [
+                                      {
+                                        "r": "311",
+                                        "s": [
+                                          {
+                                            "r": "310",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "EncounterInpatient"
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              "."
+                                            ]
+                                          },
+                                          {
+                                            "r": "311",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "status"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          " ",
+                                          "=",
+                                          " "
+                                        ]
+                                      },
+                                      {
+                                        "r": "312",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "'finished'"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "\n\t\t    and "
+                                    ]
+                                  },
+                                  {
+                                    "r": "314",
+                                    "s": [
+                                      {
+                                        "r": "321",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"LengthInDays\"",
+                                              "("
+                                            ]
+                                          },
+                                          {
+                                            "r": "316",
+                                            "s": [
+                                              {
+                                                "r": "315",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "EncounterInpatient"
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  "."
+                                                ]
+                                              },
+                                              {
+                                                "r": "316",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "period"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              ")"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "r": "328",
+                                        "value": [
+                                          " ",
+                                          "<=",
+                                          " ",
+                                          "120"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  "\n\t\t\tand "
+                                ]
+                              },
+                              {
+                                "r": "334",
+                                "s": [
+                                  {
+                                    "r": "330",
+                                    "s": [
+                                      {
+                                        "r": "329",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "EncounterInpatient"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "."
+                                        ]
+                                      },
+                                      {
+                                        "r": "330",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "period"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "r": "334",
+                                    "value": [
+                                      " ",
+                                      "ends during",
+                                      " "
+                                    ]
+                                  },
+                                  {
+                                    "r": "331",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "\"Measurement Period\""
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "335",
+            "locator": "63:2-66:65",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "297",
+                "locator": "63:2-63:54",
+                "alias": "EncounterInpatient",
+                "expression": {
+                  "localId": "300",
+                  "locator": "63:2-63:35",
+                  "dataType": "{http://hl7.org/fhir}Encounter",
+                  "templateId": "http://hl7.org/fhir/StructureDefinition/Encounter",
+                  "codeProperty": "type",
+                  "codeComparator": "in",
+                  "type": "Retrieve",
+                  "codes": {
+                    "localId": "299",
+                    "locator": "63:14-63:34",
+                    "name": "Encounter Inpatient",
+                    "preserve": true,
+                    "type": "ValueSetRef"
+                  },
+                  "include": [],
+                  "codeFilter": [],
+                  "dateFilter": [],
+                  "otherFilter": []
+                }
+              }
+            ],
+            "let": [],
+            "relationship": [],
+            "where": {
+              "localId": "307",
+              "locator": "64:3-66:65",
+              "type": "And",
+              "signature": [],
+              "operand": [
+                {
+                  "localId": "308",
+                  "locator": "64:9-65:58",
+                  "type": "And",
+                  "signature": [],
+                  "operand": [
+                    {
+                      "localId": "309",
+                      "locator": "64:9-64:46",
+                      "type": "Equal",
+                      "signature": [],
+                      "operand": [
+                        {
+                          "localId": "313",
+                          "name": "ToString",
+                          "libraryName": "FHIRHelpers",
+                          "type": "FunctionRef",
+                          "signature": [],
+                          "operand": [
+                            {
+                              "localId": "311",
+                              "locator": "64:9-64:33",
+                              "path": "status",
+                              "scope": "EncounterInpatient",
+                              "type": "Property"
+                            }
+                          ]
+                        },
+                        {
+                          "localId": "312",
+                          "locator": "64:37-64:46",
+                          "valueType": "{urn:hl7-org:elm-types:r1}String",
+                          "value": "finished",
+                          "type": "Literal"
+                        }
+                      ]
+                    },
+                    {
+                      "localId": "314",
+                      "locator": "65:11-65:58",
+                      "type": "LessOrEqual",
+                      "signature": [],
+                      "operand": [
+                        {
+                          "localId": "321",
+                          "locator": "65:11-65:51",
+                          "name": "LengthInDays",
+                          "type": "FunctionRef",
+                          "signature": [],
+                          "operand": [
+                            {
+                              "localId": "322",
+                              "name": "ToInterval",
+                              "libraryName": "FHIRHelpers",
+                              "type": "FunctionRef",
+                              "signature": [],
+                              "operand": [
+                                {
+                                  "localId": "316",
+                                  "locator": "65:26-65:50",
+                                  "path": "period",
+                                  "scope": "EncounterInpatient",
+                                  "type": "Property"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "localId": "328",
+                          "locator": "65:56-65:58",
+                          "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                          "value": "120",
+                          "type": "Literal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "localId": "334",
+                  "locator": "66:8-66:65",
+                  "type": "In",
+                  "signature": [],
+                  "operand": [
+                    {
+                      "localId": "332",
+                      "locator": "66:34-66:37",
+                      "type": "End",
+                      "signature": [],
+                      "operand": {
+                        "localId": "333",
+                        "name": "ToInterval",
+                        "libraryName": "FHIRHelpers",
+                        "type": "FunctionRef",
+                        "signature": [],
+                        "operand": [
+                          {
+                            "localId": "330",
+                            "locator": "66:8-66:32",
+                            "path": "period",
+                            "scope": "EncounterInpatient",
+                            "type": "Property"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "localId": "331",
+                      "locator": "66:46-66:65",
+                      "name": "Measurement Period",
+                      "type": "ParameterRef"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        {
+          "localId": "336",
+          "locator": "68:1-69:99",
+          "name": "ToDate",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "336",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define function \"ToDate\"(Value DateTime):\n\t"
+                    ]
+                  },
+                  {
+                    "r": "353",
+                    "s": [
+                      {
+                        "r": "353",
+                        "s": [
+                          {
+                            "value": [
+                              "DateTime",
+                              "("
+                            ]
+                          },
+                          {
+                            "r": "339",
+                            "s": [
+                              {
+                                "value": [
+                                  "year from "
+                                ]
+                              },
+                              {
+                                "r": "340",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "Value"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              ", "
+                            ]
+                          },
+                          {
+                            "r": "341",
+                            "s": [
+                              {
+                                "value": [
+                                  "month from "
+                                ]
+                              },
+                              {
+                                "r": "342",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "Value"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              ", "
+                            ]
+                          },
+                          {
+                            "r": "343",
+                            "s": [
+                              {
+                                "value": [
+                                  "day from "
+                                ]
+                              },
+                              {
+                                "r": "344",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "Value"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "r": "345",
+                            "value": [
+                              ", ",
+                              "0",
+                              ", ",
+                              "0",
+                              ", ",
+                              "0",
+                              ", ",
+                              "0",
+                              ", "
+                            ]
+                          },
+                          {
+                            "r": "349",
+                            "s": [
+                              {
+                                "value": [
+                                  "timezoneoffset from "
+                                ]
+                              },
+                              {
+                                "r": "350",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "Value"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              ")"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "353",
+            "locator": "69:2-69:99",
+            "type": "DateTime",
+            "signature": [],
+            "year": {
+              "localId": "339",
+              "locator": "69:11-69:25",
+              "precision": "Year",
+              "type": "DateTimeComponentFrom",
+              "signature": [],
+              "operand": {
+                "localId": "340",
+                "locator": "69:21-69:25",
+                "name": "Value",
+                "type": "OperandRef"
+              }
+            },
+            "month": {
+              "localId": "341",
+              "locator": "69:28-69:43",
+              "precision": "Month",
+              "type": "DateTimeComponentFrom",
+              "signature": [],
+              "operand": {
+                "localId": "342",
+                "locator": "69:39-69:43",
+                "name": "Value",
+                "type": "OperandRef"
+              }
+            },
+            "day": {
+              "localId": "343",
+              "locator": "69:46-69:59",
+              "precision": "Day",
+              "type": "DateTimeComponentFrom",
+              "signature": [],
+              "operand": {
+                "localId": "344",
+                "locator": "69:55-69:59",
+                "name": "Value",
+                "type": "OperandRef"
+              }
+            },
+            "hour": {
+              "localId": "345",
+              "locator": "69:62",
+              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+              "value": "0",
+              "type": "Literal"
+            },
+            "minute": {
+              "localId": "346",
+              "locator": "69:65",
+              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+              "value": "0",
+              "type": "Literal"
+            },
+            "second": {
+              "localId": "347",
+              "locator": "69:68",
+              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+              "value": "0",
+              "type": "Literal"
+            },
+            "millisecond": {
+              "localId": "348",
+              "locator": "69:71",
+              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+              "value": "0",
+              "type": "Literal"
+            },
+            "timezoneOffset": {
+              "localId": "349",
+              "locator": "69:74-69:98",
+              "type": "TimezoneOffsetFrom",
+              "signature": [],
+              "operand": {
+                "localId": "350",
+                "locator": "69:94-69:98",
+                "name": "Value",
+                "type": "OperandRef"
+              }
+            }
+          },
+          "operand": [
+            {
+              "localId": "338",
+              "name": "Value",
+              "operandTypeSpecifier": {
+                "localId": "337",
+                "locator": "68:32-68:39",
+                "name": "{urn:hl7-org:elm-types:r1}DateTime",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "localId": "354",
+          "locator": "71:1-72:51",
+          "name": "CalendarAgeInDaysAt",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "354",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define function \"CalendarAgeInDaysAt\"(BirthDateTime DateTime, AsOf DateTime):\n\t"
+                    ]
+                  },
+                  {
+                    "r": "359",
+                    "s": [
+                      {
+                        "r": "359",
+                        "s": [
+                          {
+                            "value": [
+                              "days between "
+                            ]
+                          },
+                          {
+                            "r": "361",
+                            "s": [
+                              {
+                                "value": [
+                                  "ToDate",
+                                  "("
+                                ]
+                              },
+                              {
+                                "r": "360",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "BirthDateTime"
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  ")"
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              "and "
+                            ]
+                          },
+                          {
+                            "r": "363",
+                            "s": [
+                              {
+                                "value": [
+                                  "ToDate",
+                                  "("
+                                ]
+                              },
+                              {
+                                "r": "362",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "AsOf"
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  ")"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "359",
+            "locator": "72:2-72:51",
+            "precision": "Day",
+            "type": "DurationBetween",
+            "signature": [],
+            "operand": [
+              {
+                "localId": "361",
+                "locator": "72:15-72:35",
+                "name": "ToDate",
+                "type": "FunctionRef",
+                "signature": [],
+                "operand": [
+                  {
+                    "localId": "360",
+                    "locator": "72:22-72:34",
+                    "name": "BirthDateTime",
+                    "type": "OperandRef"
+                  }
+                ]
+              },
+              {
+                "localId": "363",
+                "locator": "72:40-72:51",
+                "name": "ToDate",
+                "type": "FunctionRef",
+                "signature": [],
+                "operand": [
+                  {
+                    "localId": "362",
+                    "locator": "72:47-72:50",
+                    "name": "AsOf",
+                    "type": "OperandRef"
+                  }
+                ]
+              }
+            ]
+          },
+          "operand": [
+            {
+              "localId": "356",
+              "name": "BirthDateTime",
+              "operandTypeSpecifier": {
+                "localId": "355",
+                "locator": "71:53-71:60",
+                "name": "{urn:hl7-org:elm-types:r1}DateTime",
+                "type": "NamedTypeSpecifier"
+              }
+            },
+            {
+              "localId": "358",
+              "name": "AsOf",
+              "operandTypeSpecifier": {
+                "localId": "357",
+                "locator": "71:68-71:75",
+                "name": "{urn:hl7-org:elm-types:r1}DateTime",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "localId": "364",
+          "locator": "74:1-75:44",
+          "name": "CalendarAgeInDays",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "364",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define function \"CalendarAgeInDays\"(BirthDateTime DateTime):\n\t"
+                    ]
+                  },
+                  {
+                    "r": "371",
+                    "s": [
+                      {
+                        "r": "371",
+                        "s": [
+                          {
+                            "value": [
+                              "CalendarAgeInDaysAt",
+                              "("
+                            ]
+                          },
+                          {
+                            "r": "367",
+                            "s": [
+                              {
+                                "value": [
+                                  "BirthDateTime"
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              ", "
+                            ]
+                          },
+                          {
+                            "r": "370",
+                            "s": [
+                              {
+                                "value": [
+                                  "Today",
+                                  "()"
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              ")"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "371",
+            "locator": "75:2-75:44",
+            "name": "CalendarAgeInDaysAt",
+            "type": "FunctionRef",
+            "signature": [],
+            "operand": [
+              {
+                "localId": "367",
+                "locator": "75:22-75:34",
+                "name": "BirthDateTime",
+                "type": "OperandRef"
+              },
+              {
+                "localId": "373",
+                "type": "ToDateTime",
+                "signature": [],
+                "operand": {
+                  "localId": "370",
+                  "locator": "75:37-75:43",
+                  "type": "Today",
+                  "signature": []
+                }
+              }
+            ]
+          },
+          "operand": [
+            {
+              "localId": "366",
+              "name": "BirthDateTime",
+              "operandTypeSpecifier": {
+                "localId": "365",
+                "locator": "74:51-74:58",
+                "name": "{urn:hl7-org:elm-types:r1}DateTime",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "localId": "374",
+          "locator": "77:1-78:53",
+          "name": "CalendarAgeInMonthsAt",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "374",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define function \"CalendarAgeInMonthsAt\"(BirthDateTime DateTime, AsOf DateTime):\n\t"
+                    ]
+                  },
+                  {
+                    "r": "379",
+                    "s": [
+                      {
+                        "r": "379",
+                        "s": [
+                          {
+                            "value": [
+                              "months between "
+                            ]
+                          },
+                          {
+                            "r": "381",
+                            "s": [
+                              {
+                                "value": [
+                                  "ToDate",
+                                  "("
+                                ]
+                              },
+                              {
+                                "r": "380",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "BirthDateTime"
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  ")"
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              "and "
+                            ]
+                          },
+                          {
+                            "r": "383",
+                            "s": [
+                              {
+                                "value": [
+                                  "ToDate",
+                                  "("
+                                ]
+                              },
+                              {
+                                "r": "382",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "AsOf"
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  ")"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "379",
+            "locator": "78:2-78:53",
+            "precision": "Month",
+            "type": "DurationBetween",
+            "signature": [],
+            "operand": [
+              {
+                "localId": "381",
+                "locator": "78:17-78:37",
+                "name": "ToDate",
+                "type": "FunctionRef",
+                "signature": [],
+                "operand": [
+                  {
+                    "localId": "380",
+                    "locator": "78:24-78:36",
+                    "name": "BirthDateTime",
+                    "type": "OperandRef"
+                  }
+                ]
+              },
+              {
+                "localId": "383",
+                "locator": "78:42-78:53",
+                "name": "ToDate",
+                "type": "FunctionRef",
+                "signature": [],
+                "operand": [
+                  {
+                    "localId": "382",
+                    "locator": "78:49-78:52",
+                    "name": "AsOf",
+                    "type": "OperandRef"
+                  }
+                ]
+              }
+            ]
+          },
+          "operand": [
+            {
+              "localId": "376",
+              "name": "BirthDateTime",
+              "operandTypeSpecifier": {
+                "localId": "375",
+                "locator": "77:55-77:62",
+                "name": "{urn:hl7-org:elm-types:r1}DateTime",
+                "type": "NamedTypeSpecifier"
+              }
+            },
+            {
+              "localId": "378",
+              "name": "AsOf",
+              "operandTypeSpecifier": {
+                "localId": "377",
+                "locator": "77:70-77:77",
+                "name": "{urn:hl7-org:elm-types:r1}DateTime",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "localId": "384",
+          "locator": "80:1-81:46",
+          "name": "CalendarAgeInMonths",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "384",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define function \"CalendarAgeInMonths\"(BirthDateTime DateTime):\n\t"
+                    ]
+                  },
+                  {
+                    "r": "391",
+                    "s": [
+                      {
+                        "r": "391",
+                        "s": [
+                          {
+                            "value": [
+                              "CalendarAgeInMonthsAt",
+                              "("
+                            ]
+                          },
+                          {
+                            "r": "387",
+                            "s": [
+                              {
+                                "value": [
+                                  "BirthDateTime"
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              ", "
+                            ]
+                          },
+                          {
+                            "r": "390",
+                            "s": [
+                              {
+                                "value": [
+                                  "Today",
+                                  "()"
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              ")"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "391",
+            "locator": "81:2-81:46",
+            "name": "CalendarAgeInMonthsAt",
+            "type": "FunctionRef",
+            "signature": [],
+            "operand": [
+              {
+                "localId": "387",
+                "locator": "81:24-81:36",
+                "name": "BirthDateTime",
+                "type": "OperandRef"
+              },
+              {
+                "localId": "393",
+                "type": "ToDateTime",
+                "signature": [],
+                "operand": {
+                  "localId": "390",
+                  "locator": "81:39-81:45",
+                  "type": "Today",
+                  "signature": []
+                }
+              }
+            ]
+          },
+          "operand": [
+            {
+              "localId": "386",
+              "name": "BirthDateTime",
+              "operandTypeSpecifier": {
+                "localId": "385",
+                "locator": "80:53-80:60",
+                "name": "{urn:hl7-org:elm-types:r1}DateTime",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "localId": "394",
+          "locator": "83:1-84:52",
+          "name": "CalendarAgeInYearsAt",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "394",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define function \"CalendarAgeInYearsAt\"(BirthDateTime DateTime, AsOf DateTime):\n\t"
+                    ]
+                  },
+                  {
+                    "r": "399",
+                    "s": [
+                      {
+                        "r": "399",
+                        "s": [
+                          {
+                            "value": [
+                              "years between "
+                            ]
+                          },
+                          {
+                            "r": "401",
+                            "s": [
+                              {
+                                "value": [
+                                  "ToDate",
+                                  "("
+                                ]
+                              },
+                              {
+                                "r": "400",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "BirthDateTime"
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  ")"
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              "and "
+                            ]
+                          },
+                          {
+                            "r": "403",
+                            "s": [
+                              {
+                                "value": [
+                                  "ToDate",
+                                  "("
+                                ]
+                              },
+                              {
+                                "r": "402",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "AsOf"
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  ")"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "399",
+            "locator": "84:2-84:52",
+            "precision": "Year",
+            "type": "DurationBetween",
+            "signature": [],
+            "operand": [
+              {
+                "localId": "401",
+                "locator": "84:16-84:36",
+                "name": "ToDate",
+                "type": "FunctionRef",
+                "signature": [],
+                "operand": [
+                  {
+                    "localId": "400",
+                    "locator": "84:23-84:35",
+                    "name": "BirthDateTime",
+                    "type": "OperandRef"
+                  }
+                ]
+              },
+              {
+                "localId": "403",
+                "locator": "84:41-84:52",
+                "name": "ToDate",
+                "type": "FunctionRef",
+                "signature": [],
+                "operand": [
+                  {
+                    "localId": "402",
+                    "locator": "84:48-84:51",
+                    "name": "AsOf",
+                    "type": "OperandRef"
+                  }
+                ]
+              }
+            ]
+          },
+          "operand": [
+            {
+              "localId": "396",
+              "name": "BirthDateTime",
+              "operandTypeSpecifier": {
+                "localId": "395",
+                "locator": "83:54-83:61",
+                "name": "{urn:hl7-org:elm-types:r1}DateTime",
+                "type": "NamedTypeSpecifier"
+              }
+            },
+            {
+              "localId": "398",
+              "name": "AsOf",
+              "operandTypeSpecifier": {
+                "localId": "397",
+                "locator": "83:69-83:76",
+                "name": "{urn:hl7-org:elm-types:r1}DateTime",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "localId": "404",
+          "locator": "86:1-87:45",
+          "name": "CalendarAgeInYears",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "404",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define function \"CalendarAgeInYears\"(BirthDateTime DateTime):\n\t"
+                    ]
+                  },
+                  {
+                    "r": "411",
+                    "s": [
+                      {
+                        "r": "411",
+                        "s": [
+                          {
+                            "value": [
+                              "CalendarAgeInYearsAt",
+                              "("
+                            ]
+                          },
+                          {
+                            "r": "407",
+                            "s": [
+                              {
+                                "value": [
+                                  "BirthDateTime"
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              ", "
+                            ]
+                          },
+                          {
+                            "r": "410",
+                            "s": [
+                              {
+                                "value": [
+                                  "Today",
+                                  "()"
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              ")"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "411",
+            "locator": "87:2-87:45",
+            "name": "CalendarAgeInYearsAt",
+            "type": "FunctionRef",
+            "signature": [],
+            "operand": [
+              {
+                "localId": "407",
+                "locator": "87:23-87:35",
+                "name": "BirthDateTime",
+                "type": "OperandRef"
+              },
+              {
+                "localId": "413",
+                "type": "ToDateTime",
+                "signature": [],
+                "operand": {
+                  "localId": "410",
+                  "locator": "87:38-87:44",
+                  "type": "Today",
+                  "signature": []
+                }
+              }
+            ]
+          },
+          "operand": [
+            {
+              "localId": "406",
+              "name": "BirthDateTime",
+              "operandTypeSpecifier": {
+                "localId": "405",
+                "locator": "86:52-86:59",
+                "name": "{urn:hl7-org:elm-types:r1}DateTime",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "localId": "419",
+          "locator": "92:1-97:5",
+          "name": "ED Visit",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "419",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define function \"ED Visit\"(TheEncounter FHIR.Encounter):\n    "
+                    ]
+                  },
+                  {
+                    "r": "422",
+                    "s": [
+                      {
+                        "r": "422",
+                        "s": [
+                          {
+                            "value": [
+                              "singleton from "
+                            ]
+                          },
+                          {
+                            "r": "455",
+                            "s": [
+                              {
+                                "value": [
+                                  "(\n        "
+                                ]
+                              },
+                              {
+                                "r": "455",
+                                "s": [
+                                  {
+                                    "s": [
+                                      {
+                                        "r": "423",
+                                        "s": [
+                                          {
+                                            "r": "426",
+                                            "s": [
+                                              {
+                                                "r": "426",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "[",
+                                                      "Encounter",
+                                                      ": "
+                                                    ]
+                                                  },
+                                                  {
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "\"Emergency Department Visit\""
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "value": [
+                                                      "]"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              " ",
+                                              "EDVisit"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "\n            "
+                                    ]
+                                  },
+                                  {
+                                    "r": "433",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "where "
+                                        ]
+                                      },
+                                      {
+                                        "r": "433",
+                                        "s": [
+                                          {
+                                            "r": "434",
+                                            "s": [
+                                              {
+                                                "r": "436",
+                                                "s": [
+                                                  {
+                                                    "r": "435",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "EDVisit"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "value": [
+                                                      "."
+                                                    ]
+                                                  },
+                                                  {
+                                                    "r": "436",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "status"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  " ",
+                                                  "=",
+                                                  " "
+                                                ]
+                                              },
+                                              {
+                                                "r": "437",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "'finished'"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              "\n                and "
+                                            ]
+                                          },
+                                          {
+                                            "r": "454",
+                                            "s": [
+                                              {
+                                                "r": "440",
+                                                "s": [
+                                                  {
+                                                    "r": "439",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "EDVisit"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "value": [
+                                                      "."
+                                                    ]
+                                                  },
+                                                  {
+                                                    "r": "440",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "period"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  " "
+                                                ]
+                                              },
+                                              {
+                                                "r": "454",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "ends "
+                                                    ]
+                                                  },
+                                                  {
+                                                    "r": "448",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "1 ",
+                                                          "hour"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "value": [
+                                                      " or less on or before"
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  " "
+                                                ]
+                                              },
+                                              {
+                                                "r": "441",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "start of "
+                                                    ]
+                                                  },
+                                                  {
+                                                    "r": "445",
+                                                    "s": [
+                                                      {
+                                                        "r": "442",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "FHIRHelpers"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "value": [
+                                                          "."
+                                                        ]
+                                                      },
+                                                      {
+                                                        "r": "445",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "ToInterval",
+                                                              "("
+                                                            ]
+                                                          },
+                                                          {
+                                                            "r": "444",
+                                                            "s": [
+                                                              {
+                                                                "r": "443",
+                                                                "s": [
+                                                                  {
+                                                                    "value": [
+                                                                      "TheEncounter"
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "value": [
+                                                                  "."
+                                                                ]
+                                                              },
+                                                              {
+                                                                "r": "444",
+                                                                "s": [
+                                                                  {
+                                                                    "value": [
+                                                                      "period"
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "value": [
+                                                              ")"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  "\n    )"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "422",
+            "locator": "93:5-97:5",
+            "type": "SingletonFrom",
+            "signature": [],
+            "operand": {
+              "localId": "455",
+              "locator": "93:20-97:5",
+              "type": "Query",
+              "source": [
+                {
+                  "localId": "423",
+                  "locator": "94:9-94:57",
+                  "alias": "EDVisit",
+                  "expression": {
+                    "localId": "426",
+                    "locator": "94:9-94:49",
+                    "dataType": "{http://hl7.org/fhir}Encounter",
+                    "templateId": "http://hl7.org/fhir/StructureDefinition/Encounter",
+                    "codeProperty": "type",
+                    "codeComparator": "in",
+                    "type": "Retrieve",
+                    "codes": {
+                      "localId": "425",
+                      "locator": "94:21-94:48",
+                      "name": "Emergency Department Visit",
+                      "preserve": true,
+                      "type": "ValueSetRef"
+                    },
+                    "include": [],
+                    "codeFilter": [],
+                    "dateFilter": [],
+                    "otherFilter": []
+                  }
+                }
+              ],
+              "let": [],
+              "relationship": [],
+              "where": {
+                "localId": "433",
+                "locator": "95:13-96:120",
+                "type": "And",
+                "signature": [],
+                "operand": [
+                  {
+                    "localId": "434",
+                    "locator": "95:19-95:45",
+                    "type": "Equal",
+                    "signature": [],
+                    "operand": [
+                      {
+                        "localId": "438",
+                        "name": "ToString",
+                        "libraryName": "FHIRHelpers",
+                        "type": "FunctionRef",
+                        "signature": [],
+                        "operand": [
+                          {
+                            "localId": "436",
+                            "locator": "95:19-95:32",
+                            "path": "status",
+                            "scope": "EDVisit",
+                            "type": "Property"
+                          }
+                        ]
+                      },
+                      {
+                        "localId": "437",
+                        "locator": "95:36-95:45",
+                        "valueType": "{urn:hl7-org:elm-types:r1}String",
+                        "value": "finished",
+                        "type": "Literal"
+                      }
+                    ]
+                  },
+                  {
+                    "localId": "454",
+                    "locator": "96:21-96:120",
+                    "type": "And",
+                    "signature": [],
+                    "operand": [
+                      {
+                        "localId": "451",
+                        "locator": "96:41-96:54",
+                        "type": "In",
+                        "signature": [],
+                        "operand": [
+                          {
+                            "localId": "446",
+                            "locator": "96:36-96:39",
+                            "type": "End",
+                            "signature": [],
+                            "operand": {
+                              "localId": "447",
+                              "name": "ToInterval",
+                              "libraryName": "FHIRHelpers",
+                              "type": "FunctionRef",
+                              "signature": [],
+                              "operand": [
+                                {
+                                  "localId": "440",
+                                  "locator": "96:21-96:34",
+                                  "path": "period",
+                                  "scope": "EDVisit",
+                                  "type": "Property"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "localId": "450",
+                            "locator": "96:41-96:54",
+                            "lowClosed": true,
+                            "highClosed": true,
+                            "type": "Interval",
+                            "low": {
+                              "localId": "449",
+                              "locator": "96:69-96:120",
+                              "type": "Subtract",
+                              "signature": [],
+                              "operand": [
+                                {
+                                  "localId": "441",
+                                  "locator": "96:69-96:120",
+                                  "type": "Start",
+                                  "signature": [],
+                                  "operand": {
+                                    "localId": "445",
+                                    "locator": "96:78-96:120",
+                                    "name": "ToInterval",
+                                    "libraryName": "FHIRHelpers",
+                                    "type": "FunctionRef",
+                                    "signature": [],
+                                    "operand": [
+                                      {
+                                        "localId": "444",
+                                        "locator": "96:101-96:119",
+                                        "path": "period",
+                                        "type": "Property",
+                                        "source": {
+                                          "localId": "443",
+                                          "locator": "96:101-96:112",
+                                          "name": "TheEncounter",
+                                          "type": "OperandRef"
+                                        }
+                                      }
+                                    ]
+                                  }
+                                },
+                                {
+                                  "localId": "448",
+                                  "locator": "96:41-96:46",
+                                  "value": 1,
+                                  "unit": "hour",
+                                  "type": "Quantity"
+                                }
+                              ]
+                            },
+                            "high": {
+                              "localId": "441",
+                              "locator": "96:69-96:120",
+                              "type": "Start",
+                              "signature": [],
+                              "operand": {
+                                "localId": "445",
+                                "locator": "96:78-96:120",
+                                "name": "ToInterval",
+                                "libraryName": "FHIRHelpers",
+                                "type": "FunctionRef",
+                                "signature": [],
+                                "operand": [
+                                  {
+                                    "localId": "444",
+                                    "locator": "96:101-96:119",
+                                    "path": "period",
+                                    "type": "Property",
+                                    "source": {
+                                      "localId": "443",
+                                      "locator": "96:101-96:112",
+                                      "name": "TheEncounter",
+                                      "type": "OperandRef"
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "localId": "453",
+                        "locator": "96:41-96:54",
+                        "type": "Not",
+                        "signature": [],
+                        "operand": {
+                          "localId": "452",
+                          "locator": "96:41-96:54",
+                          "type": "IsNull",
+                          "signature": [],
+                          "operand": {
+                            "localId": "441",
+                            "locator": "96:69-96:120",
+                            "type": "Start",
+                            "signature": [],
+                            "operand": {
+                              "localId": "445",
+                              "locator": "96:78-96:120",
+                              "name": "ToInterval",
+                              "libraryName": "FHIRHelpers",
+                              "type": "FunctionRef",
+                              "signature": [],
+                              "operand": [
+                                {
+                                  "localId": "444",
+                                  "locator": "96:101-96:119",
+                                  "path": "period",
+                                  "type": "Property",
+                                  "source": {
+                                    "localId": "443",
+                                    "locator": "96:101-96:112",
+                                    "name": "TheEncounter",
+                                    "type": "OperandRef"
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "operand": [
+            {
+              "localId": "421",
+              "name": "TheEncounter",
+              "operandTypeSpecifier": {
+                "localId": "420",
+                "locator": "92:41-92:54",
+                "name": "{http://hl7.org/fhir}Encounter",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "localId": "456",
+          "locator": "99:1-103:116",
+          "name": "Hospitalization",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "456",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define function \"Hospitalization\"(TheEncounter FHIR.Encounter):\n\t"
+                    ]
+                  },
+                  {
+                    "r": "480",
+                    "s": [
+                      {
+                        "r": "480",
+                        "s": [
+                          {
+                            "s": [
+                              {
+                                "r": "459",
+                                "s": [
+                                  {
+                                    "r": "461",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "( "
+                                        ]
+                                      },
+                                      {
+                                        "r": "461",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"ED Visit\"",
+                                              "("
+                                            ]
+                                          },
+                                          {
+                                            "r": "460",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "TheEncounter"
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              ")"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          " )"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      " ",
+                                      "X"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              "\n    "
+                            ]
+                          },
+                          {
+                            "r": "462",
+                            "s": [
+                              {
+                                "value": [
+                                  "return\n        "
+                                ]
+                              },
+                              {
+                                "r": "463",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "if "
+                                    ]
+                                  },
+                                  {
+                                    "r": "465",
+                                    "s": [
+                                      {
+                                        "r": "464",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "X"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          " is null"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      " then "
+                                    ]
+                                  },
+                                  {
+                                    "r": "467",
+                                    "s": [
+                                      {
+                                        "r": "466",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "TheEncounter"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "."
+                                        ]
+                                      },
+                                      {
+                                        "r": "467",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "period"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "\n        else "
+                                    ]
+                                  },
+                                  {
+                                    "r": "478",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "Interval["
+                                        ]
+                                      },
+                                      {
+                                        "r": "468",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "start of "
+                                            ]
+                                          },
+                                          {
+                                            "r": "472",
+                                            "s": [
+                                              {
+                                                "r": "469",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "FHIRHelpers"
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  "."
+                                                ]
+                                              },
+                                              {
+                                                "r": "472",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "ToInterval",
+                                                      "("
+                                                    ]
+                                                  },
+                                                  {
+                                                    "r": "471",
+                                                    "s": [
+                                                      {
+                                                        "r": "470",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "X"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "value": [
+                                                          "."
+                                                        ]
+                                                      },
+                                                      {
+                                                        "r": "471",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "period"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "value": [
+                                                      ")"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          ", "
+                                        ]
+                                      },
+                                      {
+                                        "r": "473",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "end of "
+                                            ]
+                                          },
+                                          {
+                                            "r": "477",
+                                            "s": [
+                                              {
+                                                "r": "474",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "FHIRHelpers"
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  "."
+                                                ]
+                                              },
+                                              {
+                                                "r": "477",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "ToInterval",
+                                                      "("
+                                                    ]
+                                                  },
+                                                  {
+                                                    "r": "476",
+                                                    "s": [
+                                                      {
+                                                        "r": "475",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "TheEncounter"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "value": [
+                                                          "."
+                                                        ]
+                                                      },
+                                                      {
+                                                        "r": "476",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "period"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "value": [
+                                                      ")"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "]"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "480",
+            "locator": "100:2-103:116",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "459",
+                "locator": "100:2-100:31",
+                "alias": "X",
+                "expression": {
+                  "localId": "461",
+                  "locator": "100:2-100:29",
+                  "name": "ED Visit",
+                  "type": "FunctionRef",
+                  "signature": [],
+                  "operand": [
+                    {
+                      "localId": "460",
+                      "locator": "100:15-100:26",
+                      "name": "TheEncounter",
+                      "type": "OperandRef"
+                    }
+                  ]
+                }
+              }
+            ],
+            "let": [],
+            "relationship": [],
+            "return": {
+              "localId": "462",
+              "locator": "101:5-103:116",
+              "expression": {
+                "localId": "463",
+                "locator": "102:9-103:116",
+                "type": "If",
+                "condition": {
+                  "localId": "465",
+                  "locator": "102:12-102:20",
+                  "type": "IsNull",
+                  "signature": [],
+                  "operand": {
+                    "localId": "464",
+                    "locator": "102:12",
+                    "name": "X",
+                    "type": "AliasRef"
+                  }
+                },
+                "then": {
+                  "localId": "479",
+                  "name": "ToInterval",
+                  "libraryName": "FHIRHelpers",
+                  "type": "FunctionRef",
+                  "signature": [],
+                  "operand": [
+                    {
+                      "localId": "467",
+                      "locator": "102:27-102:45",
+                      "path": "period",
+                      "type": "Property",
+                      "source": {
+                        "localId": "466",
+                        "locator": "102:27-102:38",
+                        "name": "TheEncounter",
+                        "type": "OperandRef"
+                      }
+                    }
+                  ]
+                },
+                "else": {
+                  "localId": "478",
+                  "locator": "103:14-103:116",
+                  "lowClosed": true,
+                  "highClosed": true,
+                  "type": "Interval",
+                  "low": {
+                    "localId": "468",
+                    "locator": "103:23-103:63",
+                    "type": "Start",
+                    "signature": [],
+                    "operand": {
+                      "localId": "472",
+                      "locator": "103:32-103:63",
+                      "name": "ToInterval",
+                      "libraryName": "FHIRHelpers",
+                      "type": "FunctionRef",
+                      "signature": [],
+                      "operand": [
+                        {
+                          "localId": "471",
+                          "locator": "103:55-103:62",
+                          "path": "period",
+                          "scope": "X",
+                          "type": "Property"
+                        }
+                      ]
+                    }
+                  },
+                  "high": {
+                    "localId": "473",
+                    "locator": "103:66-103:115",
+                    "type": "End",
+                    "signature": [],
+                    "operand": {
+                      "localId": "477",
+                      "locator": "103:73-103:115",
+                      "name": "ToInterval",
+                      "libraryName": "FHIRHelpers",
+                      "type": "FunctionRef",
+                      "signature": [],
+                      "operand": [
+                        {
+                          "localId": "476",
+                          "locator": "103:96-103:114",
+                          "path": "period",
+                          "type": "Property",
+                          "source": {
+                            "localId": "475",
+                            "locator": "103:96-103:107",
+                            "name": "TheEncounter",
+                            "type": "OperandRef"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "operand": [
+            {
+              "localId": "458",
+              "name": "TheEncounter",
+              "operandTypeSpecifier": {
+                "localId": "457",
+                "locator": "99:48-99:61",
+                "name": "{http://hl7.org/fhir}Encounter",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "localId": "481",
+          "locator": "105:1-109:68",
+          "name": "Hospitalization Locations",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "481",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define function \"Hospitalization Locations\"(TheEncounter FHIR.Encounter):\n\t"
+                    ]
+                  },
+                  {
+                    "r": "499",
+                    "s": [
+                      {
+                        "r": "499",
+                        "s": [
+                          {
+                            "s": [
+                              {
+                                "r": "484",
+                                "s": [
+                                  {
+                                    "r": "486",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "( "
+                                        ]
+                                      },
+                                      {
+                                        "r": "486",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"ED Visit\"",
+                                              "("
+                                            ]
+                                          },
+                                          {
+                                            "r": "485",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "TheEncounter"
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              ")"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          " )"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      " ",
+                                      "EDEncounter"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              "\n    "
+                            ]
+                          },
+                          {
+                            "r": "487",
+                            "s": [
+                              {
+                                "value": [
+                                  "return\n        "
+                                ]
+                              },
+                              {
+                                "r": "488",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "if "
+                                    ]
+                                  },
+                                  {
+                                    "r": "490",
+                                    "s": [
+                                      {
+                                        "r": "489",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "EDEncounter"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          " is null"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      " then "
+                                    ]
+                                  },
+                                  {
+                                    "r": "492",
+                                    "s": [
+                                      {
+                                        "r": "491",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "TheEncounter"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "."
+                                        ]
+                                      },
+                                      {
+                                        "r": "492",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "location"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "\n        else "
+                                    ]
+                                  },
+                                  {
+                                    "r": "493",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "flatten "
+                                        ]
+                                      },
+                                      {
+                                        "r": "494",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "{ "
+                                            ]
+                                          },
+                                          {
+                                            "r": "496",
+                                            "s": [
+                                              {
+                                                "r": "495",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "EDEncounter"
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  "."
+                                                ]
+                                              },
+                                              {
+                                                "r": "496",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "location"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              ", "
+                                            ]
+                                          },
+                                          {
+                                            "r": "498",
+                                            "s": [
+                                              {
+                                                "r": "497",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "TheEncounter"
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  "."
+                                                ]
+                                              },
+                                              {
+                                                "r": "498",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "location"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              " }"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "499",
+            "locator": "106:2-109:68",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "484",
+                "locator": "106:2-106:41",
+                "alias": "EDEncounter",
+                "expression": {
+                  "localId": "486",
+                  "locator": "106:2-106:29",
+                  "name": "ED Visit",
+                  "type": "FunctionRef",
+                  "signature": [],
+                  "operand": [
+                    {
+                      "localId": "485",
+                      "locator": "106:15-106:26",
+                      "name": "TheEncounter",
+                      "type": "OperandRef"
+                    }
+                  ]
+                }
+              }
+            ],
+            "let": [],
+            "relationship": [],
+            "return": {
+              "localId": "487",
+              "locator": "107:5-109:68",
+              "expression": {
+                "localId": "488",
+                "locator": "108:9-109:68",
+                "type": "If",
+                "condition": {
+                  "localId": "490",
+                  "locator": "108:12-108:30",
+                  "type": "IsNull",
+                  "signature": [],
+                  "operand": {
+                    "localId": "489",
+                    "locator": "108:12-108:22",
+                    "name": "EDEncounter",
+                    "type": "AliasRef"
+                  }
+                },
+                "then": {
+                  "localId": "492",
+                  "locator": "108:37-108:57",
+                  "path": "location",
+                  "type": "Property",
+                  "source": {
+                    "localId": "491",
+                    "locator": "108:37-108:48",
+                    "name": "TheEncounter",
+                    "type": "OperandRef"
+                  }
+                },
+                "else": {
+                  "localId": "493",
+                  "locator": "109:14-109:68",
+                  "type": "Flatten",
+                  "signature": [],
+                  "operand": {
+                    "localId": "494",
+                    "locator": "109:22-109:68",
+                    "type": "List",
+                    "element": [
+                      {
+                        "localId": "496",
+                        "locator": "109:24-109:43",
+                        "path": "location",
+                        "scope": "EDEncounter",
+                        "type": "Property"
+                      },
+                      {
+                        "localId": "498",
+                        "locator": "109:46-109:66",
+                        "path": "location",
+                        "type": "Property",
+                        "source": {
+                          "localId": "497",
+                          "locator": "109:46-109:57",
+                          "name": "TheEncounter",
+                          "type": "OperandRef"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "operand": [
+            {
+              "localId": "483",
+              "name": "TheEncounter",
+              "operandTypeSpecifier": {
+                "localId": "482",
+                "locator": "105:58-105:71",
+                "name": "{http://hl7.org/fhir}Encounter",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "localId": "500",
+          "locator": "111:1-112:46",
+          "name": "Hospitalization Length of Stay",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "500",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define function \"Hospitalization Length of Stay\"(TheEncounter FHIR.Encounter):\n\t"
+                    ]
+                  },
+                  {
+                    "r": "505",
+                    "s": [
+                      {
+                        "r": "505",
+                        "s": [
+                          {
+                            "value": [
+                              "LengthInDays",
+                              "("
+                            ]
+                          },
+                          {
+                            "r": "504",
+                            "s": [
+                              {
+                                "value": [
+                                  "\"Hospitalization\"",
+                                  "("
+                                ]
+                              },
+                              {
+                                "r": "503",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "TheEncounter"
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  ")"
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              ")"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "505",
+            "locator": "112:2-112:46",
+            "name": "LengthInDays",
+            "type": "FunctionRef",
+            "signature": [],
+            "operand": [
+              {
+                "localId": "504",
+                "locator": "112:15-112:45",
+                "name": "Hospitalization",
+                "type": "FunctionRef",
+                "signature": [],
+                "operand": [
+                  {
+                    "localId": "503",
+                    "locator": "112:33-112:44",
+                    "name": "TheEncounter",
+                    "type": "OperandRef"
+                  }
+                ]
+              }
+            ]
+          },
+          "operand": [
+            {
+              "localId": "502",
+              "name": "TheEncounter",
+              "operandTypeSpecifier": {
+                "localId": "501",
+                "locator": "111:63-111:76",
+                "name": "{http://hl7.org/fhir}Encounter",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "localId": "506",
+          "locator": "114:1-115:41",
+          "name": "Hospital Admission Time",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "506",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define function \"Hospital Admission Time\"(TheEncounter FHIR.Encounter):\n\t"
+                    ]
+                  },
+                  {
+                    "r": "509",
+                    "s": [
+                      {
+                        "r": "509",
+                        "s": [
+                          {
+                            "value": [
+                              "start of "
+                            ]
+                          },
+                          {
+                            "r": "511",
+                            "s": [
+                              {
+                                "value": [
+                                  "\"Hospitalization\"",
+                                  "("
+                                ]
+                              },
+                              {
+                                "r": "510",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "TheEncounter"
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  ")"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "509",
+            "locator": "115:2-115:41",
+            "type": "Start",
+            "signature": [],
+            "operand": {
+              "localId": "511",
+              "locator": "115:11-115:41",
+              "name": "Hospitalization",
+              "type": "FunctionRef",
+              "signature": [],
+              "operand": [
+                {
+                  "localId": "510",
+                  "locator": "115:29-115:40",
+                  "name": "TheEncounter",
+                  "type": "OperandRef"
+                }
+              ]
+            }
+          },
+          "operand": [
+            {
+              "localId": "508",
+              "name": "TheEncounter",
+              "operandTypeSpecifier": {
+                "localId": "507",
+                "locator": "114:56-114:69",
+                "name": "{http://hl7.org/fhir}Encounter",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "localId": "512",
+          "locator": "117:1-118:51",
+          "name": "Hospital Discharge Time",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "512",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define function \"Hospital Discharge Time\"(TheEncounter FHIR.Encounter):\n\t"
+                    ]
+                  },
+                  {
+                    "r": "515",
+                    "s": [
+                      {
+                        "r": "515",
+                        "s": [
+                          {
+                            "value": [
+                              "end of "
+                            ]
+                          },
+                          {
+                            "r": "519",
+                            "s": [
+                              {
+                                "r": "516",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "FHIRHelpers"
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  "."
+                                ]
+                              },
+                              {
+                                "r": "519",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "ToInterval",
+                                      "("
+                                    ]
+                                  },
+                                  {
+                                    "r": "518",
+                                    "s": [
+                                      {
+                                        "r": "517",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "TheEncounter"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "."
+                                        ]
+                                      },
+                                      {
+                                        "r": "518",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "period"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      ")"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "515",
+            "locator": "118:2-118:51",
+            "type": "End",
+            "signature": [],
+            "operand": {
+              "localId": "519",
+              "locator": "118:9-118:51",
+              "name": "ToInterval",
+              "libraryName": "FHIRHelpers",
+              "type": "FunctionRef",
+              "signature": [],
+              "operand": [
+                {
+                  "localId": "518",
+                  "locator": "118:32-118:50",
+                  "path": "period",
+                  "type": "Property",
+                  "source": {
+                    "localId": "517",
+                    "locator": "118:32-118:43",
+                    "name": "TheEncounter",
+                    "type": "OperandRef"
+                  }
+                }
+              ]
+            }
+          },
+          "operand": [
+            {
+              "localId": "514",
+              "name": "TheEncounter",
+              "operandTypeSpecifier": {
+                "localId": "513",
+                "locator": "117:56-117:69",
+                "name": "{http://hl7.org/fhir}Encounter",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "localId": "520",
+          "locator": "120:1-124:10",
+          "name": "Hospital Arrival Time",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "520",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define function \"Hospital Arrival Time\"(TheEncounter FHIR.Encounter):\n\t"
+                    ]
+                  },
+                  {
+                    "r": "523",
+                    "s": [
+                      {
+                        "r": "523",
+                        "s": [
+                          {
+                            "value": [
+                              "start of "
+                            ]
+                          },
+                          {
+                            "r": "542",
+                            "s": [
+                              {
+                                "r": "524",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "FHIRHelpers"
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  "."
+                                ]
+                              },
+                              {
+                                "r": "542",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "ToInterval",
+                                      "("
+                                    ]
+                                  },
+                                  {
+                                    "r": "541",
+                                    "s": [
+                                      {
+                                        "r": "540",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "First",
+                                              "(\n\t    "
+                                            ]
+                                          },
+                                          {
+                                            "r": "537",
+                                            "s": [
+                                              {
+                                                "s": [
+                                                  {
+                                                    "r": "525",
+                                                    "s": [
+                                                      {
+                                                        "r": "527",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "( "
+                                                            ]
+                                                          },
+                                                          {
+                                                            "r": "527",
+                                                            "s": [
+                                                              {
+                                                                "value": [
+                                                                  "\"Hospitalization Locations\"",
+                                                                  "("
+                                                                ]
+                                                              },
+                                                              {
+                                                                "r": "526",
+                                                                "s": [
+                                                                  {
+                                                                    "value": [
+                                                                      "TheEncounter"
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "value": [
+                                                                  ")"
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "value": [
+                                                              " )"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "value": [
+                                                          " ",
+                                                          "HospitalLocation"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  "\n\t\t\t"
+                                                ]
+                                              },
+                                              {
+                                                "r": "533",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "sort by "
+                                                    ]
+                                                  },
+                                                  {
+                                                    "r": "532",
+                                                    "s": [
+                                                      {
+                                                        "r": "528",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "start of "
+                                                            ]
+                                                          },
+                                                          {
+                                                            "r": "531",
+                                                            "s": [
+                                                              {
+                                                                "r": "529",
+                                                                "s": [
+                                                                  {
+                                                                    "value": [
+                                                                      "FHIRHelpers"
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "value": [
+                                                                  "."
+                                                                ]
+                                                              },
+                                                              {
+                                                                "r": "531",
+                                                                "s": [
+                                                                  {
+                                                                    "value": [
+                                                                      "ToInterval",
+                                                                      "("
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "r": "530",
+                                                                    "s": [
+                                                                      {
+                                                                        "value": [
+                                                                          "period"
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "value": [
+                                                                      ")"
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              "\n\t)"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "."
+                                        ]
+                                      },
+                                      {
+                                        "r": "541",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "period"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      ")"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "523",
+            "locator": "121:2-124:10",
+            "type": "Start",
+            "signature": [],
+            "operand": {
+              "localId": "542",
+              "locator": "121:11-124:10",
+              "name": "ToInterval",
+              "libraryName": "FHIRHelpers",
+              "type": "FunctionRef",
+              "signature": [],
+              "operand": [
+                {
+                  "localId": "541",
+                  "locator": "121:34-124:9",
+                  "path": "period",
+                  "type": "Property",
+                  "source": {
+                    "localId": "540",
+                    "locator": "121:34-124:2",
+                    "type": "First",
+                    "signature": [],
+                    "source": {
+                      "localId": "537",
+                      "locator": "122:6-123:50",
+                      "type": "Query",
+                      "source": [
+                        {
+                          "localId": "525",
+                          "locator": "122:6-122:67",
+                          "alias": "HospitalLocation",
+                          "expression": {
+                            "localId": "527",
+                            "locator": "122:6-122:50",
+                            "name": "Hospitalization Locations",
+                            "type": "FunctionRef",
+                            "signature": [],
+                            "operand": [
+                              {
+                                "localId": "526",
+                                "locator": "122:36-122:47",
+                                "name": "TheEncounter",
+                                "type": "OperandRef"
+                              }
+                            ]
+                          }
+                        }
+                      ],
+                      "let": [],
+                      "relationship": [],
+                      "sort": {
+                        "localId": "533",
+                        "locator": "123:4-123:50",
+                        "by": [
+                          {
+                            "localId": "532",
+                            "locator": "123:12-123:50",
+                            "direction": "asc",
+                            "type": "ByExpression",
+                            "expression": {
+                              "localId": "528",
+                              "locator": "123:12-123:50",
+                              "type": "Start",
+                              "signature": [],
+                              "operand": {
+                                "localId": "531",
+                                "locator": "123:21-123:50",
+                                "name": "ToInterval",
+                                "libraryName": "FHIRHelpers",
+                                "type": "FunctionRef",
+                                "signature": [],
+                                "operand": [
+                                  {
+                                    "localId": "530",
+                                    "locator": "123:44-123:49",
+                                    "name": "period",
+                                    "type": "IdentifierRef"
+                                  }
+                                ]
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "operand": [
+            {
+              "localId": "522",
+              "name": "TheEncounter",
+              "operandTypeSpecifier": {
+                "localId": "521",
+                "locator": "120:54-120:67",
+                "name": "{http://hl7.org/fhir}Encounter",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "localId": "543",
+          "locator": "126:1-137:85",
+          "name": "HospitalizationWithObservation",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "543",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define function \"HospitalizationWithObservation\"(TheEncounter FHIR.Encounter):\n\t"
+                    ]
+                  },
+                  {
+                    "r": "647",
+                    "s": [
+                      {
+                        "r": "647",
+                        "s": [
+                          {
+                            "s": [
+                              {
+                                "r": "546",
+                                "s": [
+                                  {
+                                    "r": "547",
+                                    "s": [
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "TheEncounter"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      " ",
+                                      "Visit"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              "\n\t\t"
+                            ]
+                          },
+                          {
+                            "s": [
+                              {
+                                "value": [
+                                  "let "
+                                ]
+                              },
+                              {
+                                "r": "548",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "ObsVisit",
+                                      ": "
+                                    ]
+                                  },
+                                  {
+                                    "r": "585",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "Last",
+                                          "("
+                                        ]
+                                      },
+                                      {
+                                        "r": "582",
+                                        "s": [
+                                          {
+                                            "s": [
+                                              {
+                                                "r": "549",
+                                                "s": [
+                                                  {
+                                                    "r": "552",
+                                                    "s": [
+                                                      {
+                                                        "r": "552",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "[",
+                                                              "Encounter",
+                                                              ": "
+                                                            ]
+                                                          },
+                                                          {
+                                                            "s": [
+                                                              {
+                                                                "value": [
+                                                                  "\"Observation Services\""
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "value": [
+                                                              "]"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "value": [
+                                                      " ",
+                                                      "LastObs"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              "\n\t\t\t\t"
+                                            ]
+                                          },
+                                          {
+                                            "r": "573",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "where "
+                                                ]
+                                              },
+                                              {
+                                                "r": "573",
+                                                "s": [
+                                                  {
+                                                    "r": "560",
+                                                    "s": [
+                                                      {
+                                                        "r": "559",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "LastObs"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "value": [
+                                                          "."
+                                                        ]
+                                                      },
+                                                      {
+                                                        "r": "560",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "period"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "value": [
+                                                      " "
+                                                    ]
+                                                  },
+                                                  {
+                                                    "r": "573",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "ends "
+                                                        ]
+                                                      },
+                                                      {
+                                                        "r": "567",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "1 ",
+                                                              "hour"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "value": [
+                                                          " or less on or before"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "value": [
+                                                      " "
+                                                    ]
+                                                  },
+                                                  {
+                                                    "r": "561",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "start of "
+                                                        ]
+                                                      },
+                                                      {
+                                                        "r": "563",
+                                                        "s": [
+                                                          {
+                                                            "r": "562",
+                                                            "s": [
+                                                              {
+                                                                "value": [
+                                                                  "Visit"
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "value": [
+                                                              "."
+                                                            ]
+                                                          },
+                                                          {
+                                                            "r": "563",
+                                                            "s": [
+                                                              {
+                                                                "value": [
+                                                                  "period"
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              "\n\t\t\t\t"
+                                            ]
+                                          },
+                                          {
+                                            "r": "578",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "sort by "
+                                                ]
+                                              },
+                                              {
+                                                "r": "577",
+                                                "s": [
+                                                  {
+                                                    "r": "574",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "end of "
+                                                        ]
+                                                      },
+                                                      {
+                                                        "r": "575",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "period"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "\n\t\t\t)"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  ",\n\t\t\t"
+                                ]
+                              },
+                              {
+                                "r": "586",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "VisitStart",
+                                      ": "
+                                    ]
+                                  },
+                                  {
+                                    "r": "597",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "Coalesce",
+                                          "("
+                                        ]
+                                      },
+                                      {
+                                        "r": "587",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "start of "
+                                            ]
+                                          },
+                                          {
+                                            "r": "589",
+                                            "s": [
+                                              {
+                                                "r": "588",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "ObsVisit"
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  "."
+                                                ]
+                                              },
+                                              {
+                                                "r": "589",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "period"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          ", "
+                                        ]
+                                      },
+                                      {
+                                        "r": "591",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "start of "
+                                            ]
+                                          },
+                                          {
+                                            "r": "593",
+                                            "s": [
+                                              {
+                                                "r": "592",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "Visit"
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  "."
+                                                ]
+                                              },
+                                              {
+                                                "r": "593",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "period"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          ")"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  ",\n\t\t\t"
+                                ]
+                              },
+                              {
+                                "r": "598",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "EDVisit",
+                                      ": "
+                                    ]
+                                  },
+                                  {
+                                    "r": "632",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "Last",
+                                          "("
+                                        ]
+                                      },
+                                      {
+                                        "r": "629",
+                                        "s": [
+                                          {
+                                            "s": [
+                                              {
+                                                "r": "599",
+                                                "s": [
+                                                  {
+                                                    "r": "602",
+                                                    "s": [
+                                                      {
+                                                        "r": "602",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "[",
+                                                              "Encounter",
+                                                              ": "
+                                                            ]
+                                                          },
+                                                          {
+                                                            "s": [
+                                                              {
+                                                                "value": [
+                                                                  "\"Emergency Department Visit\""
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "value": [
+                                                              "]"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "value": [
+                                                      " ",
+                                                      "LastED"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              "\n\t\t\t\t"
+                                            ]
+                                          },
+                                          {
+                                            "r": "620",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "where "
+                                                ]
+                                              },
+                                              {
+                                                "r": "620",
+                                                "s": [
+                                                  {
+                                                    "r": "610",
+                                                    "s": [
+                                                      {
+                                                        "r": "609",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "LastED"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "value": [
+                                                          "."
+                                                        ]
+                                                      },
+                                                      {
+                                                        "r": "610",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "period"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "value": [
+                                                      " "
+                                                    ]
+                                                  },
+                                                  {
+                                                    "r": "620",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "ends "
+                                                        ]
+                                                      },
+                                                      {
+                                                        "r": "614",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "1 ",
+                                                              "hour"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "value": [
+                                                          " or less on or before"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "value": [
+                                                      " "
+                                                    ]
+                                                  },
+                                                  {
+                                                    "r": "611",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "VisitStart"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              "\n\t\t\t\t"
+                                            ]
+                                          },
+                                          {
+                                            "r": "625",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "sort by "
+                                                ]
+                                              },
+                                              {
+                                                "r": "624",
+                                                "s": [
+                                                  {
+                                                    "r": "621",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "end of "
+                                                        ]
+                                                      },
+                                                      {
+                                                        "r": "622",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "period"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "\n\t\t\t)"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              "\n\t\t"
+                            ]
+                          },
+                          {
+                            "r": "633",
+                            "s": [
+                              {
+                                "value": [
+                                  "return "
+                                ]
+                              },
+                              {
+                                "r": "646",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "Interval["
+                                    ]
+                                  },
+                                  {
+                                    "r": "641",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "Coalesce",
+                                          "("
+                                        ]
+                                      },
+                                      {
+                                        "r": "634",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "start of "
+                                            ]
+                                          },
+                                          {
+                                            "r": "636",
+                                            "s": [
+                                              {
+                                                "r": "635",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "EDVisit"
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  "."
+                                                ]
+                                              },
+                                              {
+                                                "r": "636",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "period"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          ", "
+                                        ]
+                                      },
+                                      {
+                                        "r": "638",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "VisitStart"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          ")"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      ", "
+                                    ]
+                                  },
+                                  {
+                                    "r": "642",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "end of "
+                                        ]
+                                      },
+                                      {
+                                        "r": "644",
+                                        "s": [
+                                          {
+                                            "r": "643",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "Visit"
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              "."
+                                            ]
+                                          },
+                                          {
+                                            "r": "644",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "period"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "]"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "647",
+            "locator": "127:2-137:85",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "546",
+                "locator": "127:2-127:19",
+                "alias": "Visit",
+                "expression": {
+                  "localId": "547",
+                  "locator": "127:2-127:13",
+                  "name": "TheEncounter",
+                  "type": "OperandRef"
+                }
+              }
+            ],
+            "let": [
+              {
+                "localId": "548",
+                "locator": "128:7-131:4",
+                "identifier": "ObsVisit",
+                "expression": {
+                  "localId": "585",
+                  "locator": "128:17-131:4",
+                  "type": "Last",
+                  "signature": [],
+                  "source": {
+                    "localId": "582",
+                    "locator": "128:22-130:25",
+                    "type": "Query",
+                    "source": [
+                      {
+                        "localId": "549",
+                        "locator": "128:22-128:64",
+                        "alias": "LastObs",
+                        "expression": {
+                          "localId": "552",
+                          "locator": "128:22-128:56",
+                          "dataType": "{http://hl7.org/fhir}Encounter",
+                          "templateId": "http://hl7.org/fhir/StructureDefinition/Encounter",
+                          "codeProperty": "type",
+                          "codeComparator": "in",
+                          "type": "Retrieve",
+                          "codes": {
+                            "localId": "551",
+                            "locator": "128:34-128:55",
+                            "name": "Observation Services",
+                            "preserve": true,
+                            "type": "ValueSetRef"
+                          },
+                          "include": [],
+                          "codeFilter": [],
+                          "dateFilter": [],
+                          "otherFilter": []
+                        }
+                      }
+                    ],
+                    "let": [],
+                    "relationship": [],
+                    "where": {
+                      "localId": "573",
+                      "locator": "129:5-129:79",
+                      "type": "And",
+                      "signature": [],
+                      "operand": [
+                        {
+                          "localId": "570",
+                          "locator": "129:31-129:44",
+                          "type": "In",
+                          "signature": [],
+                          "operand": [
+                            {
+                              "localId": "565",
+                              "locator": "129:26-129:29",
+                              "type": "End",
+                              "signature": [],
+                              "operand": {
+                                "localId": "566",
+                                "name": "ToInterval",
+                                "libraryName": "FHIRHelpers",
+                                "type": "FunctionRef",
+                                "signature": [],
+                                "operand": [
+                                  {
+                                    "localId": "560",
+                                    "locator": "129:11-129:24",
+                                    "path": "period",
+                                    "scope": "LastObs",
+                                    "type": "Property"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "localId": "569",
+                              "locator": "129:31-129:44",
+                              "lowClosed": true,
+                              "highClosed": true,
+                              "type": "Interval",
+                              "low": {
+                                "localId": "568",
+                                "locator": "129:59-129:79",
+                                "type": "Subtract",
+                                "signature": [],
+                                "operand": [
+                                  {
+                                    "localId": "561",
+                                    "locator": "129:59-129:79",
+                                    "type": "Start",
+                                    "signature": [],
+                                    "operand": {
+                                      "localId": "564",
+                                      "name": "ToInterval",
+                                      "libraryName": "FHIRHelpers",
+                                      "type": "FunctionRef",
+                                      "signature": [],
+                                      "operand": [
+                                        {
+                                          "localId": "563",
+                                          "locator": "129:68-129:79",
+                                          "path": "period",
+                                          "scope": "Visit",
+                                          "type": "Property"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  {
+                                    "localId": "567",
+                                    "locator": "129:31-129:36",
+                                    "value": 1,
+                                    "unit": "hour",
+                                    "type": "Quantity"
+                                  }
+                                ]
+                              },
+                              "high": {
+                                "localId": "561",
+                                "locator": "129:59-129:79",
+                                "type": "Start",
+                                "signature": [],
+                                "operand": {
+                                  "localId": "564",
+                                  "name": "ToInterval",
+                                  "libraryName": "FHIRHelpers",
+                                  "type": "FunctionRef",
+                                  "signature": [],
+                                  "operand": [
+                                    {
+                                      "localId": "563",
+                                      "locator": "129:68-129:79",
+                                      "path": "period",
+                                      "scope": "Visit",
+                                      "type": "Property"
+                                    }
+                                  ]
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "localId": "572",
+                          "locator": "129:31-129:44",
+                          "type": "Not",
+                          "signature": [],
+                          "operand": {
+                            "localId": "571",
+                            "locator": "129:31-129:44",
+                            "type": "IsNull",
+                            "signature": [],
+                            "operand": {
+                              "localId": "561",
+                              "locator": "129:59-129:79",
+                              "type": "Start",
+                              "signature": [],
+                              "operand": {
+                                "localId": "564",
+                                "name": "ToInterval",
+                                "libraryName": "FHIRHelpers",
+                                "type": "FunctionRef",
+                                "signature": [],
+                                "operand": [
+                                  {
+                                    "localId": "563",
+                                    "locator": "129:68-129:79",
+                                    "path": "period",
+                                    "scope": "Visit",
+                                    "type": "Property"
+                                  }
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "sort": {
+                      "localId": "578",
+                      "locator": "130:5-130:25",
+                      "by": [
+                        {
+                          "localId": "577",
+                          "locator": "130:13-130:25",
+                          "direction": "asc",
+                          "type": "ByExpression",
+                          "expression": {
+                            "localId": "574",
+                            "locator": "130:13-130:25",
+                            "type": "End",
+                            "signature": [],
+                            "operand": {
+                              "localId": "576",
+                              "name": "ToInterval",
+                              "libraryName": "FHIRHelpers",
+                              "type": "FunctionRef",
+                              "signature": [],
+                              "operand": [
+                                {
+                                  "localId": "575",
+                                  "locator": "130:20-130:25",
+                                  "name": "period",
+                                  "type": "IdentifierRef"
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
+              {
+                "localId": "586",
+                "locator": "132:4-132:72",
+                "identifier": "VisitStart",
+                "expression": {
+                  "localId": "597",
+                  "locator": "132:16-132:72",
+                  "type": "Coalesce",
+                  "signature": [],
+                  "operand": [
+                    {
+                      "localId": "587",
+                      "locator": "132:25-132:48",
+                      "type": "Start",
+                      "signature": [],
+                      "operand": {
+                        "localId": "590",
+                        "name": "ToInterval",
+                        "libraryName": "FHIRHelpers",
+                        "type": "FunctionRef",
+                        "signature": [],
+                        "operand": [
+                          {
+                            "localId": "589",
+                            "locator": "132:34-132:48",
+                            "path": "period",
+                            "type": "Property",
+                            "source": {
+                              "localId": "588",
+                              "locator": "132:34-132:41",
+                              "name": "ObsVisit",
+                              "type": "QueryLetRef"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "localId": "591",
+                      "locator": "132:51-132:71",
+                      "type": "Start",
+                      "signature": [],
+                      "operand": {
+                        "localId": "594",
+                        "name": "ToInterval",
+                        "libraryName": "FHIRHelpers",
+                        "type": "FunctionRef",
+                        "signature": [],
+                        "operand": [
+                          {
+                            "localId": "593",
+                            "locator": "132:60-132:71",
+                            "path": "period",
+                            "scope": "Visit",
+                            "type": "Property"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "localId": "598",
+                "locator": "133:4-136:4",
+                "identifier": "EDVisit",
+                "expression": {
+                  "localId": "632",
+                  "locator": "133:13-136:4",
+                  "type": "Last",
+                  "signature": [],
+                  "source": {
+                    "localId": "629",
+                    "locator": "133:18-135:25",
+                    "type": "Query",
+                    "source": [
+                      {
+                        "localId": "599",
+                        "locator": "133:18-133:65",
+                        "alias": "LastED",
+                        "expression": {
+                          "localId": "602",
+                          "locator": "133:18-133:58",
+                          "dataType": "{http://hl7.org/fhir}Encounter",
+                          "templateId": "http://hl7.org/fhir/StructureDefinition/Encounter",
+                          "codeProperty": "type",
+                          "codeComparator": "in",
+                          "type": "Retrieve",
+                          "codes": {
+                            "localId": "601",
+                            "locator": "133:30-133:57",
+                            "name": "Emergency Department Visit",
+                            "preserve": true,
+                            "type": "ValueSetRef"
+                          },
+                          "include": [],
+                          "codeFilter": [],
+                          "dateFilter": [],
+                          "otherFilter": []
+                        }
+                      }
+                    ],
+                    "let": [],
+                    "relationship": [],
+                    "where": {
+                      "localId": "620",
+                      "locator": "134:5-134:67",
+                      "type": "And",
+                      "signature": [],
+                      "operand": [
+                        {
+                          "localId": "617",
+                          "locator": "134:30-134:43",
+                          "type": "In",
+                          "signature": [],
+                          "operand": [
+                            {
+                              "localId": "612",
+                              "locator": "134:25-134:28",
+                              "type": "End",
+                              "signature": [],
+                              "operand": {
+                                "localId": "613",
+                                "name": "ToInterval",
+                                "libraryName": "FHIRHelpers",
+                                "type": "FunctionRef",
+                                "signature": [],
+                                "operand": [
+                                  {
+                                    "localId": "610",
+                                    "locator": "134:11-134:23",
+                                    "path": "period",
+                                    "scope": "LastED",
+                                    "type": "Property"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "localId": "616",
+                              "locator": "134:30-134:43",
+                              "lowClosed": true,
+                              "highClosed": true,
+                              "type": "Interval",
+                              "low": {
+                                "localId": "615",
+                                "locator": "134:58-134:67",
+                                "type": "Subtract",
+                                "signature": [],
+                                "operand": [
+                                  {
+                                    "localId": "611",
+                                    "locator": "134:58-134:67",
+                                    "name": "VisitStart",
+                                    "type": "QueryLetRef"
+                                  },
+                                  {
+                                    "localId": "614",
+                                    "locator": "134:30-134:35",
+                                    "value": 1,
+                                    "unit": "hour",
+                                    "type": "Quantity"
+                                  }
+                                ]
+                              },
+                              "high": {
+                                "localId": "611",
+                                "locator": "134:58-134:67",
+                                "name": "VisitStart",
+                                "type": "QueryLetRef"
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "localId": "619",
+                          "locator": "134:30-134:43",
+                          "type": "Not",
+                          "signature": [],
+                          "operand": {
+                            "localId": "618",
+                            "locator": "134:30-134:43",
+                            "type": "IsNull",
+                            "signature": [],
+                            "operand": {
+                              "localId": "611",
+                              "locator": "134:58-134:67",
+                              "name": "VisitStart",
+                              "type": "QueryLetRef"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "sort": {
+                      "localId": "625",
+                      "locator": "135:5-135:25",
+                      "by": [
+                        {
+                          "localId": "624",
+                          "locator": "135:13-135:25",
+                          "direction": "asc",
+                          "type": "ByExpression",
+                          "expression": {
+                            "localId": "621",
+                            "locator": "135:13-135:25",
+                            "type": "End",
+                            "signature": [],
+                            "operand": {
+                              "localId": "623",
+                              "name": "ToInterval",
+                              "libraryName": "FHIRHelpers",
+                              "type": "FunctionRef",
+                              "signature": [],
+                              "operand": [
+                                {
+                                  "localId": "622",
+                                  "locator": "135:20-135:25",
+                                  "name": "period",
+                                  "type": "IdentifierRef"
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            ],
+            "relationship": [],
+            "return": {
+              "localId": "633",
+              "locator": "137:3-137:85",
+              "expression": {
+                "localId": "646",
+                "locator": "137:10-137:85",
+                "lowClosed": true,
+                "highClosed": true,
+                "type": "Interval",
+                "low": {
+                  "localId": "641",
+                  "locator": "137:19-137:63",
+                  "type": "Coalesce",
+                  "signature": [],
+                  "operand": [
+                    {
+                      "localId": "634",
+                      "locator": "137:28-137:50",
+                      "type": "Start",
+                      "signature": [],
+                      "operand": {
+                        "localId": "637",
+                        "name": "ToInterval",
+                        "libraryName": "FHIRHelpers",
+                        "type": "FunctionRef",
+                        "signature": [],
+                        "operand": [
+                          {
+                            "localId": "636",
+                            "locator": "137:37-137:50",
+                            "path": "period",
+                            "type": "Property",
+                            "source": {
+                              "localId": "635",
+                              "locator": "137:37-137:43",
+                              "name": "EDVisit",
+                              "type": "QueryLetRef"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "localId": "638",
+                      "locator": "137:53-137:62",
+                      "name": "VisitStart",
+                      "type": "QueryLetRef"
+                    }
+                  ]
+                },
+                "high": {
+                  "localId": "642",
+                  "locator": "137:66-137:84",
+                  "type": "End",
+                  "signature": [],
+                  "operand": {
+                    "localId": "645",
+                    "name": "ToInterval",
+                    "libraryName": "FHIRHelpers",
+                    "type": "FunctionRef",
+                    "signature": [],
+                    "operand": [
+                      {
+                        "localId": "644",
+                        "locator": "137:73-137:84",
+                        "path": "period",
+                        "scope": "Visit",
+                        "type": "Property"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "operand": [
+            {
+              "localId": "545",
+              "name": "TheEncounter",
+              "operandTypeSpecifier": {
+                "localId": "544",
+                "locator": "126:63-126:76",
+                "name": "{http://hl7.org/fhir}Encounter",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "localId": "648",
+          "locator": "139:1-140:60",
+          "name": "HospitalizationWithObservationLengthofStay",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "648",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define function \"HospitalizationWithObservationLengthofStay\"(Encounter FHIR.Encounter):\n\t"
+                    ]
+                  },
+                  {
+                    "r": "653",
+                    "s": [
+                      {
+                        "r": "653",
+                        "s": [
+                          {
+                            "value": [
+                              "\"LengthInDays\"",
+                              "("
+                            ]
+                          },
+                          {
+                            "r": "652",
+                            "s": [
+                              {
+                                "value": [
+                                  "\"HospitalizationWithObservation\"",
+                                  "("
+                                ]
+                              },
+                              {
+                                "r": "651",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "Encounter"
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  ")"
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              ")"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "653",
+            "locator": "140:2-140:60",
+            "name": "LengthInDays",
+            "type": "FunctionRef",
+            "signature": [],
+            "operand": [
+              {
+                "localId": "652",
+                "locator": "140:17-140:59",
+                "name": "HospitalizationWithObservation",
+                "type": "FunctionRef",
+                "signature": [],
+                "operand": [
+                  {
+                    "localId": "651",
+                    "locator": "140:50-140:58",
+                    "name": "Encounter",
+                    "type": "OperandRef"
+                  }
+                ]
+              }
+            ]
+          },
+          "operand": [
+            {
+              "localId": "650",
+              "name": "Encounter",
+              "operandTypeSpecifier": {
+                "localId": "649",
+                "locator": "139:72-139:85",
+                "name": "{http://hl7.org/fhir}Encounter",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "localId": "654",
+          "locator": "171:1-191:4",
+          "name": "Normalize Interval",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "654",
+                "s": [
+                  {
+                    "value": [
+                      "// TODO - fix these (must fetch Location resources and compare id to reference)\n/*define function \"Hospital Departure Time\"(TheEncounter FHIR.Encounter):\n\tend of FHIRHelpers.ToInterval(Last(\n\t    ( \"Hospitalization Locations\"(TheEncounter) ) HospitalLocation\n\t\t\tsort by start of FHIRHelpers.ToInterval(period)\n\t).period)\n\ndefine function \"Emergency Department Arrival Time\"(TheEncounter FHIR.Encounter):\n\tstart of FHIRHelpers.ToInterval((\n\t    singleton from (\n\t        ( \"Hospitalization Locations\"(TheEncounter) ) HospitalLocation\n\t\t\t\twhere HospitalLocation.type ~ \"ER\"\n\t\t)\n\t).period)\n\ndefine function \"First Inpatient Intensive Care Unit\"(TheEncounter FHIR.Encounter):\n\tFirst(\n\t    ( TheEncounter.location ) HospitalLocation\n\t\t\twhere HospitalLocation.type ~ \"ICU\"\n\t\t\t\tand HospitalLocation.period during TheEncounter.period\n\t\t\tsort by start of FHIRHelpers.ToInterval(period)\n\t)*/\n\n/*\n*\n*    CQFMeasures Common Logic\n*\n*/\n\n",
+                      "define function \"Normalize Interval\"(choice Choice<FHIR.dateTime, FHIR.Period, FHIR.Timing, FHIR.instant, FHIR.string, FHIR.Age, FHIR.Range>):\n  "
+                    ]
+                  },
+                  {
+                    "r": "664",
+                    "s": [
+                      {
+                        "r": "664",
+                        "s": [
+                          {
+                            "value": [
+                              "case\n\t  "
+                            ]
+                          },
+                          {
+                            "r": "665",
+                            "s": [
+                              {
+                                "value": [
+                                  "when "
+                                ]
+                              },
+                              {
+                                "r": "666",
+                                "s": [
+                                  {
+                                    "r": "667",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "choice"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      " is "
+                                    ]
+                                  },
+                                  {
+                                    "r": "668",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "FHIR",
+                                          ".",
+                                          "dateTime"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " then\n    \t"
+                                ]
+                              },
+                              {
+                                "r": "679",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "Interval["
+                                    ]
+                                  },
+                                  {
+                                    "r": "673",
+                                    "s": [
+                                      {
+                                        "r": "669",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "FHIRHelpers"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "."
+                                        ]
+                                      },
+                                      {
+                                        "r": "673",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "ToDateTime",
+                                              "("
+                                            ]
+                                          },
+                                          {
+                                            "r": "670",
+                                            "s": [
+                                              {
+                                                "r": "671",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "choice"
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  " as "
+                                                ]
+                                              },
+                                              {
+                                                "r": "672",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "FHIR",
+                                                      ".",
+                                                      "dateTime"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              ")"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      ", "
+                                    ]
+                                  },
+                                  {
+                                    "r": "678",
+                                    "s": [
+                                      {
+                                        "r": "674",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "FHIRHelpers"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "."
+                                        ]
+                                      },
+                                      {
+                                        "r": "678",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "ToDateTime",
+                                              "("
+                                            ]
+                                          },
+                                          {
+                                            "r": "675",
+                                            "s": [
+                                              {
+                                                "r": "676",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "choice"
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  " as "
+                                                ]
+                                              },
+                                              {
+                                                "r": "677",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "FHIR",
+                                                      ".",
+                                                      "dateTime"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              ")"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "]"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              "\n\t\t"
+                            ]
+                          },
+                          {
+                            "r": "680",
+                            "s": [
+                              {
+                                "value": [
+                                  "when "
+                                ]
+                              },
+                              {
+                                "r": "681",
+                                "s": [
+                                  {
+                                    "r": "682",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "choice"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      " is "
+                                    ]
+                                  },
+                                  {
+                                    "r": "683",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "FHIR",
+                                          ".",
+                                          "Period"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " then\n  \t\t"
+                                ]
+                              },
+                              {
+                                "r": "688",
+                                "s": [
+                                  {
+                                    "r": "684",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "FHIRHelpers"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "."
+                                    ]
+                                  },
+                                  {
+                                    "r": "688",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "ToInterval",
+                                          "("
+                                        ]
+                                      },
+                                      {
+                                        "r": "685",
+                                        "s": [
+                                          {
+                                            "r": "686",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "choice"
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              " as "
+                                            ]
+                                          },
+                                          {
+                                            "r": "687",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "FHIR",
+                                                  ".",
+                                                  "Period"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          ")"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              "\n\t\t"
+                            ]
+                          },
+                          {
+                            "r": "689",
+                            "s": [
+                              {
+                                "value": [
+                                  "when "
+                                ]
+                              },
+                              {
+                                "r": "690",
+                                "s": [
+                                  {
+                                    "r": "691",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "choice"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      " is "
+                                    ]
+                                  },
+                                  {
+                                    "r": "692",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "FHIR",
+                                          ".",
+                                          "instant"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " then\n\t\t\t"
+                                ]
+                              },
+                              {
+                                "r": "703",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "Interval["
+                                    ]
+                                  },
+                                  {
+                                    "r": "697",
+                                    "s": [
+                                      {
+                                        "r": "693",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "FHIRHelpers"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "."
+                                        ]
+                                      },
+                                      {
+                                        "r": "697",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "ToDateTime",
+                                              "("
+                                            ]
+                                          },
+                                          {
+                                            "r": "694",
+                                            "s": [
+                                              {
+                                                "r": "695",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "choice"
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  " as "
+                                                ]
+                                              },
+                                              {
+                                                "r": "696",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "FHIR",
+                                                      ".",
+                                                      "instant"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              ")"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      ", "
+                                    ]
+                                  },
+                                  {
+                                    "r": "702",
+                                    "s": [
+                                      {
+                                        "r": "698",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "FHIRHelpers"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "."
+                                        ]
+                                      },
+                                      {
+                                        "r": "702",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "ToDateTime",
+                                              "("
+                                            ]
+                                          },
+                                          {
+                                            "r": "699",
+                                            "s": [
+                                              {
+                                                "r": "700",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "choice"
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  " as "
+                                                ]
+                                              },
+                                              {
+                                                "r": "701",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "FHIR",
+                                                      ".",
+                                                      "instant"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              ")"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "]"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              "\n\t\t"
+                            ]
+                          },
+                          {
+                            "r": "704",
+                            "s": [
+                              {
+                                "value": [
+                                  "when "
+                                ]
+                              },
+                              {
+                                "r": "705",
+                                "s": [
+                                  {
+                                    "r": "706",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "choice"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      " is "
+                                    ]
+                                  },
+                                  {
+                                    "r": "707",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "FHIR",
+                                          ".",
+                                          "Age"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " then\n\t\t  "
+                                ]
+                              },
+                              {
+                                "r": "730",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "Interval["
+                                    ]
+                                  },
+                                  {
+                                    "r": "708",
+                                    "s": [
+                                      {
+                                        "r": "712",
+                                        "s": [
+                                          {
+                                            "r": "709",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "FHIRHelpers"
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              "."
+                                            ]
+                                          },
+                                          {
+                                            "r": "712",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "ToDate",
+                                                  "("
+                                                ]
+                                              },
+                                              {
+                                                "r": "711",
+                                                "s": [
+                                                  {
+                                                    "r": "710",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "Patient"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "value": [
+                                                      "."
+                                                    ]
+                                                  },
+                                                  {
+                                                    "r": "711",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "birthDate"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  ")"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          " + "
+                                        ]
+                                      },
+                                      {
+                                        "r": "717",
+                                        "s": [
+                                          {
+                                            "r": "713",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "FHIRHelpers"
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              "."
+                                            ]
+                                          },
+                                          {
+                                            "r": "717",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "ToQuantity",
+                                                  "("
+                                                ]
+                                              },
+                                              {
+                                                "r": "714",
+                                                "s": [
+                                                  {
+                                                    "r": "715",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "choice"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "value": [
+                                                      " as "
+                                                    ]
+                                                  },
+                                                  {
+                                                    "r": "716",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "FHIR",
+                                                          ".",
+                                                          "Age"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  ")"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      ",\n\t\t\t  "
+                                    ]
+                                  },
+                                  {
+                                    "r": "718",
+                                    "s": [
+                                      {
+                                        "r": "719",
+                                        "s": [
+                                          {
+                                            "r": "723",
+                                            "s": [
+                                              {
+                                                "r": "720",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "FHIRHelpers"
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  "."
+                                                ]
+                                              },
+                                              {
+                                                "r": "723",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "ToDate",
+                                                      "("
+                                                    ]
+                                                  },
+                                                  {
+                                                    "r": "722",
+                                                    "s": [
+                                                      {
+                                                        "r": "721",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "Patient"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "value": [
+                                                          "."
+                                                        ]
+                                                      },
+                                                      {
+                                                        "r": "722",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "birthDate"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "value": [
+                                                      ")"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              " + "
+                                            ]
+                                          },
+                                          {
+                                            "r": "728",
+                                            "s": [
+                                              {
+                                                "r": "724",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "FHIRHelpers"
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  "."
+                                                ]
+                                              },
+                                              {
+                                                "r": "728",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "ToQuantity",
+                                                      "("
+                                                    ]
+                                                  },
+                                                  {
+                                                    "r": "725",
+                                                    "s": [
+                                                      {
+                                                        "r": "726",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "choice"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "value": [
+                                                          " as "
+                                                        ]
+                                                      },
+                                                      {
+                                                        "r": "727",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "FHIR",
+                                                              ".",
+                                                              "Age"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "value": [
+                                                      ")"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          " + "
+                                        ]
+                                      },
+                                      {
+                                        "r": "729",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "1 ",
+                                              "year"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      ")"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              "\n\t\t"
+                            ]
+                          },
+                          {
+                            "r": "731",
+                            "s": [
+                              {
+                                "value": [
+                                  "when "
+                                ]
+                              },
+                              {
+                                "r": "732",
+                                "s": [
+                                  {
+                                    "r": "733",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "choice"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      " is "
+                                    ]
+                                  },
+                                  {
+                                    "r": "734",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "FHIR",
+                                          ".",
+                                          "Range"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " then\n\t\t  "
+                                ]
+                              },
+                              {
+                                "r": "759",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "Interval["
+                                    ]
+                                  },
+                                  {
+                                    "r": "735",
+                                    "s": [
+                                      {
+                                        "r": "739",
+                                        "s": [
+                                          {
+                                            "r": "736",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "FHIRHelpers"
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              "."
+                                            ]
+                                          },
+                                          {
+                                            "r": "739",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "ToDate",
+                                                  "("
+                                                ]
+                                              },
+                                              {
+                                                "r": "738",
+                                                "s": [
+                                                  {
+                                                    "r": "737",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "Patient"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "value": [
+                                                      "."
+                                                    ]
+                                                  },
+                                                  {
+                                                    "r": "738",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "birthDate"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  ")"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          " + "
+                                        ]
+                                      },
+                                      {
+                                        "r": "745",
+                                        "s": [
+                                          {
+                                            "r": "740",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "FHIRHelpers"
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              "."
+                                            ]
+                                          },
+                                          {
+                                            "r": "745",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "ToQuantity",
+                                                  "("
+                                                ]
+                                              },
+                                              {
+                                                "r": "744",
+                                                "s": [
+                                                  {
+                                                    "r": "741",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "("
+                                                        ]
+                                                      },
+                                                      {
+                                                        "r": "741",
+                                                        "s": [
+                                                          {
+                                                            "r": "742",
+                                                            "s": [
+                                                              {
+                                                                "value": [
+                                                                  "choice"
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "value": [
+                                                              " as "
+                                                            ]
+                                                          },
+                                                          {
+                                                            "r": "743",
+                                                            "s": [
+                                                              {
+                                                                "value": [
+                                                                  "FHIR",
+                                                                  ".",
+                                                                  "Range"
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "value": [
+                                                          ")"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "value": [
+                                                      "."
+                                                    ]
+                                                  },
+                                                  {
+                                                    "r": "744",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "low"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  ")"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      ",\n\t\t\t  "
+                                    ]
+                                  },
+                                  {
+                                    "r": "746",
+                                    "s": [
+                                      {
+                                        "r": "747",
+                                        "s": [
+                                          {
+                                            "r": "751",
+                                            "s": [
+                                              {
+                                                "r": "748",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "FHIRHelpers"
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  "."
+                                                ]
+                                              },
+                                              {
+                                                "r": "751",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "ToDate",
+                                                      "("
+                                                    ]
+                                                  },
+                                                  {
+                                                    "r": "750",
+                                                    "s": [
+                                                      {
+                                                        "r": "749",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "Patient"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "value": [
+                                                          "."
+                                                        ]
+                                                      },
+                                                      {
+                                                        "r": "750",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "birthDate"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "value": [
+                                                      ")"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              " + "
+                                            ]
+                                          },
+                                          {
+                                            "r": "757",
+                                            "s": [
+                                              {
+                                                "r": "752",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "FHIRHelpers"
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  "."
+                                                ]
+                                              },
+                                              {
+                                                "r": "757",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "ToQuantity",
+                                                      "("
+                                                    ]
+                                                  },
+                                                  {
+                                                    "r": "756",
+                                                    "s": [
+                                                      {
+                                                        "r": "753",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "("
+                                                            ]
+                                                          },
+                                                          {
+                                                            "r": "753",
+                                                            "s": [
+                                                              {
+                                                                "r": "754",
+                                                                "s": [
+                                                                  {
+                                                                    "value": [
+                                                                      "choice"
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "value": [
+                                                                  " as "
+                                                                ]
+                                                              },
+                                                              {
+                                                                "r": "755",
+                                                                "s": [
+                                                                  {
+                                                                    "value": [
+                                                                      "FHIR",
+                                                                      ".",
+                                                                      "Range"
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "value": [
+                                                              ")"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "value": [
+                                                          "."
+                                                        ]
+                                                      },
+                                                      {
+                                                        "r": "756",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "high"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "value": [
+                                                      ")"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          " + "
+                                        ]
+                                      },
+                                      {
+                                        "r": "758",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "1 ",
+                                              "year"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      ")"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              "\n\t\t"
+                            ]
+                          },
+                          {
+                            "r": "760",
+                            "s": [
+                              {
+                                "value": [
+                                  "when "
+                                ]
+                              },
+                              {
+                                "r": "761",
+                                "s": [
+                                  {
+                                    "r": "762",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "choice"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      " is "
+                                    ]
+                                  },
+                                  {
+                                    "r": "763",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "FHIR",
+                                          ".",
+                                          "Timing"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " then\n\t\t  "
+                                ]
+                              },
+                              {
+                                "r": "774",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "Message",
+                                      "("
+                                    ]
+                                  },
+                                  {
+                                    "r": "764",
+                                    "s": [
+                                      {
+                                        "r": "765",
+                                        "value": [
+                                          "null",
+                                          " as "
+                                        ]
+                                      },
+                                      {
+                                        "r": "766",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "Interval<"
+                                            ]
+                                          },
+                                          {
+                                            "r": "767",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "DateTime"
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              ">"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "r": "768",
+                                    "value": [
+                                      ", ",
+                                      "true",
+                                      ", "
+                                    ]
+                                  },
+                                  {
+                                    "r": "769",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "'1'"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      ", "
+                                    ]
+                                  },
+                                  {
+                                    "r": "770",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "'Error'"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      ", "
+                                    ]
+                                  },
+                                  {
+                                    "r": "771",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "'Cannot compute a single interval from a Timing type'"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      ")"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              "\n    "
+                            ]
+                          },
+                          {
+                            "r": "775",
+                            "s": [
+                              {
+                                "value": [
+                                  "when "
+                                ]
+                              },
+                              {
+                                "r": "776",
+                                "s": [
+                                  {
+                                    "r": "777",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "choice"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      " is "
+                                    ]
+                                  },
+                                  {
+                                    "r": "778",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "FHIR",
+                                          ".",
+                                          "string"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " then\n      "
+                                ]
+                              },
+                              {
+                                "r": "789",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "Message",
+                                      "("
+                                    ]
+                                  },
+                                  {
+                                    "r": "779",
+                                    "s": [
+                                      {
+                                        "r": "780",
+                                        "value": [
+                                          "null",
+                                          " as "
+                                        ]
+                                      },
+                                      {
+                                        "r": "781",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "Interval<"
+                                            ]
+                                          },
+                                          {
+                                            "r": "782",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "DateTime"
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              ">"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "r": "783",
+                                    "value": [
+                                      ", ",
+                                      "true",
+                                      ", "
+                                    ]
+                                  },
+                                  {
+                                    "r": "784",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "'1'"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      ", "
+                                    ]
+                                  },
+                                  {
+                                    "r": "785",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "'Error'"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      ", "
+                                    ]
+                                  },
+                                  {
+                                    "r": "786",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "'Cannot compute an interval from a String value'"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      ")"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              "\n\t\telse\n\t\t\t"
+                            ]
+                          },
+                          {
+                            "r": "790",
+                            "s": [
+                              {
+                                "r": "791",
+                                "value": [
+                                  "null",
+                                  " as "
+                                ]
+                              },
+                              {
+                                "r": "792",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "Interval<"
+                                    ]
+                                  },
+                                  {
+                                    "r": "793",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "DateTime"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      ">"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              "\n\tend"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "664",
+            "locator": "172:3-191:4",
+            "type": "Case",
+            "caseItem": [
+              {
+                "localId": "665",
+                "locator": "173:4-174:111",
+                "when": {
+                  "localId": "666",
+                  "locator": "173:9-173:31",
+                  "type": "Is",
+                  "signature": [],
+                  "operand": {
+                    "localId": "667",
+                    "locator": "173:9-173:14",
+                    "name": "choice",
+                    "type": "OperandRef"
+                  },
+                  "isTypeSpecifier": {
+                    "localId": "668",
+                    "locator": "173:19-173:31",
+                    "name": "{http://hl7.org/fhir}dateTime",
+                    "type": "NamedTypeSpecifier"
+                  }
+                },
+                "then": {
+                  "localId": "679",
+                  "locator": "174:6-174:111",
+                  "lowClosed": true,
+                  "highClosed": true,
+                  "type": "Interval",
+                  "low": {
+                    "localId": "673",
+                    "locator": "174:15-174:61",
+                    "name": "ToDateTime",
+                    "libraryName": "FHIRHelpers",
+                    "type": "FunctionRef",
+                    "signature": [],
+                    "operand": [
+                      {
+                        "localId": "670",
+                        "locator": "174:38-174:60",
+                        "strict": false,
+                        "type": "As",
+                        "signature": [],
+                        "operand": {
+                          "localId": "671",
+                          "locator": "174:38-174:43",
+                          "name": "choice",
+                          "type": "OperandRef"
+                        },
+                        "asTypeSpecifier": {
+                          "localId": "672",
+                          "locator": "174:48-174:60",
+                          "name": "{http://hl7.org/fhir}dateTime",
+                          "type": "NamedTypeSpecifier"
+                        }
+                      }
+                    ]
+                  },
+                  "high": {
+                    "localId": "678",
+                    "locator": "174:64-174:110",
+                    "name": "ToDateTime",
+                    "libraryName": "FHIRHelpers",
+                    "type": "FunctionRef",
+                    "signature": [],
+                    "operand": [
+                      {
+                        "localId": "675",
+                        "locator": "174:87-174:109",
+                        "strict": false,
+                        "type": "As",
+                        "signature": [],
+                        "operand": {
+                          "localId": "676",
+                          "locator": "174:87-174:92",
+                          "name": "choice",
+                          "type": "OperandRef"
+                        },
+                        "asTypeSpecifier": {
+                          "localId": "677",
+                          "locator": "174:97-174:109",
+                          "name": "{http://hl7.org/fhir}dateTime",
+                          "type": "NamedTypeSpecifier"
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "localId": "680",
+                "locator": "175:3-176:49",
+                "when": {
+                  "localId": "681",
+                  "locator": "175:8-175:28",
+                  "type": "Is",
+                  "signature": [],
+                  "operand": {
+                    "localId": "682",
+                    "locator": "175:8-175:13",
+                    "name": "choice",
+                    "type": "OperandRef"
+                  },
+                  "isTypeSpecifier": {
+                    "localId": "683",
+                    "locator": "175:18-175:28",
+                    "name": "{http://hl7.org/fhir}Period",
+                    "type": "NamedTypeSpecifier"
+                  }
+                },
+                "then": {
+                  "localId": "688",
+                  "locator": "176:5-176:49",
+                  "name": "ToInterval",
+                  "libraryName": "FHIRHelpers",
+                  "type": "FunctionRef",
+                  "signature": [],
+                  "operand": [
+                    {
+                      "localId": "685",
+                      "locator": "176:28-176:48",
+                      "strict": false,
+                      "type": "As",
+                      "signature": [],
+                      "operand": {
+                        "localId": "686",
+                        "locator": "176:28-176:33",
+                        "name": "choice",
+                        "type": "OperandRef"
+                      },
+                      "asTypeSpecifier": {
+                        "localId": "687",
+                        "locator": "176:38-176:48",
+                        "name": "{http://hl7.org/fhir}Period",
+                        "type": "NamedTypeSpecifier"
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "localId": "689",
+                "locator": "177:3-178:107",
+                "when": {
+                  "localId": "690",
+                  "locator": "177:8-177:29",
+                  "type": "Is",
+                  "signature": [],
+                  "operand": {
+                    "localId": "691",
+                    "locator": "177:8-177:13",
+                    "name": "choice",
+                    "type": "OperandRef"
+                  },
+                  "isTypeSpecifier": {
+                    "localId": "692",
+                    "locator": "177:18-177:29",
+                    "name": "{http://hl7.org/fhir}instant",
+                    "type": "NamedTypeSpecifier"
+                  }
+                },
+                "then": {
+                  "localId": "703",
+                  "locator": "178:4-178:107",
+                  "lowClosed": true,
+                  "highClosed": true,
+                  "type": "Interval",
+                  "low": {
+                    "localId": "697",
+                    "locator": "178:13-178:58",
+                    "name": "ToDateTime",
+                    "libraryName": "FHIRHelpers",
+                    "type": "FunctionRef",
+                    "signature": [],
+                    "operand": [
+                      {
+                        "localId": "694",
+                        "locator": "178:36-178:57",
+                        "strict": false,
+                        "type": "As",
+                        "signature": [],
+                        "operand": {
+                          "localId": "695",
+                          "locator": "178:36-178:41",
+                          "name": "choice",
+                          "type": "OperandRef"
+                        },
+                        "asTypeSpecifier": {
+                          "localId": "696",
+                          "locator": "178:46-178:57",
+                          "name": "{http://hl7.org/fhir}instant",
+                          "type": "NamedTypeSpecifier"
+                        }
+                      }
+                    ]
+                  },
+                  "high": {
+                    "localId": "702",
+                    "locator": "178:61-178:106",
+                    "name": "ToDateTime",
+                    "libraryName": "FHIRHelpers",
+                    "type": "FunctionRef",
+                    "signature": [],
+                    "operand": [
+                      {
+                        "localId": "699",
+                        "locator": "178:84-178:105",
+                        "strict": false,
+                        "type": "As",
+                        "signature": [],
+                        "operand": {
+                          "localId": "700",
+                          "locator": "178:84-178:89",
+                          "name": "choice",
+                          "type": "OperandRef"
+                        },
+                        "asTypeSpecifier": {
+                          "localId": "701",
+                          "locator": "178:94-178:105",
+                          "name": "{http://hl7.org/fhir}instant",
+                          "type": "NamedTypeSpecifier"
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "localId": "704",
+                "locator": "179:3-181:97",
+                "when": {
+                  "localId": "705",
+                  "locator": "179:8-179:25",
+                  "type": "Is",
+                  "signature": [],
+                  "operand": {
+                    "localId": "706",
+                    "locator": "179:8-179:13",
+                    "name": "choice",
+                    "type": "OperandRef"
+                  },
+                  "isTypeSpecifier": {
+                    "localId": "707",
+                    "locator": "179:18-179:25",
+                    "name": "{http://hl7.org/fhir}Age",
+                    "type": "NamedTypeSpecifier"
+                  }
+                },
+                "then": {
+                  "localId": "794",
+                  "type": "Interval",
+                  "low": {
+                    "localId": "797",
+                    "type": "ToDateTime",
+                    "signature": [],
+                    "operand": {
+                      "localId": "795",
+                      "path": "low",
+                      "type": "Property",
+                      "source": {
+                        "localId": "730",
+                        "locator": "180:5-181:97",
+                        "lowClosed": true,
+                        "highClosed": false,
+                        "type": "Interval",
+                        "low": {
+                          "localId": "708",
+                          "locator": "180:14-180:95",
+                          "type": "Add",
+                          "signature": [],
+                          "operand": [
+                            {
+                              "localId": "712",
+                              "locator": "180:14-180:50",
+                              "name": "ToDate",
+                              "libraryName": "FHIRHelpers",
+                              "type": "FunctionRef",
+                              "signature": [],
+                              "operand": [
+                                {
+                                  "localId": "711",
+                                  "locator": "180:33-180:49",
+                                  "path": "birthDate",
+                                  "type": "Property",
+                                  "source": {
+                                    "localId": "710",
+                                    "locator": "180:33-180:39",
+                                    "name": "Patient",
+                                    "type": "ExpressionRef"
+                                  }
+                                }
+                              ]
+                            },
+                            {
+                              "localId": "717",
+                              "locator": "180:54-180:95",
+                              "name": "ToQuantity",
+                              "libraryName": "FHIRHelpers",
+                              "type": "FunctionRef",
+                              "signature": [],
+                              "operand": [
+                                {
+                                  "localId": "714",
+                                  "locator": "180:77-180:94",
+                                  "strict": false,
+                                  "type": "As",
+                                  "signature": [],
+                                  "operand": {
+                                    "localId": "715",
+                                    "locator": "180:77-180:82",
+                                    "name": "choice",
+                                    "type": "OperandRef"
+                                  },
+                                  "asTypeSpecifier": {
+                                    "localId": "716",
+                                    "locator": "180:87-180:94",
+                                    "name": "{http://hl7.org/fhir}Age",
+                                    "type": "NamedTypeSpecifier"
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "high": {
+                          "localId": "718",
+                          "locator": "181:6-181:96",
+                          "type": "Add",
+                          "signature": [],
+                          "operand": [
+                            {
+                              "localId": "719",
+                              "locator": "181:6-181:87",
+                              "type": "Add",
+                              "signature": [],
+                              "operand": [
+                                {
+                                  "localId": "723",
+                                  "locator": "181:6-181:42",
+                                  "name": "ToDate",
+                                  "libraryName": "FHIRHelpers",
+                                  "type": "FunctionRef",
+                                  "signature": [],
+                                  "operand": [
+                                    {
+                                      "localId": "722",
+                                      "locator": "181:25-181:41",
+                                      "path": "birthDate",
+                                      "type": "Property",
+                                      "source": {
+                                        "localId": "721",
+                                        "locator": "181:25-181:31",
+                                        "name": "Patient",
+                                        "type": "ExpressionRef"
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "localId": "728",
+                                  "locator": "181:46-181:87",
+                                  "name": "ToQuantity",
+                                  "libraryName": "FHIRHelpers",
+                                  "type": "FunctionRef",
+                                  "signature": [],
+                                  "operand": [
+                                    {
+                                      "localId": "725",
+                                      "locator": "181:69-181:86",
+                                      "strict": false,
+                                      "type": "As",
+                                      "signature": [],
+                                      "operand": {
+                                        "localId": "726",
+                                        "locator": "181:69-181:74",
+                                        "name": "choice",
+                                        "type": "OperandRef"
+                                      },
+                                      "asTypeSpecifier": {
+                                        "localId": "727",
+                                        "locator": "181:79-181:86",
+                                        "name": "{http://hl7.org/fhir}Age",
+                                        "type": "NamedTypeSpecifier"
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "localId": "729",
+                              "locator": "181:91-181:96",
+                              "value": 1,
+                              "unit": "year",
+                              "type": "Quantity"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "lowClosedExpression": {
+                    "localId": "798",
+                    "path": "lowClosed",
+                    "type": "Property",
+                    "source": {
+                      "localId": "730",
+                      "locator": "180:5-181:97",
+                      "lowClosed": true,
+                      "highClosed": false,
+                      "type": "Interval",
+                      "low": {
+                        "localId": "708",
+                        "locator": "180:14-180:95",
+                        "type": "Add",
+                        "signature": [],
+                        "operand": [
+                          {
+                            "localId": "712",
+                            "locator": "180:14-180:50",
+                            "name": "ToDate",
+                            "libraryName": "FHIRHelpers",
+                            "type": "FunctionRef",
+                            "signature": [],
+                            "operand": [
+                              {
+                                "localId": "711",
+                                "locator": "180:33-180:49",
+                                "path": "birthDate",
+                                "type": "Property",
+                                "source": {
+                                  "localId": "710",
+                                  "locator": "180:33-180:39",
+                                  "name": "Patient",
+                                  "type": "ExpressionRef"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "localId": "717",
+                            "locator": "180:54-180:95",
+                            "name": "ToQuantity",
+                            "libraryName": "FHIRHelpers",
+                            "type": "FunctionRef",
+                            "signature": [],
+                            "operand": [
+                              {
+                                "localId": "714",
+                                "locator": "180:77-180:94",
+                                "strict": false,
+                                "type": "As",
+                                "signature": [],
+                                "operand": {
+                                  "localId": "715",
+                                  "locator": "180:77-180:82",
+                                  "name": "choice",
+                                  "type": "OperandRef"
+                                },
+                                "asTypeSpecifier": {
+                                  "localId": "716",
+                                  "locator": "180:87-180:94",
+                                  "name": "{http://hl7.org/fhir}Age",
+                                  "type": "NamedTypeSpecifier"
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      "high": {
+                        "localId": "718",
+                        "locator": "181:6-181:96",
+                        "type": "Add",
+                        "signature": [],
+                        "operand": [
+                          {
+                            "localId": "719",
+                            "locator": "181:6-181:87",
+                            "type": "Add",
+                            "signature": [],
+                            "operand": [
+                              {
+                                "localId": "723",
+                                "locator": "181:6-181:42",
+                                "name": "ToDate",
+                                "libraryName": "FHIRHelpers",
+                                "type": "FunctionRef",
+                                "signature": [],
+                                "operand": [
+                                  {
+                                    "localId": "722",
+                                    "locator": "181:25-181:41",
+                                    "path": "birthDate",
+                                    "type": "Property",
+                                    "source": {
+                                      "localId": "721",
+                                      "locator": "181:25-181:31",
+                                      "name": "Patient",
+                                      "type": "ExpressionRef"
+                                    }
+                                  }
+                                ]
+                              },
+                              {
+                                "localId": "728",
+                                "locator": "181:46-181:87",
+                                "name": "ToQuantity",
+                                "libraryName": "FHIRHelpers",
+                                "type": "FunctionRef",
+                                "signature": [],
+                                "operand": [
+                                  {
+                                    "localId": "725",
+                                    "locator": "181:69-181:86",
+                                    "strict": false,
+                                    "type": "As",
+                                    "signature": [],
+                                    "operand": {
+                                      "localId": "726",
+                                      "locator": "181:69-181:74",
+                                      "name": "choice",
+                                      "type": "OperandRef"
+                                    },
+                                    "asTypeSpecifier": {
+                                      "localId": "727",
+                                      "locator": "181:79-181:86",
+                                      "name": "{http://hl7.org/fhir}Age",
+                                      "type": "NamedTypeSpecifier"
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "localId": "729",
+                            "locator": "181:91-181:96",
+                            "value": 1,
+                            "unit": "year",
+                            "type": "Quantity"
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "high": {
+                    "localId": "801",
+                    "type": "ToDateTime",
+                    "signature": [],
+                    "operand": {
+                      "localId": "799",
+                      "path": "high",
+                      "type": "Property",
+                      "source": {
+                        "localId": "730",
+                        "locator": "180:5-181:97",
+                        "lowClosed": true,
+                        "highClosed": false,
+                        "type": "Interval",
+                        "low": {
+                          "localId": "708",
+                          "locator": "180:14-180:95",
+                          "type": "Add",
+                          "signature": [],
+                          "operand": [
+                            {
+                              "localId": "712",
+                              "locator": "180:14-180:50",
+                              "name": "ToDate",
+                              "libraryName": "FHIRHelpers",
+                              "type": "FunctionRef",
+                              "signature": [],
+                              "operand": [
+                                {
+                                  "localId": "711",
+                                  "locator": "180:33-180:49",
+                                  "path": "birthDate",
+                                  "type": "Property",
+                                  "source": {
+                                    "localId": "710",
+                                    "locator": "180:33-180:39",
+                                    "name": "Patient",
+                                    "type": "ExpressionRef"
+                                  }
+                                }
+                              ]
+                            },
+                            {
+                              "localId": "717",
+                              "locator": "180:54-180:95",
+                              "name": "ToQuantity",
+                              "libraryName": "FHIRHelpers",
+                              "type": "FunctionRef",
+                              "signature": [],
+                              "operand": [
+                                {
+                                  "localId": "714",
+                                  "locator": "180:77-180:94",
+                                  "strict": false,
+                                  "type": "As",
+                                  "signature": [],
+                                  "operand": {
+                                    "localId": "715",
+                                    "locator": "180:77-180:82",
+                                    "name": "choice",
+                                    "type": "OperandRef"
+                                  },
+                                  "asTypeSpecifier": {
+                                    "localId": "716",
+                                    "locator": "180:87-180:94",
+                                    "name": "{http://hl7.org/fhir}Age",
+                                    "type": "NamedTypeSpecifier"
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "high": {
+                          "localId": "718",
+                          "locator": "181:6-181:96",
+                          "type": "Add",
+                          "signature": [],
+                          "operand": [
+                            {
+                              "localId": "719",
+                              "locator": "181:6-181:87",
+                              "type": "Add",
+                              "signature": [],
+                              "operand": [
+                                {
+                                  "localId": "723",
+                                  "locator": "181:6-181:42",
+                                  "name": "ToDate",
+                                  "libraryName": "FHIRHelpers",
+                                  "type": "FunctionRef",
+                                  "signature": [],
+                                  "operand": [
+                                    {
+                                      "localId": "722",
+                                      "locator": "181:25-181:41",
+                                      "path": "birthDate",
+                                      "type": "Property",
+                                      "source": {
+                                        "localId": "721",
+                                        "locator": "181:25-181:31",
+                                        "name": "Patient",
+                                        "type": "ExpressionRef"
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "localId": "728",
+                                  "locator": "181:46-181:87",
+                                  "name": "ToQuantity",
+                                  "libraryName": "FHIRHelpers",
+                                  "type": "FunctionRef",
+                                  "signature": [],
+                                  "operand": [
+                                    {
+                                      "localId": "725",
+                                      "locator": "181:69-181:86",
+                                      "strict": false,
+                                      "type": "As",
+                                      "signature": [],
+                                      "operand": {
+                                        "localId": "726",
+                                        "locator": "181:69-181:74",
+                                        "name": "choice",
+                                        "type": "OperandRef"
+                                      },
+                                      "asTypeSpecifier": {
+                                        "localId": "727",
+                                        "locator": "181:79-181:86",
+                                        "name": "{http://hl7.org/fhir}Age",
+                                        "type": "NamedTypeSpecifier"
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "localId": "729",
+                              "locator": "181:91-181:96",
+                              "value": 1,
+                              "unit": "year",
+                              "type": "Quantity"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "highClosedExpression": {
+                    "localId": "802",
+                    "path": "highClosed",
+                    "type": "Property",
+                    "source": {
+                      "localId": "730",
+                      "locator": "180:5-181:97",
+                      "lowClosed": true,
+                      "highClosed": false,
+                      "type": "Interval",
+                      "low": {
+                        "localId": "708",
+                        "locator": "180:14-180:95",
+                        "type": "Add",
+                        "signature": [],
+                        "operand": [
+                          {
+                            "localId": "712",
+                            "locator": "180:14-180:50",
+                            "name": "ToDate",
+                            "libraryName": "FHIRHelpers",
+                            "type": "FunctionRef",
+                            "signature": [],
+                            "operand": [
+                              {
+                                "localId": "711",
+                                "locator": "180:33-180:49",
+                                "path": "birthDate",
+                                "type": "Property",
+                                "source": {
+                                  "localId": "710",
+                                  "locator": "180:33-180:39",
+                                  "name": "Patient",
+                                  "type": "ExpressionRef"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "localId": "717",
+                            "locator": "180:54-180:95",
+                            "name": "ToQuantity",
+                            "libraryName": "FHIRHelpers",
+                            "type": "FunctionRef",
+                            "signature": [],
+                            "operand": [
+                              {
+                                "localId": "714",
+                                "locator": "180:77-180:94",
+                                "strict": false,
+                                "type": "As",
+                                "signature": [],
+                                "operand": {
+                                  "localId": "715",
+                                  "locator": "180:77-180:82",
+                                  "name": "choice",
+                                  "type": "OperandRef"
+                                },
+                                "asTypeSpecifier": {
+                                  "localId": "716",
+                                  "locator": "180:87-180:94",
+                                  "name": "{http://hl7.org/fhir}Age",
+                                  "type": "NamedTypeSpecifier"
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      "high": {
+                        "localId": "718",
+                        "locator": "181:6-181:96",
+                        "type": "Add",
+                        "signature": [],
+                        "operand": [
+                          {
+                            "localId": "719",
+                            "locator": "181:6-181:87",
+                            "type": "Add",
+                            "signature": [],
+                            "operand": [
+                              {
+                                "localId": "723",
+                                "locator": "181:6-181:42",
+                                "name": "ToDate",
+                                "libraryName": "FHIRHelpers",
+                                "type": "FunctionRef",
+                                "signature": [],
+                                "operand": [
+                                  {
+                                    "localId": "722",
+                                    "locator": "181:25-181:41",
+                                    "path": "birthDate",
+                                    "type": "Property",
+                                    "source": {
+                                      "localId": "721",
+                                      "locator": "181:25-181:31",
+                                      "name": "Patient",
+                                      "type": "ExpressionRef"
+                                    }
+                                  }
+                                ]
+                              },
+                              {
+                                "localId": "728",
+                                "locator": "181:46-181:87",
+                                "name": "ToQuantity",
+                                "libraryName": "FHIRHelpers",
+                                "type": "FunctionRef",
+                                "signature": [],
+                                "operand": [
+                                  {
+                                    "localId": "725",
+                                    "locator": "181:69-181:86",
+                                    "strict": false,
+                                    "type": "As",
+                                    "signature": [],
+                                    "operand": {
+                                      "localId": "726",
+                                      "locator": "181:69-181:74",
+                                      "name": "choice",
+                                      "type": "OperandRef"
+                                    },
+                                    "asTypeSpecifier": {
+                                      "localId": "727",
+                                      "locator": "181:79-181:86",
+                                      "name": "{http://hl7.org/fhir}Age",
+                                      "type": "NamedTypeSpecifier"
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "localId": "729",
+                            "locator": "181:91-181:96",
+                            "value": 1,
+                            "unit": "year",
+                            "type": "Quantity"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "localId": "731",
+                "locator": "182:3-184:106",
+                "when": {
+                  "localId": "732",
+                  "locator": "182:8-182:27",
+                  "type": "Is",
+                  "signature": [],
+                  "operand": {
+                    "localId": "733",
+                    "locator": "182:8-182:13",
+                    "name": "choice",
+                    "type": "OperandRef"
+                  },
+                  "isTypeSpecifier": {
+                    "localId": "734",
+                    "locator": "182:18-182:27",
+                    "name": "{http://hl7.org/fhir}Range",
+                    "type": "NamedTypeSpecifier"
+                  }
+                },
+                "then": {
+                  "localId": "803",
+                  "type": "Interval",
+                  "low": {
+                    "localId": "806",
+                    "type": "ToDateTime",
+                    "signature": [],
+                    "operand": {
+                      "localId": "804",
+                      "path": "low",
+                      "type": "Property",
+                      "source": {
+                        "localId": "759",
+                        "locator": "183:5-184:106",
+                        "lowClosed": true,
+                        "highClosed": false,
+                        "type": "Interval",
+                        "low": {
+                          "localId": "735",
+                          "locator": "183:14-183:103",
+                          "type": "Add",
+                          "signature": [],
+                          "operand": [
+                            {
+                              "localId": "739",
+                              "locator": "183:14-183:50",
+                              "name": "ToDate",
+                              "libraryName": "FHIRHelpers",
+                              "type": "FunctionRef",
+                              "signature": [],
+                              "operand": [
+                                {
+                                  "localId": "738",
+                                  "locator": "183:33-183:49",
+                                  "path": "birthDate",
+                                  "type": "Property",
+                                  "source": {
+                                    "localId": "737",
+                                    "locator": "183:33-183:39",
+                                    "name": "Patient",
+                                    "type": "ExpressionRef"
+                                  }
+                                }
+                              ]
+                            },
+                            {
+                              "localId": "745",
+                              "locator": "183:54-183:103",
+                              "name": "ToQuantity",
+                              "libraryName": "FHIRHelpers",
+                              "type": "FunctionRef",
+                              "signature": [],
+                              "operand": [
+                                {
+                                  "localId": "744",
+                                  "locator": "183:77-183:102",
+                                  "path": "low",
+                                  "type": "Property",
+                                  "source": {
+                                    "localId": "741",
+                                    "locator": "183:77-183:98",
+                                    "strict": false,
+                                    "type": "As",
+                                    "signature": [],
+                                    "operand": {
+                                      "localId": "742",
+                                      "locator": "183:78-183:83",
+                                      "name": "choice",
+                                      "type": "OperandRef"
+                                    },
+                                    "asTypeSpecifier": {
+                                      "localId": "743",
+                                      "locator": "183:88-183:97",
+                                      "name": "{http://hl7.org/fhir}Range",
+                                      "type": "NamedTypeSpecifier"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "high": {
+                          "localId": "746",
+                          "locator": "184:6-184:105",
+                          "type": "Add",
+                          "signature": [],
+                          "operand": [
+                            {
+                              "localId": "747",
+                              "locator": "184:6-184:96",
+                              "type": "Add",
+                              "signature": [],
+                              "operand": [
+                                {
+                                  "localId": "751",
+                                  "locator": "184:6-184:42",
+                                  "name": "ToDate",
+                                  "libraryName": "FHIRHelpers",
+                                  "type": "FunctionRef",
+                                  "signature": [],
+                                  "operand": [
+                                    {
+                                      "localId": "750",
+                                      "locator": "184:25-184:41",
+                                      "path": "birthDate",
+                                      "type": "Property",
+                                      "source": {
+                                        "localId": "749",
+                                        "locator": "184:25-184:31",
+                                        "name": "Patient",
+                                        "type": "ExpressionRef"
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "localId": "757",
+                                  "locator": "184:46-184:96",
+                                  "name": "ToQuantity",
+                                  "libraryName": "FHIRHelpers",
+                                  "type": "FunctionRef",
+                                  "signature": [],
+                                  "operand": [
+                                    {
+                                      "localId": "756",
+                                      "locator": "184:69-184:95",
+                                      "path": "high",
+                                      "type": "Property",
+                                      "source": {
+                                        "localId": "753",
+                                        "locator": "184:69-184:90",
+                                        "strict": false,
+                                        "type": "As",
+                                        "signature": [],
+                                        "operand": {
+                                          "localId": "754",
+                                          "locator": "184:70-184:75",
+                                          "name": "choice",
+                                          "type": "OperandRef"
+                                        },
+                                        "asTypeSpecifier": {
+                                          "localId": "755",
+                                          "locator": "184:80-184:89",
+                                          "name": "{http://hl7.org/fhir}Range",
+                                          "type": "NamedTypeSpecifier"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "localId": "758",
+                              "locator": "184:100-184:105",
+                              "value": 1,
+                              "unit": "year",
+                              "type": "Quantity"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "lowClosedExpression": {
+                    "localId": "807",
+                    "path": "lowClosed",
+                    "type": "Property",
+                    "source": {
+                      "localId": "759",
+                      "locator": "183:5-184:106",
+                      "lowClosed": true,
+                      "highClosed": false,
+                      "type": "Interval",
+                      "low": {
+                        "localId": "735",
+                        "locator": "183:14-183:103",
+                        "type": "Add",
+                        "signature": [],
+                        "operand": [
+                          {
+                            "localId": "739",
+                            "locator": "183:14-183:50",
+                            "name": "ToDate",
+                            "libraryName": "FHIRHelpers",
+                            "type": "FunctionRef",
+                            "signature": [],
+                            "operand": [
+                              {
+                                "localId": "738",
+                                "locator": "183:33-183:49",
+                                "path": "birthDate",
+                                "type": "Property",
+                                "source": {
+                                  "localId": "737",
+                                  "locator": "183:33-183:39",
+                                  "name": "Patient",
+                                  "type": "ExpressionRef"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "localId": "745",
+                            "locator": "183:54-183:103",
+                            "name": "ToQuantity",
+                            "libraryName": "FHIRHelpers",
+                            "type": "FunctionRef",
+                            "signature": [],
+                            "operand": [
+                              {
+                                "localId": "744",
+                                "locator": "183:77-183:102",
+                                "path": "low",
+                                "type": "Property",
+                                "source": {
+                                  "localId": "741",
+                                  "locator": "183:77-183:98",
+                                  "strict": false,
+                                  "type": "As",
+                                  "signature": [],
+                                  "operand": {
+                                    "localId": "742",
+                                    "locator": "183:78-183:83",
+                                    "name": "choice",
+                                    "type": "OperandRef"
+                                  },
+                                  "asTypeSpecifier": {
+                                    "localId": "743",
+                                    "locator": "183:88-183:97",
+                                    "name": "{http://hl7.org/fhir}Range",
+                                    "type": "NamedTypeSpecifier"
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      "high": {
+                        "localId": "746",
+                        "locator": "184:6-184:105",
+                        "type": "Add",
+                        "signature": [],
+                        "operand": [
+                          {
+                            "localId": "747",
+                            "locator": "184:6-184:96",
+                            "type": "Add",
+                            "signature": [],
+                            "operand": [
+                              {
+                                "localId": "751",
+                                "locator": "184:6-184:42",
+                                "name": "ToDate",
+                                "libraryName": "FHIRHelpers",
+                                "type": "FunctionRef",
+                                "signature": [],
+                                "operand": [
+                                  {
+                                    "localId": "750",
+                                    "locator": "184:25-184:41",
+                                    "path": "birthDate",
+                                    "type": "Property",
+                                    "source": {
+                                      "localId": "749",
+                                      "locator": "184:25-184:31",
+                                      "name": "Patient",
+                                      "type": "ExpressionRef"
+                                    }
+                                  }
+                                ]
+                              },
+                              {
+                                "localId": "757",
+                                "locator": "184:46-184:96",
+                                "name": "ToQuantity",
+                                "libraryName": "FHIRHelpers",
+                                "type": "FunctionRef",
+                                "signature": [],
+                                "operand": [
+                                  {
+                                    "localId": "756",
+                                    "locator": "184:69-184:95",
+                                    "path": "high",
+                                    "type": "Property",
+                                    "source": {
+                                      "localId": "753",
+                                      "locator": "184:69-184:90",
+                                      "strict": false,
+                                      "type": "As",
+                                      "signature": [],
+                                      "operand": {
+                                        "localId": "754",
+                                        "locator": "184:70-184:75",
+                                        "name": "choice",
+                                        "type": "OperandRef"
+                                      },
+                                      "asTypeSpecifier": {
+                                        "localId": "755",
+                                        "locator": "184:80-184:89",
+                                        "name": "{http://hl7.org/fhir}Range",
+                                        "type": "NamedTypeSpecifier"
+                                      }
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "localId": "758",
+                            "locator": "184:100-184:105",
+                            "value": 1,
+                            "unit": "year",
+                            "type": "Quantity"
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "high": {
+                    "localId": "810",
+                    "type": "ToDateTime",
+                    "signature": [],
+                    "operand": {
+                      "localId": "808",
+                      "path": "high",
+                      "type": "Property",
+                      "source": {
+                        "localId": "759",
+                        "locator": "183:5-184:106",
+                        "lowClosed": true,
+                        "highClosed": false,
+                        "type": "Interval",
+                        "low": {
+                          "localId": "735",
+                          "locator": "183:14-183:103",
+                          "type": "Add",
+                          "signature": [],
+                          "operand": [
+                            {
+                              "localId": "739",
+                              "locator": "183:14-183:50",
+                              "name": "ToDate",
+                              "libraryName": "FHIRHelpers",
+                              "type": "FunctionRef",
+                              "signature": [],
+                              "operand": [
+                                {
+                                  "localId": "738",
+                                  "locator": "183:33-183:49",
+                                  "path": "birthDate",
+                                  "type": "Property",
+                                  "source": {
+                                    "localId": "737",
+                                    "locator": "183:33-183:39",
+                                    "name": "Patient",
+                                    "type": "ExpressionRef"
+                                  }
+                                }
+                              ]
+                            },
+                            {
+                              "localId": "745",
+                              "locator": "183:54-183:103",
+                              "name": "ToQuantity",
+                              "libraryName": "FHIRHelpers",
+                              "type": "FunctionRef",
+                              "signature": [],
+                              "operand": [
+                                {
+                                  "localId": "744",
+                                  "locator": "183:77-183:102",
+                                  "path": "low",
+                                  "type": "Property",
+                                  "source": {
+                                    "localId": "741",
+                                    "locator": "183:77-183:98",
+                                    "strict": false,
+                                    "type": "As",
+                                    "signature": [],
+                                    "operand": {
+                                      "localId": "742",
+                                      "locator": "183:78-183:83",
+                                      "name": "choice",
+                                      "type": "OperandRef"
+                                    },
+                                    "asTypeSpecifier": {
+                                      "localId": "743",
+                                      "locator": "183:88-183:97",
+                                      "name": "{http://hl7.org/fhir}Range",
+                                      "type": "NamedTypeSpecifier"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "high": {
+                          "localId": "746",
+                          "locator": "184:6-184:105",
+                          "type": "Add",
+                          "signature": [],
+                          "operand": [
+                            {
+                              "localId": "747",
+                              "locator": "184:6-184:96",
+                              "type": "Add",
+                              "signature": [],
+                              "operand": [
+                                {
+                                  "localId": "751",
+                                  "locator": "184:6-184:42",
+                                  "name": "ToDate",
+                                  "libraryName": "FHIRHelpers",
+                                  "type": "FunctionRef",
+                                  "signature": [],
+                                  "operand": [
+                                    {
+                                      "localId": "750",
+                                      "locator": "184:25-184:41",
+                                      "path": "birthDate",
+                                      "type": "Property",
+                                      "source": {
+                                        "localId": "749",
+                                        "locator": "184:25-184:31",
+                                        "name": "Patient",
+                                        "type": "ExpressionRef"
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "localId": "757",
+                                  "locator": "184:46-184:96",
+                                  "name": "ToQuantity",
+                                  "libraryName": "FHIRHelpers",
+                                  "type": "FunctionRef",
+                                  "signature": [],
+                                  "operand": [
+                                    {
+                                      "localId": "756",
+                                      "locator": "184:69-184:95",
+                                      "path": "high",
+                                      "type": "Property",
+                                      "source": {
+                                        "localId": "753",
+                                        "locator": "184:69-184:90",
+                                        "strict": false,
+                                        "type": "As",
+                                        "signature": [],
+                                        "operand": {
+                                          "localId": "754",
+                                          "locator": "184:70-184:75",
+                                          "name": "choice",
+                                          "type": "OperandRef"
+                                        },
+                                        "asTypeSpecifier": {
+                                          "localId": "755",
+                                          "locator": "184:80-184:89",
+                                          "name": "{http://hl7.org/fhir}Range",
+                                          "type": "NamedTypeSpecifier"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "localId": "758",
+                              "locator": "184:100-184:105",
+                              "value": 1,
+                              "unit": "year",
+                              "type": "Quantity"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "highClosedExpression": {
+                    "localId": "811",
+                    "path": "highClosed",
+                    "type": "Property",
+                    "source": {
+                      "localId": "759",
+                      "locator": "183:5-184:106",
+                      "lowClosed": true,
+                      "highClosed": false,
+                      "type": "Interval",
+                      "low": {
+                        "localId": "735",
+                        "locator": "183:14-183:103",
+                        "type": "Add",
+                        "signature": [],
+                        "operand": [
+                          {
+                            "localId": "739",
+                            "locator": "183:14-183:50",
+                            "name": "ToDate",
+                            "libraryName": "FHIRHelpers",
+                            "type": "FunctionRef",
+                            "signature": [],
+                            "operand": [
+                              {
+                                "localId": "738",
+                                "locator": "183:33-183:49",
+                                "path": "birthDate",
+                                "type": "Property",
+                                "source": {
+                                  "localId": "737",
+                                  "locator": "183:33-183:39",
+                                  "name": "Patient",
+                                  "type": "ExpressionRef"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "localId": "745",
+                            "locator": "183:54-183:103",
+                            "name": "ToQuantity",
+                            "libraryName": "FHIRHelpers",
+                            "type": "FunctionRef",
+                            "signature": [],
+                            "operand": [
+                              {
+                                "localId": "744",
+                                "locator": "183:77-183:102",
+                                "path": "low",
+                                "type": "Property",
+                                "source": {
+                                  "localId": "741",
+                                  "locator": "183:77-183:98",
+                                  "strict": false,
+                                  "type": "As",
+                                  "signature": [],
+                                  "operand": {
+                                    "localId": "742",
+                                    "locator": "183:78-183:83",
+                                    "name": "choice",
+                                    "type": "OperandRef"
+                                  },
+                                  "asTypeSpecifier": {
+                                    "localId": "743",
+                                    "locator": "183:88-183:97",
+                                    "name": "{http://hl7.org/fhir}Range",
+                                    "type": "NamedTypeSpecifier"
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      "high": {
+                        "localId": "746",
+                        "locator": "184:6-184:105",
+                        "type": "Add",
+                        "signature": [],
+                        "operand": [
+                          {
+                            "localId": "747",
+                            "locator": "184:6-184:96",
+                            "type": "Add",
+                            "signature": [],
+                            "operand": [
+                              {
+                                "localId": "751",
+                                "locator": "184:6-184:42",
+                                "name": "ToDate",
+                                "libraryName": "FHIRHelpers",
+                                "type": "FunctionRef",
+                                "signature": [],
+                                "operand": [
+                                  {
+                                    "localId": "750",
+                                    "locator": "184:25-184:41",
+                                    "path": "birthDate",
+                                    "type": "Property",
+                                    "source": {
+                                      "localId": "749",
+                                      "locator": "184:25-184:31",
+                                      "name": "Patient",
+                                      "type": "ExpressionRef"
+                                    }
+                                  }
+                                ]
+                              },
+                              {
+                                "localId": "757",
+                                "locator": "184:46-184:96",
+                                "name": "ToQuantity",
+                                "libraryName": "FHIRHelpers",
+                                "type": "FunctionRef",
+                                "signature": [],
+                                "operand": [
+                                  {
+                                    "localId": "756",
+                                    "locator": "184:69-184:95",
+                                    "path": "high",
+                                    "type": "Property",
+                                    "source": {
+                                      "localId": "753",
+                                      "locator": "184:69-184:90",
+                                      "strict": false,
+                                      "type": "As",
+                                      "signature": [],
+                                      "operand": {
+                                        "localId": "754",
+                                        "locator": "184:70-184:75",
+                                        "name": "choice",
+                                        "type": "OperandRef"
+                                      },
+                                      "asTypeSpecifier": {
+                                        "localId": "755",
+                                        "locator": "184:80-184:89",
+                                        "name": "{http://hl7.org/fhir}Range",
+                                        "type": "NamedTypeSpecifier"
+                                      }
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "localId": "758",
+                            "locator": "184:100-184:105",
+                            "value": 1,
+                            "unit": "year",
+                            "type": "Quantity"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "localId": "760",
+                "locator": "185:3-186:114",
+                "when": {
+                  "localId": "761",
+                  "locator": "185:8-185:28",
+                  "type": "Is",
+                  "signature": [],
+                  "operand": {
+                    "localId": "762",
+                    "locator": "185:8-185:13",
+                    "name": "choice",
+                    "type": "OperandRef"
+                  },
+                  "isTypeSpecifier": {
+                    "localId": "763",
+                    "locator": "185:18-185:28",
+                    "name": "{http://hl7.org/fhir}Timing",
+                    "type": "NamedTypeSpecifier"
+                  }
+                },
+                "then": {
+                  "localId": "774",
+                  "locator": "186:5-186:114",
+                  "type": "Message",
+                  "signature": [],
+                  "source": {
+                    "localId": "764",
+                    "locator": "186:13-186:38",
+                    "strict": false,
+                    "type": "As",
+                    "signature": [],
+                    "operand": {
+                      "localId": "765",
+                      "locator": "186:13-186:16",
+                      "type": "Null"
+                    },
+                    "asTypeSpecifier": {
+                      "localId": "766",
+                      "locator": "186:21-186:38",
+                      "type": "IntervalTypeSpecifier",
+                      "pointType": {
+                        "localId": "767",
+                        "locator": "186:30-186:37",
+                        "name": "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type": "NamedTypeSpecifier"
+                      }
+                    }
+                  },
+                  "condition": {
+                    "localId": "768",
+                    "locator": "186:41-186:44",
+                    "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+                    "value": "true",
+                    "type": "Literal"
+                  },
+                  "code": {
+                    "localId": "769",
+                    "locator": "186:47-186:49",
+                    "valueType": "{urn:hl7-org:elm-types:r1}String",
+                    "value": "1",
+                    "type": "Literal"
+                  },
+                  "severity": {
+                    "localId": "770",
+                    "locator": "186:52-186:58",
+                    "valueType": "{urn:hl7-org:elm-types:r1}String",
+                    "value": "Error",
+                    "type": "Literal"
+                  },
+                  "message": {
+                    "localId": "771",
+                    "locator": "186:61-186:113",
+                    "valueType": "{urn:hl7-org:elm-types:r1}String",
+                    "value": "Cannot compute a single interval from a Timing type",
+                    "type": "Literal"
+                  }
+                }
+              },
+              {
+                "localId": "775",
+                "locator": "187:5-188:111",
+                "when": {
+                  "localId": "776",
+                  "locator": "187:10-187:30",
+                  "type": "Is",
+                  "signature": [],
+                  "operand": {
+                    "localId": "777",
+                    "locator": "187:10-187:15",
+                    "name": "choice",
+                    "type": "OperandRef"
+                  },
+                  "isTypeSpecifier": {
+                    "localId": "778",
+                    "locator": "187:20-187:30",
+                    "name": "{http://hl7.org/fhir}string",
+                    "type": "NamedTypeSpecifier"
+                  }
+                },
+                "then": {
+                  "localId": "789",
+                  "locator": "188:7-188:111",
+                  "type": "Message",
+                  "signature": [],
+                  "source": {
+                    "localId": "779",
+                    "locator": "188:15-188:40",
+                    "strict": false,
+                    "type": "As",
+                    "signature": [],
+                    "operand": {
+                      "localId": "780",
+                      "locator": "188:15-188:18",
+                      "type": "Null"
+                    },
+                    "asTypeSpecifier": {
+                      "localId": "781",
+                      "locator": "188:23-188:40",
+                      "type": "IntervalTypeSpecifier",
+                      "pointType": {
+                        "localId": "782",
+                        "locator": "188:32-188:39",
+                        "name": "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type": "NamedTypeSpecifier"
+                      }
+                    }
+                  },
+                  "condition": {
+                    "localId": "783",
+                    "locator": "188:43-188:46",
+                    "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+                    "value": "true",
+                    "type": "Literal"
+                  },
+                  "code": {
+                    "localId": "784",
+                    "locator": "188:49-188:51",
+                    "valueType": "{urn:hl7-org:elm-types:r1}String",
+                    "value": "1",
+                    "type": "Literal"
+                  },
+                  "severity": {
+                    "localId": "785",
+                    "locator": "188:54-188:60",
+                    "valueType": "{urn:hl7-org:elm-types:r1}String",
+                    "value": "Error",
+                    "type": "Literal"
+                  },
+                  "message": {
+                    "localId": "786",
+                    "locator": "188:63-188:110",
+                    "valueType": "{urn:hl7-org:elm-types:r1}String",
+                    "value": "Cannot compute an interval from a String value",
+                    "type": "Literal"
+                  }
+                }
+              }
+            ],
+            "else": {
+              "localId": "790",
+              "locator": "190:4-190:29",
+              "strict": false,
+              "type": "As",
+              "signature": [],
+              "operand": {
+                "localId": "791",
+                "locator": "190:4-190:7",
+                "type": "Null"
+              },
+              "asTypeSpecifier": {
+                "localId": "792",
+                "locator": "190:12-190:29",
+                "type": "IntervalTypeSpecifier",
+                "pointType": {
+                  "localId": "793",
+                  "locator": "190:21-190:28",
+                  "name": "{urn:hl7-org:elm-types:r1}DateTime",
+                  "type": "NamedTypeSpecifier"
+                }
+              }
+            }
+          },
+          "operand": [
+            {
+              "localId": "663",
+              "name": "choice",
+              "operandTypeSpecifier": {
+                "localId": "662",
+                "locator": "171:45-171:140",
+                "type": "ChoiceTypeSpecifier",
+                "choice": [
+                  {
+                    "localId": "655",
+                    "locator": "171:52-171:64",
+                    "name": "{http://hl7.org/fhir}dateTime",
+                    "type": "NamedTypeSpecifier"
+                  },
+                  {
+                    "localId": "656",
+                    "locator": "171:67-171:77",
+                    "name": "{http://hl7.org/fhir}Period",
+                    "type": "NamedTypeSpecifier"
+                  },
+                  {
+                    "localId": "657",
+                    "locator": "171:80-171:90",
+                    "name": "{http://hl7.org/fhir}Timing",
+                    "type": "NamedTypeSpecifier"
+                  },
+                  {
+                    "localId": "658",
+                    "locator": "171:93-171:104",
+                    "name": "{http://hl7.org/fhir}instant",
+                    "type": "NamedTypeSpecifier"
+                  },
+                  {
+                    "localId": "659",
+                    "locator": "171:107-171:117",
+                    "name": "{http://hl7.org/fhir}string",
+                    "type": "NamedTypeSpecifier"
+                  },
+                  {
+                    "localId": "660",
+                    "locator": "171:120-171:127",
+                    "name": "{http://hl7.org/fhir}Age",
+                    "type": "NamedTypeSpecifier"
+                  },
+                  {
+                    "localId": "661",
+                    "locator": "171:130-171:139",
+                    "name": "{http://hl7.org/fhir}Range",
+                    "type": "NamedTypeSpecifier"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "localId": "812",
+          "locator": "193:1-208:10",
+          "name": "Normalize Abatement",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "812",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define function \"Normalize Abatement\"(condition Condition):\n\t"
+                    ]
+                  },
+                  {
+                    "r": "815",
+                    "s": [
+                      {
+                        "r": "815",
+                        "s": [
+                          {
+                            "value": [
+                              "if "
+                            ]
+                          },
+                          {
+                            "r": "816",
+                            "s": [
+                              {
+                                "r": "818",
+                                "s": [
+                                  {
+                                    "r": "817",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "condition"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "."
+                                    ]
+                                  },
+                                  {
+                                    "r": "818",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "abatement"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " is "
+                                ]
+                              },
+                              {
+                                "r": "819",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "FHIR",
+                                      ".",
+                                      "dateTime"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              " then\n\t  "
+                            ]
+                          },
+                          {
+                            "r": "832",
+                            "s": [
+                              {
+                                "value": [
+                                  "Interval["
+                                ]
+                              },
+                              {
+                                "r": "825",
+                                "s": [
+                                  {
+                                    "r": "820",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "FHIRHelpers"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "."
+                                    ]
+                                  },
+                                  {
+                                    "r": "825",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "ToDateTime",
+                                          "("
+                                        ]
+                                      },
+                                      {
+                                        "r": "821",
+                                        "s": [
+                                          {
+                                            "r": "823",
+                                            "s": [
+                                              {
+                                                "r": "822",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "condition"
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  "."
+                                                ]
+                                              },
+                                              {
+                                                "r": "823",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "abatement"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              " as "
+                                            ]
+                                          },
+                                          {
+                                            "r": "824",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "FHIR",
+                                                  ".",
+                                                  "dateTime"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          ")"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  ", "
+                                ]
+                              },
+                              {
+                                "r": "831",
+                                "s": [
+                                  {
+                                    "r": "826",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "FHIRHelpers"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "."
+                                    ]
+                                  },
+                                  {
+                                    "r": "831",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "ToDateTime",
+                                          "("
+                                        ]
+                                      },
+                                      {
+                                        "r": "827",
+                                        "s": [
+                                          {
+                                            "r": "829",
+                                            "s": [
+                                              {
+                                                "r": "828",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "condition"
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  "."
+                                                ]
+                                              },
+                                              {
+                                                "r": "829",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "abatement"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              " as "
+                                            ]
+                                          },
+                                          {
+                                            "r": "830",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "FHIR",
+                                                  ".",
+                                                  "dateTime"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          ")"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  "]"
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              "\n\telse "
+                            ]
+                          },
+                          {
+                            "r": "833",
+                            "s": [
+                              {
+                                "value": [
+                                  "if "
+                                ]
+                              },
+                              {
+                                "r": "834",
+                                "s": [
+                                  {
+                                    "r": "836",
+                                    "s": [
+                                      {
+                                        "r": "835",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "condition"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "."
+                                        ]
+                                      },
+                                      {
+                                        "r": "836",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "abatement"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      " is "
+                                    ]
+                                  },
+                                  {
+                                    "r": "837",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "FHIR",
+                                          ".",
+                                          "Period"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " then\n\t  "
+                                ]
+                              },
+                              {
+                                "r": "843",
+                                "s": [
+                                  {
+                                    "r": "838",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "FHIRHelpers"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "."
+                                    ]
+                                  },
+                                  {
+                                    "r": "843",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "ToInterval",
+                                          "("
+                                        ]
+                                      },
+                                      {
+                                        "r": "839",
+                                        "s": [
+                                          {
+                                            "r": "841",
+                                            "s": [
+                                              {
+                                                "r": "840",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "condition"
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  "."
+                                                ]
+                                              },
+                                              {
+                                                "r": "841",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "abatement"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              " as "
+                                            ]
+                                          },
+                                          {
+                                            "r": "842",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "FHIR",
+                                                  ".",
+                                                  "Period"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          ")"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  "\n\telse "
+                                ]
+                              },
+                              {
+                                "r": "844",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "if "
+                                    ]
+                                  },
+                                  {
+                                    "r": "845",
+                                    "s": [
+                                      {
+                                        "r": "847",
+                                        "s": [
+                                          {
+                                            "r": "846",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "condition"
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              "."
+                                            ]
+                                          },
+                                          {
+                                            "r": "847",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "abatement"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          " is "
+                                        ]
+                                      },
+                                      {
+                                        "r": "848",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "FHIR",
+                                              ".",
+                                              "string"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      " then\n    "
+                                    ]
+                                  },
+                                  {
+                                    "r": "859",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "Message",
+                                          "("
+                                        ]
+                                      },
+                                      {
+                                        "r": "849",
+                                        "s": [
+                                          {
+                                            "r": "850",
+                                            "value": [
+                                              "null",
+                                              " as "
+                                            ]
+                                          },
+                                          {
+                                            "r": "851",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "Interval<"
+                                                ]
+                                              },
+                                              {
+                                                "r": "852",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "DateTime"
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  ">"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "r": "853",
+                                        "value": [
+                                          ", ",
+                                          "true",
+                                          ", "
+                                        ]
+                                      },
+                                      {
+                                        "r": "854",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "'1'"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          ", "
+                                        ]
+                                      },
+                                      {
+                                        "r": "855",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "'Error'"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          ", "
+                                        ]
+                                      },
+                                      {
+                                        "r": "856",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "'Cannot compute an interval from a String value'"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          ")"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "\n\telse "
+                                    ]
+                                  },
+                                  {
+                                    "r": "860",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "if "
+                                        ]
+                                      },
+                                      {
+                                        "r": "861",
+                                        "s": [
+                                          {
+                                            "r": "863",
+                                            "s": [
+                                              {
+                                                "r": "862",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "condition"
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  "."
+                                                ]
+                                              },
+                                              {
+                                                "r": "863",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "abatement"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              " is "
+                                            ]
+                                          },
+                                          {
+                                            "r": "864",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "FHIR",
+                                                  ".",
+                                                  "Age"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          " then\n\t\t"
+                                        ]
+                                      },
+                                      {
+                                        "r": "889",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "Interval["
+                                            ]
+                                          },
+                                          {
+                                            "r": "865",
+                                            "s": [
+                                              {
+                                                "r": "869",
+                                                "s": [
+                                                  {
+                                                    "r": "866",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "FHIRHelpers"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "value": [
+                                                      "."
+                                                    ]
+                                                  },
+                                                  {
+                                                    "r": "869",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "ToDate",
+                                                          "("
+                                                        ]
+                                                      },
+                                                      {
+                                                        "r": "868",
+                                                        "s": [
+                                                          {
+                                                            "r": "867",
+                                                            "s": [
+                                                              {
+                                                                "value": [
+                                                                  "Patient"
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "value": [
+                                                              "."
+                                                            ]
+                                                          },
+                                                          {
+                                                            "r": "868",
+                                                            "s": [
+                                                              {
+                                                                "value": [
+                                                                  "birthDate"
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "value": [
+                                                          ")"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  " + "
+                                                ]
+                                              },
+                                              {
+                                                "r": "875",
+                                                "s": [
+                                                  {
+                                                    "r": "870",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "FHIRHelpers"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "value": [
+                                                      "."
+                                                    ]
+                                                  },
+                                                  {
+                                                    "r": "875",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "ToQuantity",
+                                                          "("
+                                                        ]
+                                                      },
+                                                      {
+                                                        "r": "871",
+                                                        "s": [
+                                                          {
+                                                            "r": "873",
+                                                            "s": [
+                                                              {
+                                                                "r": "872",
+                                                                "s": [
+                                                                  {
+                                                                    "value": [
+                                                                      "condition"
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "value": [
+                                                                  "."
+                                                                ]
+                                                              },
+                                                              {
+                                                                "r": "873",
+                                                                "s": [
+                                                                  {
+                                                                    "value": [
+                                                                      "abatement"
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "value": [
+                                                              " as "
+                                                            ]
+                                                          },
+                                                          {
+                                                            "r": "874",
+                                                            "s": [
+                                                              {
+                                                                "value": [
+                                                                  "FHIR",
+                                                                  ".",
+                                                                  "Age"
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "value": [
+                                                          ")"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              ",\n\t\t\t"
+                                            ]
+                                          },
+                                          {
+                                            "r": "876",
+                                            "s": [
+                                              {
+                                                "r": "877",
+                                                "s": [
+                                                  {
+                                                    "r": "881",
+                                                    "s": [
+                                                      {
+                                                        "r": "878",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "FHIRHelpers"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "value": [
+                                                          "."
+                                                        ]
+                                                      },
+                                                      {
+                                                        "r": "881",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "ToDate",
+                                                              "("
+                                                            ]
+                                                          },
+                                                          {
+                                                            "r": "880",
+                                                            "s": [
+                                                              {
+                                                                "r": "879",
+                                                                "s": [
+                                                                  {
+                                                                    "value": [
+                                                                      "Patient"
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "value": [
+                                                                  "."
+                                                                ]
+                                                              },
+                                                              {
+                                                                "r": "880",
+                                                                "s": [
+                                                                  {
+                                                                    "value": [
+                                                                      "birthDate"
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "value": [
+                                                              ")"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "value": [
+                                                      " + "
+                                                    ]
+                                                  },
+                                                  {
+                                                    "r": "887",
+                                                    "s": [
+                                                      {
+                                                        "r": "882",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "FHIRHelpers"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "value": [
+                                                          "."
+                                                        ]
+                                                      },
+                                                      {
+                                                        "r": "887",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "ToQuantity",
+                                                              "("
+                                                            ]
+                                                          },
+                                                          {
+                                                            "r": "883",
+                                                            "s": [
+                                                              {
+                                                                "r": "885",
+                                                                "s": [
+                                                                  {
+                                                                    "r": "884",
+                                                                    "s": [
+                                                                      {
+                                                                        "value": [
+                                                                          "condition"
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "value": [
+                                                                      "."
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "r": "885",
+                                                                    "s": [
+                                                                      {
+                                                                        "value": [
+                                                                          "abatement"
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "value": [
+                                                                  " as "
+                                                                ]
+                                                              },
+                                                              {
+                                                                "r": "886",
+                                                                "s": [
+                                                                  {
+                                                                    "value": [
+                                                                      "FHIR",
+                                                                      ".",
+                                                                      "Age"
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "value": [
+                                                              ")"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  " + "
+                                                ]
+                                              },
+                                              {
+                                                "r": "888",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "1 ",
+                                                      "year"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              ")"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "\n\telse "
+                                        ]
+                                      },
+                                      {
+                                        "r": "890",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "if "
+                                            ]
+                                          },
+                                          {
+                                            "r": "891",
+                                            "s": [
+                                              {
+                                                "r": "893",
+                                                "s": [
+                                                  {
+                                                    "r": "892",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "condition"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "value": [
+                                                      "."
+                                                    ]
+                                                  },
+                                                  {
+                                                    "r": "893",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "abatement"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  " is "
+                                                ]
+                                              },
+                                              {
+                                                "r": "894",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "FHIR",
+                                                      ".",
+                                                      "Range"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              " then\n\t  "
+                                            ]
+                                          },
+                                          {
+                                            "r": "921",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "Interval["
+                                                ]
+                                              },
+                                              {
+                                                "r": "895",
+                                                "s": [
+                                                  {
+                                                    "r": "899",
+                                                    "s": [
+                                                      {
+                                                        "r": "896",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "FHIRHelpers"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "value": [
+                                                          "."
+                                                        ]
+                                                      },
+                                                      {
+                                                        "r": "899",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "ToDate",
+                                                              "("
+                                                            ]
+                                                          },
+                                                          {
+                                                            "r": "898",
+                                                            "s": [
+                                                              {
+                                                                "r": "897",
+                                                                "s": [
+                                                                  {
+                                                                    "value": [
+                                                                      "Patient"
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "value": [
+                                                                  "."
+                                                                ]
+                                                              },
+                                                              {
+                                                                "r": "898",
+                                                                "s": [
+                                                                  {
+                                                                    "value": [
+                                                                      "birthDate"
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "value": [
+                                                              ")"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "value": [
+                                                      " + "
+                                                    ]
+                                                  },
+                                                  {
+                                                    "r": "906",
+                                                    "s": [
+                                                      {
+                                                        "r": "900",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "FHIRHelpers"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "value": [
+                                                          "."
+                                                        ]
+                                                      },
+                                                      {
+                                                        "r": "906",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "ToQuantity",
+                                                              "("
+                                                            ]
+                                                          },
+                                                          {
+                                                            "r": "905",
+                                                            "s": [
+                                                              {
+                                                                "r": "901",
+                                                                "s": [
+                                                                  {
+                                                                    "value": [
+                                                                      "("
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "r": "901",
+                                                                    "s": [
+                                                                      {
+                                                                        "r": "903",
+                                                                        "s": [
+                                                                          {
+                                                                            "r": "902",
+                                                                            "s": [
+                                                                              {
+                                                                                "value": [
+                                                                                  "condition"
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          },
+                                                                          {
+                                                                            "value": [
+                                                                              "."
+                                                                            ]
+                                                                          },
+                                                                          {
+                                                                            "r": "903",
+                                                                            "s": [
+                                                                              {
+                                                                                "value": [
+                                                                                  "abatement"
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "value": [
+                                                                          " as "
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "r": "904",
+                                                                        "s": [
+                                                                          {
+                                                                            "value": [
+                                                                              "FHIR",
+                                                                              ".",
+                                                                              "Range"
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "value": [
+                                                                      ")"
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "value": [
+                                                                  "."
+                                                                ]
+                                                              },
+                                                              {
+                                                                "r": "905",
+                                                                "s": [
+                                                                  {
+                                                                    "value": [
+                                                                      "low"
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "value": [
+                                                              ")"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  ",\n\t\t  "
+                                                ]
+                                              },
+                                              {
+                                                "r": "907",
+                                                "s": [
+                                                  {
+                                                    "r": "908",
+                                                    "s": [
+                                                      {
+                                                        "r": "912",
+                                                        "s": [
+                                                          {
+                                                            "r": "909",
+                                                            "s": [
+                                                              {
+                                                                "value": [
+                                                                  "FHIRHelpers"
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "value": [
+                                                              "."
+                                                            ]
+                                                          },
+                                                          {
+                                                            "r": "912",
+                                                            "s": [
+                                                              {
+                                                                "value": [
+                                                                  "ToDate",
+                                                                  "("
+                                                                ]
+                                                              },
+                                                              {
+                                                                "r": "911",
+                                                                "s": [
+                                                                  {
+                                                                    "r": "910",
+                                                                    "s": [
+                                                                      {
+                                                                        "value": [
+                                                                          "Patient"
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "value": [
+                                                                      "."
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "r": "911",
+                                                                    "s": [
+                                                                      {
+                                                                        "value": [
+                                                                          "birthDate"
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "value": [
+                                                                  ")"
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "value": [
+                                                          " + "
+                                                        ]
+                                                      },
+                                                      {
+                                                        "r": "919",
+                                                        "s": [
+                                                          {
+                                                            "r": "913",
+                                                            "s": [
+                                                              {
+                                                                "value": [
+                                                                  "FHIRHelpers"
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "value": [
+                                                              "."
+                                                            ]
+                                                          },
+                                                          {
+                                                            "r": "919",
+                                                            "s": [
+                                                              {
+                                                                "value": [
+                                                                  "ToQuantity",
+                                                                  "("
+                                                                ]
+                                                              },
+                                                              {
+                                                                "r": "918",
+                                                                "s": [
+                                                                  {
+                                                                    "r": "914",
+                                                                    "s": [
+                                                                      {
+                                                                        "value": [
+                                                                          "("
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "r": "914",
+                                                                        "s": [
+                                                                          {
+                                                                            "r": "916",
+                                                                            "s": [
+                                                                              {
+                                                                                "r": "915",
+                                                                                "s": [
+                                                                                  {
+                                                                                    "value": [
+                                                                                      "condition"
+                                                                                    ]
+                                                                                  }
+                                                                                ]
+                                                                              },
+                                                                              {
+                                                                                "value": [
+                                                                                  "."
+                                                                                ]
+                                                                              },
+                                                                              {
+                                                                                "r": "916",
+                                                                                "s": [
+                                                                                  {
+                                                                                    "value": [
+                                                                                      "abatement"
+                                                                                    ]
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          },
+                                                                          {
+                                                                            "value": [
+                                                                              " as "
+                                                                            ]
+                                                                          },
+                                                                          {
+                                                                            "r": "917",
+                                                                            "s": [
+                                                                              {
+                                                                                "value": [
+                                                                                  "FHIR",
+                                                                                  ".",
+                                                                                  "Range"
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "value": [
+                                                                          ")"
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "value": [
+                                                                      "."
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "r": "918",
+                                                                    "s": [
+                                                                      {
+                                                                        "value": [
+                                                                          "high"
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "value": [
+                                                                  ")"
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "value": [
+                                                      " + "
+                                                    ]
+                                                  },
+                                                  {
+                                                    "r": "920",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "1 ",
+                                                          "year"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  ")"
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              "\n\telse "
+                                            ]
+                                          },
+                                          {
+                                            "r": "922",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "if "
+                                                ]
+                                              },
+                                              {
+                                                "r": "923",
+                                                "s": [
+                                                  {
+                                                    "r": "925",
+                                                    "s": [
+                                                      {
+                                                        "r": "924",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "condition"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "value": [
+                                                          "."
+                                                        ]
+                                                      },
+                                                      {
+                                                        "r": "925",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "abatement"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "value": [
+                                                      " is "
+                                                    ]
+                                                  },
+                                                  {
+                                                    "r": "926",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "FHIR",
+                                                          ".",
+                                                          "boolean"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  " then\n\t  "
+                                                ]
+                                              },
+                                              {
+                                                "r": "933",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "Interval["
+                                                    ]
+                                                  },
+                                                  {
+                                                    "r": "927",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "end of "
+                                                        ]
+                                                      },
+                                                      {
+                                                        "r": "930",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "\"Normalize Interval\"",
+                                                              "("
+                                                            ]
+                                                          },
+                                                          {
+                                                            "r": "929",
+                                                            "s": [
+                                                              {
+                                                                "r": "928",
+                                                                "s": [
+                                                                  {
+                                                                    "value": [
+                                                                      "condition"
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "value": [
+                                                                  "."
+                                                                ]
+                                                              },
+                                                              {
+                                                                "r": "929",
+                                                                "s": [
+                                                                  {
+                                                                    "value": [
+                                                                      "onset"
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "value": [
+                                                              ")"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "value": [
+                                                      ", "
+                                                    ]
+                                                  },
+                                                  {
+                                                    "r": "932",
+                                                    "s": [
+                                                      {
+                                                        "r": "931",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "condition"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "value": [
+                                                          "."
+                                                        ]
+                                                      },
+                                                      {
+                                                        "r": "932",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "recordedDate"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "value": [
+                                                      ")"
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "r": "935",
+                                                "value": [
+                                                  "\n\telse ",
+                                                  "null"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "815",
+            "locator": "194:2-208:10",
+            "type": "If",
+            "condition": {
+              "localId": "816",
+              "locator": "194:5-194:40",
+              "type": "Is",
+              "signature": [],
+              "operand": {
+                "localId": "818",
+                "locator": "194:5-194:23",
+                "path": "abatement",
+                "type": "Property",
+                "source": {
+                  "localId": "817",
+                  "locator": "194:5-194:13",
+                  "name": "condition",
+                  "type": "OperandRef"
+                }
+              },
+              "isTypeSpecifier": {
+                "localId": "819",
+                "locator": "194:28-194:40",
+                "name": "{http://hl7.org/fhir}dateTime",
+                "type": "NamedTypeSpecifier"
+              }
+            },
+            "then": {
+              "localId": "832",
+              "locator": "195:4-195:135",
+              "lowClosed": true,
+              "highClosed": true,
+              "type": "Interval",
+              "low": {
+                "localId": "825",
+                "locator": "195:13-195:72",
+                "name": "ToDateTime",
+                "libraryName": "FHIRHelpers",
+                "type": "FunctionRef",
+                "signature": [],
+                "operand": [
+                  {
+                    "localId": "821",
+                    "locator": "195:36-195:71",
+                    "strict": false,
+                    "type": "As",
+                    "signature": [],
+                    "operand": {
+                      "localId": "823",
+                      "locator": "195:36-195:54",
+                      "path": "abatement",
+                      "type": "Property",
+                      "source": {
+                        "localId": "822",
+                        "locator": "195:36-195:44",
+                        "name": "condition",
+                        "type": "OperandRef"
+                      }
+                    },
+                    "asTypeSpecifier": {
+                      "localId": "824",
+                      "locator": "195:59-195:71",
+                      "name": "{http://hl7.org/fhir}dateTime",
+                      "type": "NamedTypeSpecifier"
+                    }
+                  }
+                ]
+              },
+              "high": {
+                "localId": "831",
+                "locator": "195:75-195:134",
+                "name": "ToDateTime",
+                "libraryName": "FHIRHelpers",
+                "type": "FunctionRef",
+                "signature": [],
+                "operand": [
+                  {
+                    "localId": "827",
+                    "locator": "195:98-195:133",
+                    "strict": false,
+                    "type": "As",
+                    "signature": [],
+                    "operand": {
+                      "localId": "829",
+                      "locator": "195:98-195:116",
+                      "path": "abatement",
+                      "type": "Property",
+                      "source": {
+                        "localId": "828",
+                        "locator": "195:98-195:106",
+                        "name": "condition",
+                        "type": "OperandRef"
+                      }
+                    },
+                    "asTypeSpecifier": {
+                      "localId": "830",
+                      "locator": "195:121-195:133",
+                      "name": "{http://hl7.org/fhir}dateTime",
+                      "type": "NamedTypeSpecifier"
+                    }
+                  }
+                ]
+              }
+            },
+            "else": {
+              "localId": "833",
+              "locator": "196:7-208:10",
+              "type": "If",
+              "condition": {
+                "localId": "834",
+                "locator": "196:10-196:43",
+                "type": "Is",
+                "signature": [],
+                "operand": {
+                  "localId": "836",
+                  "locator": "196:10-196:28",
+                  "path": "abatement",
+                  "type": "Property",
+                  "source": {
+                    "localId": "835",
+                    "locator": "196:10-196:18",
+                    "name": "condition",
+                    "type": "OperandRef"
+                  }
+                },
+                "isTypeSpecifier": {
+                  "localId": "837",
+                  "locator": "196:33-196:43",
+                  "name": "{http://hl7.org/fhir}Period",
+                  "type": "NamedTypeSpecifier"
+                }
+              },
+              "then": {
+                "localId": "843",
+                "locator": "197:4-197:61",
+                "name": "ToInterval",
+                "libraryName": "FHIRHelpers",
+                "type": "FunctionRef",
+                "signature": [],
+                "operand": [
+                  {
+                    "localId": "839",
+                    "locator": "197:27-197:60",
+                    "strict": false,
+                    "type": "As",
+                    "signature": [],
+                    "operand": {
+                      "localId": "841",
+                      "locator": "197:27-197:45",
+                      "path": "abatement",
+                      "type": "Property",
+                      "source": {
+                        "localId": "840",
+                        "locator": "197:27-197:35",
+                        "name": "condition",
+                        "type": "OperandRef"
+                      }
+                    },
+                    "asTypeSpecifier": {
+                      "localId": "842",
+                      "locator": "197:50-197:60",
+                      "name": "{http://hl7.org/fhir}Period",
+                      "type": "NamedTypeSpecifier"
+                    }
+                  }
+                ]
+              },
+              "else": {
+                "localId": "844",
+                "locator": "198:7-208:10",
+                "type": "If",
+                "condition": {
+                  "localId": "845",
+                  "locator": "198:10-198:43",
+                  "type": "Is",
+                  "signature": [],
+                  "operand": {
+                    "localId": "847",
+                    "locator": "198:10-198:28",
+                    "path": "abatement",
+                    "type": "Property",
+                    "source": {
+                      "localId": "846",
+                      "locator": "198:10-198:18",
+                      "name": "condition",
+                      "type": "OperandRef"
+                    }
+                  },
+                  "isTypeSpecifier": {
+                    "localId": "848",
+                    "locator": "198:33-198:43",
+                    "name": "{http://hl7.org/fhir}string",
+                    "type": "NamedTypeSpecifier"
+                  }
+                },
+                "then": {
+                  "localId": "859",
+                  "locator": "199:5-199:109",
+                  "type": "Message",
+                  "signature": [],
+                  "source": {
+                    "localId": "849",
+                    "locator": "199:13-199:38",
+                    "strict": false,
+                    "type": "As",
+                    "signature": [],
+                    "operand": {
+                      "localId": "850",
+                      "locator": "199:13-199:16",
+                      "type": "Null"
+                    },
+                    "asTypeSpecifier": {
+                      "localId": "851",
+                      "locator": "199:21-199:38",
+                      "type": "IntervalTypeSpecifier",
+                      "pointType": {
+                        "localId": "852",
+                        "locator": "199:30-199:37",
+                        "name": "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type": "NamedTypeSpecifier"
+                      }
+                    }
+                  },
+                  "condition": {
+                    "localId": "853",
+                    "locator": "199:41-199:44",
+                    "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+                    "value": "true",
+                    "type": "Literal"
+                  },
+                  "code": {
+                    "localId": "854",
+                    "locator": "199:47-199:49",
+                    "valueType": "{urn:hl7-org:elm-types:r1}String",
+                    "value": "1",
+                    "type": "Literal"
+                  },
+                  "severity": {
+                    "localId": "855",
+                    "locator": "199:52-199:58",
+                    "valueType": "{urn:hl7-org:elm-types:r1}String",
+                    "value": "Error",
+                    "type": "Literal"
+                  },
+                  "message": {
+                    "localId": "856",
+                    "locator": "199:61-199:108",
+                    "valueType": "{urn:hl7-org:elm-types:r1}String",
+                    "value": "Cannot compute an interval from a String value",
+                    "type": "Literal"
+                  }
+                },
+                "else": {
+                  "localId": "860",
+                  "locator": "200:7-208:10",
+                  "type": "If",
+                  "condition": {
+                    "localId": "861",
+                    "locator": "200:10-200:40",
+                    "type": "Is",
+                    "signature": [],
+                    "operand": {
+                      "localId": "863",
+                      "locator": "200:10-200:28",
+                      "path": "abatement",
+                      "type": "Property",
+                      "source": {
+                        "localId": "862",
+                        "locator": "200:10-200:18",
+                        "name": "condition",
+                        "type": "OperandRef"
+                      }
+                    },
+                    "isTypeSpecifier": {
+                      "localId": "864",
+                      "locator": "200:33-200:40",
+                      "name": "{http://hl7.org/fhir}Age",
+                      "type": "NamedTypeSpecifier"
+                    }
+                  },
+                  "then": {
+                    "localId": "948",
+                    "type": "Interval",
+                    "low": {
+                      "localId": "951",
+                      "type": "ToDateTime",
+                      "signature": [],
+                      "operand": {
+                        "localId": "949",
+                        "path": "low",
+                        "type": "Property",
+                        "source": {
+                          "localId": "889",
+                          "locator": "201:3-202:108",
+                          "lowClosed": true,
+                          "highClosed": false,
+                          "type": "Interval",
+                          "low": {
+                            "localId": "865",
+                            "locator": "201:12-201:106",
+                            "type": "Add",
+                            "signature": [],
+                            "operand": [
+                              {
+                                "localId": "869",
+                                "locator": "201:12-201:48",
+                                "name": "ToDate",
+                                "libraryName": "FHIRHelpers",
+                                "type": "FunctionRef",
+                                "signature": [],
+                                "operand": [
+                                  {
+                                    "localId": "868",
+                                    "locator": "201:31-201:47",
+                                    "path": "birthDate",
+                                    "type": "Property",
+                                    "source": {
+                                      "localId": "867",
+                                      "locator": "201:31-201:37",
+                                      "name": "Patient",
+                                      "type": "ExpressionRef"
+                                    }
+                                  }
+                                ]
+                              },
+                              {
+                                "localId": "875",
+                                "locator": "201:52-201:106",
+                                "name": "ToQuantity",
+                                "libraryName": "FHIRHelpers",
+                                "type": "FunctionRef",
+                                "signature": [],
+                                "operand": [
+                                  {
+                                    "localId": "871",
+                                    "locator": "201:75-201:105",
+                                    "strict": false,
+                                    "type": "As",
+                                    "signature": [],
+                                    "operand": {
+                                      "localId": "873",
+                                      "locator": "201:75-201:93",
+                                      "path": "abatement",
+                                      "type": "Property",
+                                      "source": {
+                                        "localId": "872",
+                                        "locator": "201:75-201:83",
+                                        "name": "condition",
+                                        "type": "OperandRef"
+                                      }
+                                    },
+                                    "asTypeSpecifier": {
+                                      "localId": "874",
+                                      "locator": "201:98-201:105",
+                                      "name": "{http://hl7.org/fhir}Age",
+                                      "type": "NamedTypeSpecifier"
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          "high": {
+                            "localId": "876",
+                            "locator": "202:4-202:107",
+                            "type": "Add",
+                            "signature": [],
+                            "operand": [
+                              {
+                                "localId": "877",
+                                "locator": "202:4-202:98",
+                                "type": "Add",
+                                "signature": [],
+                                "operand": [
+                                  {
+                                    "localId": "881",
+                                    "locator": "202:4-202:40",
+                                    "name": "ToDate",
+                                    "libraryName": "FHIRHelpers",
+                                    "type": "FunctionRef",
+                                    "signature": [],
+                                    "operand": [
+                                      {
+                                        "localId": "880",
+                                        "locator": "202:23-202:39",
+                                        "path": "birthDate",
+                                        "type": "Property",
+                                        "source": {
+                                          "localId": "879",
+                                          "locator": "202:23-202:29",
+                                          "name": "Patient",
+                                          "type": "ExpressionRef"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "localId": "887",
+                                    "locator": "202:44-202:98",
+                                    "name": "ToQuantity",
+                                    "libraryName": "FHIRHelpers",
+                                    "type": "FunctionRef",
+                                    "signature": [],
+                                    "operand": [
+                                      {
+                                        "localId": "883",
+                                        "locator": "202:67-202:97",
+                                        "strict": false,
+                                        "type": "As",
+                                        "signature": [],
+                                        "operand": {
+                                          "localId": "885",
+                                          "locator": "202:67-202:85",
+                                          "path": "abatement",
+                                          "type": "Property",
+                                          "source": {
+                                            "localId": "884",
+                                            "locator": "202:67-202:75",
+                                            "name": "condition",
+                                            "type": "OperandRef"
+                                          }
+                                        },
+                                        "asTypeSpecifier": {
+                                          "localId": "886",
+                                          "locator": "202:90-202:97",
+                                          "name": "{http://hl7.org/fhir}Age",
+                                          "type": "NamedTypeSpecifier"
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "localId": "888",
+                                "locator": "202:102-202:107",
+                                "value": 1,
+                                "unit": "year",
+                                "type": "Quantity"
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "lowClosedExpression": {
+                      "localId": "952",
+                      "path": "lowClosed",
+                      "type": "Property",
+                      "source": {
+                        "localId": "889",
+                        "locator": "201:3-202:108",
+                        "lowClosed": true,
+                        "highClosed": false,
+                        "type": "Interval",
+                        "low": {
+                          "localId": "865",
+                          "locator": "201:12-201:106",
+                          "type": "Add",
+                          "signature": [],
+                          "operand": [
+                            {
+                              "localId": "869",
+                              "locator": "201:12-201:48",
+                              "name": "ToDate",
+                              "libraryName": "FHIRHelpers",
+                              "type": "FunctionRef",
+                              "signature": [],
+                              "operand": [
+                                {
+                                  "localId": "868",
+                                  "locator": "201:31-201:47",
+                                  "path": "birthDate",
+                                  "type": "Property",
+                                  "source": {
+                                    "localId": "867",
+                                    "locator": "201:31-201:37",
+                                    "name": "Patient",
+                                    "type": "ExpressionRef"
+                                  }
+                                }
+                              ]
+                            },
+                            {
+                              "localId": "875",
+                              "locator": "201:52-201:106",
+                              "name": "ToQuantity",
+                              "libraryName": "FHIRHelpers",
+                              "type": "FunctionRef",
+                              "signature": [],
+                              "operand": [
+                                {
+                                  "localId": "871",
+                                  "locator": "201:75-201:105",
+                                  "strict": false,
+                                  "type": "As",
+                                  "signature": [],
+                                  "operand": {
+                                    "localId": "873",
+                                    "locator": "201:75-201:93",
+                                    "path": "abatement",
+                                    "type": "Property",
+                                    "source": {
+                                      "localId": "872",
+                                      "locator": "201:75-201:83",
+                                      "name": "condition",
+                                      "type": "OperandRef"
+                                    }
+                                  },
+                                  "asTypeSpecifier": {
+                                    "localId": "874",
+                                    "locator": "201:98-201:105",
+                                    "name": "{http://hl7.org/fhir}Age",
+                                    "type": "NamedTypeSpecifier"
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "high": {
+                          "localId": "876",
+                          "locator": "202:4-202:107",
+                          "type": "Add",
+                          "signature": [],
+                          "operand": [
+                            {
+                              "localId": "877",
+                              "locator": "202:4-202:98",
+                              "type": "Add",
+                              "signature": [],
+                              "operand": [
+                                {
+                                  "localId": "881",
+                                  "locator": "202:4-202:40",
+                                  "name": "ToDate",
+                                  "libraryName": "FHIRHelpers",
+                                  "type": "FunctionRef",
+                                  "signature": [],
+                                  "operand": [
+                                    {
+                                      "localId": "880",
+                                      "locator": "202:23-202:39",
+                                      "path": "birthDate",
+                                      "type": "Property",
+                                      "source": {
+                                        "localId": "879",
+                                        "locator": "202:23-202:29",
+                                        "name": "Patient",
+                                        "type": "ExpressionRef"
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "localId": "887",
+                                  "locator": "202:44-202:98",
+                                  "name": "ToQuantity",
+                                  "libraryName": "FHIRHelpers",
+                                  "type": "FunctionRef",
+                                  "signature": [],
+                                  "operand": [
+                                    {
+                                      "localId": "883",
+                                      "locator": "202:67-202:97",
+                                      "strict": false,
+                                      "type": "As",
+                                      "signature": [],
+                                      "operand": {
+                                        "localId": "885",
+                                        "locator": "202:67-202:85",
+                                        "path": "abatement",
+                                        "type": "Property",
+                                        "source": {
+                                          "localId": "884",
+                                          "locator": "202:67-202:75",
+                                          "name": "condition",
+                                          "type": "OperandRef"
+                                        }
+                                      },
+                                      "asTypeSpecifier": {
+                                        "localId": "886",
+                                        "locator": "202:90-202:97",
+                                        "name": "{http://hl7.org/fhir}Age",
+                                        "type": "NamedTypeSpecifier"
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "localId": "888",
+                              "locator": "202:102-202:107",
+                              "value": 1,
+                              "unit": "year",
+                              "type": "Quantity"
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    "high": {
+                      "localId": "955",
+                      "type": "ToDateTime",
+                      "signature": [],
+                      "operand": {
+                        "localId": "953",
+                        "path": "high",
+                        "type": "Property",
+                        "source": {
+                          "localId": "889",
+                          "locator": "201:3-202:108",
+                          "lowClosed": true,
+                          "highClosed": false,
+                          "type": "Interval",
+                          "low": {
+                            "localId": "865",
+                            "locator": "201:12-201:106",
+                            "type": "Add",
+                            "signature": [],
+                            "operand": [
+                              {
+                                "localId": "869",
+                                "locator": "201:12-201:48",
+                                "name": "ToDate",
+                                "libraryName": "FHIRHelpers",
+                                "type": "FunctionRef",
+                                "signature": [],
+                                "operand": [
+                                  {
+                                    "localId": "868",
+                                    "locator": "201:31-201:47",
+                                    "path": "birthDate",
+                                    "type": "Property",
+                                    "source": {
+                                      "localId": "867",
+                                      "locator": "201:31-201:37",
+                                      "name": "Patient",
+                                      "type": "ExpressionRef"
+                                    }
+                                  }
+                                ]
+                              },
+                              {
+                                "localId": "875",
+                                "locator": "201:52-201:106",
+                                "name": "ToQuantity",
+                                "libraryName": "FHIRHelpers",
+                                "type": "FunctionRef",
+                                "signature": [],
+                                "operand": [
+                                  {
+                                    "localId": "871",
+                                    "locator": "201:75-201:105",
+                                    "strict": false,
+                                    "type": "As",
+                                    "signature": [],
+                                    "operand": {
+                                      "localId": "873",
+                                      "locator": "201:75-201:93",
+                                      "path": "abatement",
+                                      "type": "Property",
+                                      "source": {
+                                        "localId": "872",
+                                        "locator": "201:75-201:83",
+                                        "name": "condition",
+                                        "type": "OperandRef"
+                                      }
+                                    },
+                                    "asTypeSpecifier": {
+                                      "localId": "874",
+                                      "locator": "201:98-201:105",
+                                      "name": "{http://hl7.org/fhir}Age",
+                                      "type": "NamedTypeSpecifier"
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          "high": {
+                            "localId": "876",
+                            "locator": "202:4-202:107",
+                            "type": "Add",
+                            "signature": [],
+                            "operand": [
+                              {
+                                "localId": "877",
+                                "locator": "202:4-202:98",
+                                "type": "Add",
+                                "signature": [],
+                                "operand": [
+                                  {
+                                    "localId": "881",
+                                    "locator": "202:4-202:40",
+                                    "name": "ToDate",
+                                    "libraryName": "FHIRHelpers",
+                                    "type": "FunctionRef",
+                                    "signature": [],
+                                    "operand": [
+                                      {
+                                        "localId": "880",
+                                        "locator": "202:23-202:39",
+                                        "path": "birthDate",
+                                        "type": "Property",
+                                        "source": {
+                                          "localId": "879",
+                                          "locator": "202:23-202:29",
+                                          "name": "Patient",
+                                          "type": "ExpressionRef"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "localId": "887",
+                                    "locator": "202:44-202:98",
+                                    "name": "ToQuantity",
+                                    "libraryName": "FHIRHelpers",
+                                    "type": "FunctionRef",
+                                    "signature": [],
+                                    "operand": [
+                                      {
+                                        "localId": "883",
+                                        "locator": "202:67-202:97",
+                                        "strict": false,
+                                        "type": "As",
+                                        "signature": [],
+                                        "operand": {
+                                          "localId": "885",
+                                          "locator": "202:67-202:85",
+                                          "path": "abatement",
+                                          "type": "Property",
+                                          "source": {
+                                            "localId": "884",
+                                            "locator": "202:67-202:75",
+                                            "name": "condition",
+                                            "type": "OperandRef"
+                                          }
+                                        },
+                                        "asTypeSpecifier": {
+                                          "localId": "886",
+                                          "locator": "202:90-202:97",
+                                          "name": "{http://hl7.org/fhir}Age",
+                                          "type": "NamedTypeSpecifier"
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "localId": "888",
+                                "locator": "202:102-202:107",
+                                "value": 1,
+                                "unit": "year",
+                                "type": "Quantity"
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "highClosedExpression": {
+                      "localId": "956",
+                      "path": "highClosed",
+                      "type": "Property",
+                      "source": {
+                        "localId": "889",
+                        "locator": "201:3-202:108",
+                        "lowClosed": true,
+                        "highClosed": false,
+                        "type": "Interval",
+                        "low": {
+                          "localId": "865",
+                          "locator": "201:12-201:106",
+                          "type": "Add",
+                          "signature": [],
+                          "operand": [
+                            {
+                              "localId": "869",
+                              "locator": "201:12-201:48",
+                              "name": "ToDate",
+                              "libraryName": "FHIRHelpers",
+                              "type": "FunctionRef",
+                              "signature": [],
+                              "operand": [
+                                {
+                                  "localId": "868",
+                                  "locator": "201:31-201:47",
+                                  "path": "birthDate",
+                                  "type": "Property",
+                                  "source": {
+                                    "localId": "867",
+                                    "locator": "201:31-201:37",
+                                    "name": "Patient",
+                                    "type": "ExpressionRef"
+                                  }
+                                }
+                              ]
+                            },
+                            {
+                              "localId": "875",
+                              "locator": "201:52-201:106",
+                              "name": "ToQuantity",
+                              "libraryName": "FHIRHelpers",
+                              "type": "FunctionRef",
+                              "signature": [],
+                              "operand": [
+                                {
+                                  "localId": "871",
+                                  "locator": "201:75-201:105",
+                                  "strict": false,
+                                  "type": "As",
+                                  "signature": [],
+                                  "operand": {
+                                    "localId": "873",
+                                    "locator": "201:75-201:93",
+                                    "path": "abatement",
+                                    "type": "Property",
+                                    "source": {
+                                      "localId": "872",
+                                      "locator": "201:75-201:83",
+                                      "name": "condition",
+                                      "type": "OperandRef"
+                                    }
+                                  },
+                                  "asTypeSpecifier": {
+                                    "localId": "874",
+                                    "locator": "201:98-201:105",
+                                    "name": "{http://hl7.org/fhir}Age",
+                                    "type": "NamedTypeSpecifier"
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "high": {
+                          "localId": "876",
+                          "locator": "202:4-202:107",
+                          "type": "Add",
+                          "signature": [],
+                          "operand": [
+                            {
+                              "localId": "877",
+                              "locator": "202:4-202:98",
+                              "type": "Add",
+                              "signature": [],
+                              "operand": [
+                                {
+                                  "localId": "881",
+                                  "locator": "202:4-202:40",
+                                  "name": "ToDate",
+                                  "libraryName": "FHIRHelpers",
+                                  "type": "FunctionRef",
+                                  "signature": [],
+                                  "operand": [
+                                    {
+                                      "localId": "880",
+                                      "locator": "202:23-202:39",
+                                      "path": "birthDate",
+                                      "type": "Property",
+                                      "source": {
+                                        "localId": "879",
+                                        "locator": "202:23-202:29",
+                                        "name": "Patient",
+                                        "type": "ExpressionRef"
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "localId": "887",
+                                  "locator": "202:44-202:98",
+                                  "name": "ToQuantity",
+                                  "libraryName": "FHIRHelpers",
+                                  "type": "FunctionRef",
+                                  "signature": [],
+                                  "operand": [
+                                    {
+                                      "localId": "883",
+                                      "locator": "202:67-202:97",
+                                      "strict": false,
+                                      "type": "As",
+                                      "signature": [],
+                                      "operand": {
+                                        "localId": "885",
+                                        "locator": "202:67-202:85",
+                                        "path": "abatement",
+                                        "type": "Property",
+                                        "source": {
+                                          "localId": "884",
+                                          "locator": "202:67-202:75",
+                                          "name": "condition",
+                                          "type": "OperandRef"
+                                        }
+                                      },
+                                      "asTypeSpecifier": {
+                                        "localId": "886",
+                                        "locator": "202:90-202:97",
+                                        "name": "{http://hl7.org/fhir}Age",
+                                        "type": "NamedTypeSpecifier"
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "localId": "888",
+                              "locator": "202:102-202:107",
+                              "value": 1,
+                              "unit": "year",
+                              "type": "Quantity"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "else": {
+                    "localId": "890",
+                    "locator": "203:7-208:10",
+                    "type": "If",
+                    "condition": {
+                      "localId": "891",
+                      "locator": "203:10-203:42",
+                      "type": "Is",
+                      "signature": [],
+                      "operand": {
+                        "localId": "893",
+                        "locator": "203:10-203:28",
+                        "path": "abatement",
+                        "type": "Property",
+                        "source": {
+                          "localId": "892",
+                          "locator": "203:10-203:18",
+                          "name": "condition",
+                          "type": "OperandRef"
+                        }
+                      },
+                      "isTypeSpecifier": {
+                        "localId": "894",
+                        "locator": "203:33-203:42",
+                        "name": "{http://hl7.org/fhir}Range",
+                        "type": "NamedTypeSpecifier"
+                      }
+                    },
+                    "then": {
+                      "localId": "939",
+                      "type": "Interval",
+                      "low": {
+                        "localId": "942",
+                        "type": "ToDateTime",
+                        "signature": [],
+                        "operand": {
+                          "localId": "940",
+                          "path": "low",
+                          "type": "Property",
+                          "source": {
+                            "localId": "921",
+                            "locator": "204:4-205:118",
+                            "lowClosed": true,
+                            "highClosed": false,
+                            "type": "Interval",
+                            "low": {
+                              "localId": "895",
+                              "locator": "204:13-204:115",
+                              "type": "Add",
+                              "signature": [],
+                              "operand": [
+                                {
+                                  "localId": "899",
+                                  "locator": "204:13-204:49",
+                                  "name": "ToDate",
+                                  "libraryName": "FHIRHelpers",
+                                  "type": "FunctionRef",
+                                  "signature": [],
+                                  "operand": [
+                                    {
+                                      "localId": "898",
+                                      "locator": "204:32-204:48",
+                                      "path": "birthDate",
+                                      "type": "Property",
+                                      "source": {
+                                        "localId": "897",
+                                        "locator": "204:32-204:38",
+                                        "name": "Patient",
+                                        "type": "ExpressionRef"
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "localId": "906",
+                                  "locator": "204:53-204:115",
+                                  "name": "ToQuantity",
+                                  "libraryName": "FHIRHelpers",
+                                  "type": "FunctionRef",
+                                  "signature": [],
+                                  "operand": [
+                                    {
+                                      "localId": "905",
+                                      "locator": "204:76-204:114",
+                                      "path": "low",
+                                      "type": "Property",
+                                      "source": {
+                                        "localId": "901",
+                                        "locator": "204:76-204:110",
+                                        "strict": false,
+                                        "type": "As",
+                                        "signature": [],
+                                        "operand": {
+                                          "localId": "903",
+                                          "locator": "204:77-204:95",
+                                          "path": "abatement",
+                                          "type": "Property",
+                                          "source": {
+                                            "localId": "902",
+                                            "locator": "204:77-204:85",
+                                            "name": "condition",
+                                            "type": "OperandRef"
+                                          }
+                                        },
+                                        "asTypeSpecifier": {
+                                          "localId": "904",
+                                          "locator": "204:100-204:109",
+                                          "name": "{http://hl7.org/fhir}Range",
+                                          "type": "NamedTypeSpecifier"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            "high": {
+                              "localId": "907",
+                              "locator": "205:5-205:117",
+                              "type": "Add",
+                              "signature": [],
+                              "operand": [
+                                {
+                                  "localId": "908",
+                                  "locator": "205:5-205:108",
+                                  "type": "Add",
+                                  "signature": [],
+                                  "operand": [
+                                    {
+                                      "localId": "912",
+                                      "locator": "205:5-205:41",
+                                      "name": "ToDate",
+                                      "libraryName": "FHIRHelpers",
+                                      "type": "FunctionRef",
+                                      "signature": [],
+                                      "operand": [
+                                        {
+                                          "localId": "911",
+                                          "locator": "205:24-205:40",
+                                          "path": "birthDate",
+                                          "type": "Property",
+                                          "source": {
+                                            "localId": "910",
+                                            "locator": "205:24-205:30",
+                                            "name": "Patient",
+                                            "type": "ExpressionRef"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "localId": "919",
+                                      "locator": "205:45-205:108",
+                                      "name": "ToQuantity",
+                                      "libraryName": "FHIRHelpers",
+                                      "type": "FunctionRef",
+                                      "signature": [],
+                                      "operand": [
+                                        {
+                                          "localId": "918",
+                                          "locator": "205:68-205:107",
+                                          "path": "high",
+                                          "type": "Property",
+                                          "source": {
+                                            "localId": "914",
+                                            "locator": "205:68-205:102",
+                                            "strict": false,
+                                            "type": "As",
+                                            "signature": [],
+                                            "operand": {
+                                              "localId": "916",
+                                              "locator": "205:69-205:87",
+                                              "path": "abatement",
+                                              "type": "Property",
+                                              "source": {
+                                                "localId": "915",
+                                                "locator": "205:69-205:77",
+                                                "name": "condition",
+                                                "type": "OperandRef"
+                                              }
+                                            },
+                                            "asTypeSpecifier": {
+                                              "localId": "917",
+                                              "locator": "205:92-205:101",
+                                              "name": "{http://hl7.org/fhir}Range",
+                                              "type": "NamedTypeSpecifier"
+                                            }
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "localId": "920",
+                                  "locator": "205:112-205:117",
+                                  "value": 1,
+                                  "unit": "year",
+                                  "type": "Quantity"
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      "lowClosedExpression": {
+                        "localId": "943",
+                        "path": "lowClosed",
+                        "type": "Property",
+                        "source": {
+                          "localId": "921",
+                          "locator": "204:4-205:118",
+                          "lowClosed": true,
+                          "highClosed": false,
+                          "type": "Interval",
+                          "low": {
+                            "localId": "895",
+                            "locator": "204:13-204:115",
+                            "type": "Add",
+                            "signature": [],
+                            "operand": [
+                              {
+                                "localId": "899",
+                                "locator": "204:13-204:49",
+                                "name": "ToDate",
+                                "libraryName": "FHIRHelpers",
+                                "type": "FunctionRef",
+                                "signature": [],
+                                "operand": [
+                                  {
+                                    "localId": "898",
+                                    "locator": "204:32-204:48",
+                                    "path": "birthDate",
+                                    "type": "Property",
+                                    "source": {
+                                      "localId": "897",
+                                      "locator": "204:32-204:38",
+                                      "name": "Patient",
+                                      "type": "ExpressionRef"
+                                    }
+                                  }
+                                ]
+                              },
+                              {
+                                "localId": "906",
+                                "locator": "204:53-204:115",
+                                "name": "ToQuantity",
+                                "libraryName": "FHIRHelpers",
+                                "type": "FunctionRef",
+                                "signature": [],
+                                "operand": [
+                                  {
+                                    "localId": "905",
+                                    "locator": "204:76-204:114",
+                                    "path": "low",
+                                    "type": "Property",
+                                    "source": {
+                                      "localId": "901",
+                                      "locator": "204:76-204:110",
+                                      "strict": false,
+                                      "type": "As",
+                                      "signature": [],
+                                      "operand": {
+                                        "localId": "903",
+                                        "locator": "204:77-204:95",
+                                        "path": "abatement",
+                                        "type": "Property",
+                                        "source": {
+                                          "localId": "902",
+                                          "locator": "204:77-204:85",
+                                          "name": "condition",
+                                          "type": "OperandRef"
+                                        }
+                                      },
+                                      "asTypeSpecifier": {
+                                        "localId": "904",
+                                        "locator": "204:100-204:109",
+                                        "name": "{http://hl7.org/fhir}Range",
+                                        "type": "NamedTypeSpecifier"
+                                      }
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          "high": {
+                            "localId": "907",
+                            "locator": "205:5-205:117",
+                            "type": "Add",
+                            "signature": [],
+                            "operand": [
+                              {
+                                "localId": "908",
+                                "locator": "205:5-205:108",
+                                "type": "Add",
+                                "signature": [],
+                                "operand": [
+                                  {
+                                    "localId": "912",
+                                    "locator": "205:5-205:41",
+                                    "name": "ToDate",
+                                    "libraryName": "FHIRHelpers",
+                                    "type": "FunctionRef",
+                                    "signature": [],
+                                    "operand": [
+                                      {
+                                        "localId": "911",
+                                        "locator": "205:24-205:40",
+                                        "path": "birthDate",
+                                        "type": "Property",
+                                        "source": {
+                                          "localId": "910",
+                                          "locator": "205:24-205:30",
+                                          "name": "Patient",
+                                          "type": "ExpressionRef"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "localId": "919",
+                                    "locator": "205:45-205:108",
+                                    "name": "ToQuantity",
+                                    "libraryName": "FHIRHelpers",
+                                    "type": "FunctionRef",
+                                    "signature": [],
+                                    "operand": [
+                                      {
+                                        "localId": "918",
+                                        "locator": "205:68-205:107",
+                                        "path": "high",
+                                        "type": "Property",
+                                        "source": {
+                                          "localId": "914",
+                                          "locator": "205:68-205:102",
+                                          "strict": false,
+                                          "type": "As",
+                                          "signature": [],
+                                          "operand": {
+                                            "localId": "916",
+                                            "locator": "205:69-205:87",
+                                            "path": "abatement",
+                                            "type": "Property",
+                                            "source": {
+                                              "localId": "915",
+                                              "locator": "205:69-205:77",
+                                              "name": "condition",
+                                              "type": "OperandRef"
+                                            }
+                                          },
+                                          "asTypeSpecifier": {
+                                            "localId": "917",
+                                            "locator": "205:92-205:101",
+                                            "name": "{http://hl7.org/fhir}Range",
+                                            "type": "NamedTypeSpecifier"
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "localId": "920",
+                                "locator": "205:112-205:117",
+                                "value": 1,
+                                "unit": "year",
+                                "type": "Quantity"
+                              }
+                            ]
+                          }
+                        }
+                      },
+                      "high": {
+                        "localId": "946",
+                        "type": "ToDateTime",
+                        "signature": [],
+                        "operand": {
+                          "localId": "944",
+                          "path": "high",
+                          "type": "Property",
+                          "source": {
+                            "localId": "921",
+                            "locator": "204:4-205:118",
+                            "lowClosed": true,
+                            "highClosed": false,
+                            "type": "Interval",
+                            "low": {
+                              "localId": "895",
+                              "locator": "204:13-204:115",
+                              "type": "Add",
+                              "signature": [],
+                              "operand": [
+                                {
+                                  "localId": "899",
+                                  "locator": "204:13-204:49",
+                                  "name": "ToDate",
+                                  "libraryName": "FHIRHelpers",
+                                  "type": "FunctionRef",
+                                  "signature": [],
+                                  "operand": [
+                                    {
+                                      "localId": "898",
+                                      "locator": "204:32-204:48",
+                                      "path": "birthDate",
+                                      "type": "Property",
+                                      "source": {
+                                        "localId": "897",
+                                        "locator": "204:32-204:38",
+                                        "name": "Patient",
+                                        "type": "ExpressionRef"
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "localId": "906",
+                                  "locator": "204:53-204:115",
+                                  "name": "ToQuantity",
+                                  "libraryName": "FHIRHelpers",
+                                  "type": "FunctionRef",
+                                  "signature": [],
+                                  "operand": [
+                                    {
+                                      "localId": "905",
+                                      "locator": "204:76-204:114",
+                                      "path": "low",
+                                      "type": "Property",
+                                      "source": {
+                                        "localId": "901",
+                                        "locator": "204:76-204:110",
+                                        "strict": false,
+                                        "type": "As",
+                                        "signature": [],
+                                        "operand": {
+                                          "localId": "903",
+                                          "locator": "204:77-204:95",
+                                          "path": "abatement",
+                                          "type": "Property",
+                                          "source": {
+                                            "localId": "902",
+                                            "locator": "204:77-204:85",
+                                            "name": "condition",
+                                            "type": "OperandRef"
+                                          }
+                                        },
+                                        "asTypeSpecifier": {
+                                          "localId": "904",
+                                          "locator": "204:100-204:109",
+                                          "name": "{http://hl7.org/fhir}Range",
+                                          "type": "NamedTypeSpecifier"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            "high": {
+                              "localId": "907",
+                              "locator": "205:5-205:117",
+                              "type": "Add",
+                              "signature": [],
+                              "operand": [
+                                {
+                                  "localId": "908",
+                                  "locator": "205:5-205:108",
+                                  "type": "Add",
+                                  "signature": [],
+                                  "operand": [
+                                    {
+                                      "localId": "912",
+                                      "locator": "205:5-205:41",
+                                      "name": "ToDate",
+                                      "libraryName": "FHIRHelpers",
+                                      "type": "FunctionRef",
+                                      "signature": [],
+                                      "operand": [
+                                        {
+                                          "localId": "911",
+                                          "locator": "205:24-205:40",
+                                          "path": "birthDate",
+                                          "type": "Property",
+                                          "source": {
+                                            "localId": "910",
+                                            "locator": "205:24-205:30",
+                                            "name": "Patient",
+                                            "type": "ExpressionRef"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "localId": "919",
+                                      "locator": "205:45-205:108",
+                                      "name": "ToQuantity",
+                                      "libraryName": "FHIRHelpers",
+                                      "type": "FunctionRef",
+                                      "signature": [],
+                                      "operand": [
+                                        {
+                                          "localId": "918",
+                                          "locator": "205:68-205:107",
+                                          "path": "high",
+                                          "type": "Property",
+                                          "source": {
+                                            "localId": "914",
+                                            "locator": "205:68-205:102",
+                                            "strict": false,
+                                            "type": "As",
+                                            "signature": [],
+                                            "operand": {
+                                              "localId": "916",
+                                              "locator": "205:69-205:87",
+                                              "path": "abatement",
+                                              "type": "Property",
+                                              "source": {
+                                                "localId": "915",
+                                                "locator": "205:69-205:77",
+                                                "name": "condition",
+                                                "type": "OperandRef"
+                                              }
+                                            },
+                                            "asTypeSpecifier": {
+                                              "localId": "917",
+                                              "locator": "205:92-205:101",
+                                              "name": "{http://hl7.org/fhir}Range",
+                                              "type": "NamedTypeSpecifier"
+                                            }
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "localId": "920",
+                                  "locator": "205:112-205:117",
+                                  "value": 1,
+                                  "unit": "year",
+                                  "type": "Quantity"
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      "highClosedExpression": {
+                        "localId": "947",
+                        "path": "highClosed",
+                        "type": "Property",
+                        "source": {
+                          "localId": "921",
+                          "locator": "204:4-205:118",
+                          "lowClosed": true,
+                          "highClosed": false,
+                          "type": "Interval",
+                          "low": {
+                            "localId": "895",
+                            "locator": "204:13-204:115",
+                            "type": "Add",
+                            "signature": [],
+                            "operand": [
+                              {
+                                "localId": "899",
+                                "locator": "204:13-204:49",
+                                "name": "ToDate",
+                                "libraryName": "FHIRHelpers",
+                                "type": "FunctionRef",
+                                "signature": [],
+                                "operand": [
+                                  {
+                                    "localId": "898",
+                                    "locator": "204:32-204:48",
+                                    "path": "birthDate",
+                                    "type": "Property",
+                                    "source": {
+                                      "localId": "897",
+                                      "locator": "204:32-204:38",
+                                      "name": "Patient",
+                                      "type": "ExpressionRef"
+                                    }
+                                  }
+                                ]
+                              },
+                              {
+                                "localId": "906",
+                                "locator": "204:53-204:115",
+                                "name": "ToQuantity",
+                                "libraryName": "FHIRHelpers",
+                                "type": "FunctionRef",
+                                "signature": [],
+                                "operand": [
+                                  {
+                                    "localId": "905",
+                                    "locator": "204:76-204:114",
+                                    "path": "low",
+                                    "type": "Property",
+                                    "source": {
+                                      "localId": "901",
+                                      "locator": "204:76-204:110",
+                                      "strict": false,
+                                      "type": "As",
+                                      "signature": [],
+                                      "operand": {
+                                        "localId": "903",
+                                        "locator": "204:77-204:95",
+                                        "path": "abatement",
+                                        "type": "Property",
+                                        "source": {
+                                          "localId": "902",
+                                          "locator": "204:77-204:85",
+                                          "name": "condition",
+                                          "type": "OperandRef"
+                                        }
+                                      },
+                                      "asTypeSpecifier": {
+                                        "localId": "904",
+                                        "locator": "204:100-204:109",
+                                        "name": "{http://hl7.org/fhir}Range",
+                                        "type": "NamedTypeSpecifier"
+                                      }
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          "high": {
+                            "localId": "907",
+                            "locator": "205:5-205:117",
+                            "type": "Add",
+                            "signature": [],
+                            "operand": [
+                              {
+                                "localId": "908",
+                                "locator": "205:5-205:108",
+                                "type": "Add",
+                                "signature": [],
+                                "operand": [
+                                  {
+                                    "localId": "912",
+                                    "locator": "205:5-205:41",
+                                    "name": "ToDate",
+                                    "libraryName": "FHIRHelpers",
+                                    "type": "FunctionRef",
+                                    "signature": [],
+                                    "operand": [
+                                      {
+                                        "localId": "911",
+                                        "locator": "205:24-205:40",
+                                        "path": "birthDate",
+                                        "type": "Property",
+                                        "source": {
+                                          "localId": "910",
+                                          "locator": "205:24-205:30",
+                                          "name": "Patient",
+                                          "type": "ExpressionRef"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "localId": "919",
+                                    "locator": "205:45-205:108",
+                                    "name": "ToQuantity",
+                                    "libraryName": "FHIRHelpers",
+                                    "type": "FunctionRef",
+                                    "signature": [],
+                                    "operand": [
+                                      {
+                                        "localId": "918",
+                                        "locator": "205:68-205:107",
+                                        "path": "high",
+                                        "type": "Property",
+                                        "source": {
+                                          "localId": "914",
+                                          "locator": "205:68-205:102",
+                                          "strict": false,
+                                          "type": "As",
+                                          "signature": [],
+                                          "operand": {
+                                            "localId": "916",
+                                            "locator": "205:69-205:87",
+                                            "path": "abatement",
+                                            "type": "Property",
+                                            "source": {
+                                              "localId": "915",
+                                              "locator": "205:69-205:77",
+                                              "name": "condition",
+                                              "type": "OperandRef"
+                                            }
+                                          },
+                                          "asTypeSpecifier": {
+                                            "localId": "917",
+                                            "locator": "205:92-205:101",
+                                            "name": "{http://hl7.org/fhir}Range",
+                                            "type": "NamedTypeSpecifier"
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "localId": "920",
+                                "locator": "205:112-205:117",
+                                "value": 1,
+                                "unit": "year",
+                                "type": "Quantity"
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "else": {
+                      "localId": "922",
+                      "locator": "206:7-208:10",
+                      "type": "If",
+                      "condition": {
+                        "localId": "923",
+                        "locator": "206:10-206:44",
+                        "type": "Is",
+                        "signature": [],
+                        "operand": {
+                          "localId": "925",
+                          "locator": "206:10-206:28",
+                          "path": "abatement",
+                          "type": "Property",
+                          "source": {
+                            "localId": "924",
+                            "locator": "206:10-206:18",
+                            "name": "condition",
+                            "type": "OperandRef"
+                          }
+                        },
+                        "isTypeSpecifier": {
+                          "localId": "926",
+                          "locator": "206:33-206:44",
+                          "name": "{http://hl7.org/fhir}boolean",
+                          "type": "NamedTypeSpecifier"
+                        }
+                      },
+                      "then": {
+                        "localId": "933",
+                        "locator": "207:4-207:81",
+                        "lowClosed": true,
+                        "highClosed": false,
+                        "type": "Interval",
+                        "low": {
+                          "localId": "927",
+                          "locator": "207:13-207:56",
+                          "type": "End",
+                          "signature": [],
+                          "operand": {
+                            "localId": "930",
+                            "locator": "207:20-207:56",
+                            "name": "Normalize Interval",
+                            "type": "FunctionRef",
+                            "signature": [],
+                            "operand": [
+                              {
+                                "localId": "929",
+                                "locator": "207:41-207:55",
+                                "path": "onset",
+                                "type": "Property",
+                                "source": {
+                                  "localId": "928",
+                                  "locator": "207:41-207:49",
+                                  "name": "condition",
+                                  "type": "OperandRef"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        "high": {
+                          "localId": "934",
+                          "name": "ToDateTime",
+                          "libraryName": "FHIRHelpers",
+                          "type": "FunctionRef",
+                          "signature": [],
+                          "operand": [
+                            {
+                              "localId": "932",
+                              "locator": "207:59-207:80",
+                              "path": "recordedDate",
+                              "type": "Property",
+                              "source": {
+                                "localId": "931",
+                                "locator": "207:59-207:67",
+                                "name": "condition",
+                                "type": "OperandRef"
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      "else": {
+                        "localId": "936",
+                        "type": "As",
+                        "signature": [],
+                        "operand": {
+                          "localId": "935",
+                          "locator": "208:7-208:10",
+                          "type": "Null"
+                        },
+                        "asTypeSpecifier": {
+                          "localId": "937",
+                          "type": "IntervalTypeSpecifier",
+                          "pointType": {
+                            "localId": "938",
+                            "name": "{urn:hl7-org:elm-types:r1}DateTime",
+                            "type": "NamedTypeSpecifier"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "operand": [
+            {
+              "localId": "814",
+              "name": "condition",
+              "operandTypeSpecifier": {
+                "localId": "813",
+                "locator": "193:49-193:57",
+                "name": "{http://hl7.org/fhir}Condition",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "localId": "957",
+          "locator": "210:1-211:99",
+          "name": "Prevalence Period",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "957",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define function \"Prevalence Period\"(condition Condition):\n  "
+                    ]
+                  },
+                  {
+                    "r": "967",
+                    "s": [
+                      {
+                        "r": "967",
+                        "s": [
+                          {
+                            "value": [
+                              "Interval["
+                            ]
+                          },
+                          {
+                            "r": "960",
+                            "s": [
+                              {
+                                "value": [
+                                  "start of "
+                                ]
+                              },
+                              {
+                                "r": "963",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "\"Normalize Interval\"",
+                                      "("
+                                    ]
+                                  },
+                                  {
+                                    "r": "962",
+                                    "s": [
+                                      {
+                                        "r": "961",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "condition"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "."
+                                        ]
+                                      },
+                                      {
+                                        "r": "962",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "onset"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      ")"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              ", "
+                            ]
+                          },
+                          {
+                            "r": "964",
+                            "s": [
+                              {
+                                "value": [
+                                  "end of "
+                                ]
+                              },
+                              {
+                                "r": "966",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "\"Normalize Abatement\"",
+                                      "("
+                                    ]
+                                  },
+                                  {
+                                    "r": "965",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "condition"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      ")"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              ")"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "967",
+            "locator": "211:3-211:99",
+            "lowClosed": true,
+            "highClosed": false,
+            "type": "Interval",
+            "low": {
+              "localId": "960",
+              "locator": "211:12-211:57",
+              "type": "Start",
+              "signature": [],
+              "operand": {
+                "localId": "963",
+                "locator": "211:21-211:57",
+                "name": "Normalize Interval",
+                "type": "FunctionRef",
+                "signature": [],
+                "operand": [
+                  {
+                    "localId": "962",
+                    "locator": "211:42-211:56",
+                    "path": "onset",
+                    "type": "Property",
+                    "source": {
+                      "localId": "961",
+                      "locator": "211:42-211:50",
+                      "name": "condition",
+                      "type": "OperandRef"
+                    }
+                  }
+                ]
+              }
+            },
+            "high": {
+              "localId": "964",
+              "locator": "211:60-211:98",
+              "type": "End",
+              "signature": [],
+              "operand": {
+                "localId": "966",
+                "locator": "211:67-211:98",
+                "name": "Normalize Abatement",
+                "type": "FunctionRef",
+                "signature": [],
+                "operand": [
+                  {
+                    "localId": "965",
+                    "locator": "211:89-211:97",
+                    "name": "condition",
+                    "type": "OperandRef"
+                  }
+                ]
+              }
+            }
+          },
+          "operand": [
+            {
+              "localId": "959",
+              "name": "condition",
+              "operandTypeSpecifier": {
+                "localId": "958",
+                "locator": "210:47-210:55",
+                "name": "{http://hl7.org/fhir}Condition",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "localId": "968",
+          "locator": "213:1-214:22",
+          "name": "GetId",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "968",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define function \"GetId\"(uri String):\n\t"
+                    ]
+                  },
+                  {
+                    "r": "978",
+                    "s": [
+                      {
+                        "r": "978",
+                        "s": [
+                          {
+                            "value": [
+                              "Last",
+                              "("
+                            ]
+                          },
+                          {
+                            "r": "975",
+                            "s": [
+                              {
+                                "value": [
+                                  "Split",
+                                  "("
+                                ]
+                              },
+                              {
+                                "r": "971",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "uri"
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  ", "
+                                ]
+                              },
+                              {
+                                "r": "972",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "'/'"
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  ")"
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              ")"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "978",
+            "locator": "214:2-214:22",
+            "type": "Last",
+            "signature": [],
+            "source": {
+              "localId": "975",
+              "locator": "214:7-214:21",
+              "type": "Split",
+              "signature": [],
+              "stringToSplit": {
+                "localId": "971",
+                "locator": "214:13-214:15",
+                "name": "uri",
+                "type": "OperandRef"
+              },
+              "separator": {
+                "localId": "972",
+                "locator": "214:18-214:20",
+                "valueType": "{urn:hl7-org:elm-types:r1}String",
+                "value": "/",
+                "type": "Literal"
+              }
+            }
+          },
+          "operand": [
+            {
+              "localId": "970",
+              "name": "uri",
+              "operandTypeSpecifier": {
+                "localId": "969",
+                "locator": "213:29-213:34",
+                "name": "{urn:hl7-org:elm-types:r1}String",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "localId": "979",
+          "locator": "217:1-219:85",
+          "name": "EncounterDiagnosis",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "979",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define function \"EncounterDiagnosis\"(Encounter Encounter):\n  "
+                    ]
+                  },
+                  {
+                    "r": "999",
+                    "s": [
+                      {
+                        "r": "999",
+                        "s": [
+                          {
+                            "s": [
+                              {
+                                "r": "982",
+                                "s": [
+                                  {
+                                    "r": "984",
+                                    "s": [
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "Encounter",
+                                              ".",
+                                              "diagnosis"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      " ",
+                                      "D"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              "\n    "
+                            ]
+                          },
+                          {
+                            "r": "985",
+                            "s": [
+                              {
+                                "value": [
+                                  "return "
+                                ]
+                              },
+                              {
+                                "r": "986",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "singleton from "
+                                    ]
+                                  },
+                                  {
+                                    "r": "998",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "("
+                                        ]
+                                      },
+                                      {
+                                        "r": "998",
+                                        "s": [
+                                          {
+                                            "s": [
+                                              {
+                                                "r": "987",
+                                                "s": [
+                                                  {
+                                                    "r": "988",
+                                                    "s": [
+                                                      {
+                                                        "r": "988",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "[",
+                                                              "Condition",
+                                                              "]"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "value": [
+                                                      " ",
+                                                      "C"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              " "
+                                            ]
+                                          },
+                                          {
+                                            "r": "989",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "where "
+                                                ]
+                                              },
+                                              {
+                                                "r": "989",
+                                                "s": [
+                                                  {
+                                                    "r": "991",
+                                                    "s": [
+                                                      {
+                                                        "r": "990",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "C"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "value": [
+                                                          "."
+                                                        ]
+                                                      },
+                                                      {
+                                                        "r": "991",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "id"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "value": [
+                                                      " ",
+                                                      "=",
+                                                      " "
+                                                    ]
+                                                  },
+                                                  {
+                                                    "r": "995",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "\"GetId\"",
+                                                          "("
+                                                        ]
+                                                      },
+                                                      {
+                                                        "r": "994",
+                                                        "s": [
+                                                          {
+                                                            "r": "993",
+                                                            "s": [
+                                                              {
+                                                                "r": "992",
+                                                                "s": [
+                                                                  {
+                                                                    "value": [
+                                                                      "D"
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "value": [
+                                                                  "."
+                                                                ]
+                                                              },
+                                                              {
+                                                                "r": "993",
+                                                                "s": [
+                                                                  {
+                                                                    "value": [
+                                                                      "condition"
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "value": [
+                                                              "."
+                                                            ]
+                                                          },
+                                                          {
+                                                            "r": "994",
+                                                            "s": [
+                                                              {
+                                                                "value": [
+                                                                  "reference"
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "value": [
+                                                          ")"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          ")"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "999",
+            "locator": "218:3-219:85",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "982",
+                "locator": "218:3-218:23",
+                "alias": "D",
+                "expression": {
+                  "localId": "984",
+                  "locator": "218:3-218:21",
+                  "path": "diagnosis",
+                  "type": "Property",
+                  "source": {
+                    "localId": "983",
+                    "name": "Encounter",
+                    "type": "OperandRef"
+                  }
+                }
+              }
+            ],
+            "let": [],
+            "relationship": [],
+            "return": {
+              "localId": "985",
+              "locator": "219:5-219:85",
+              "expression": {
+                "localId": "986",
+                "locator": "219:12-219:85",
+                "type": "SingletonFrom",
+                "signature": [],
+                "operand": {
+                  "localId": "998",
+                  "locator": "219:27-219:85",
+                  "type": "Query",
+                  "source": [
+                    {
+                      "localId": "987",
+                      "locator": "219:28-219:40",
+                      "alias": "C",
+                      "expression": {
+                        "localId": "988",
+                        "locator": "219:28-219:38",
+                        "dataType": "{http://hl7.org/fhir}Condition",
+                        "templateId": "http://hl7.org/fhir/StructureDefinition/Condition",
+                        "type": "Retrieve",
+                        "include": [],
+                        "codeFilter": [],
+                        "dateFilter": [],
+                        "otherFilter": []
+                      }
+                    }
+                  ],
+                  "let": [],
+                  "relationship": [],
+                  "where": {
+                    "localId": "989",
+                    "locator": "219:42-219:84",
+                    "type": "Equal",
+                    "signature": [],
+                    "operand": [
+                      {
+                        "localId": "997",
+                        "name": "ToString",
+                        "libraryName": "FHIRHelpers",
+                        "type": "FunctionRef",
+                        "signature": [],
+                        "operand": [
+                          {
+                            "localId": "991",
+                            "locator": "219:48-219:51",
+                            "path": "id",
+                            "scope": "C",
+                            "type": "Property"
+                          }
+                        ]
+                      },
+                      {
+                        "localId": "995",
+                        "locator": "219:55-219:84",
+                        "name": "GetId",
+                        "type": "FunctionRef",
+                        "signature": [],
+                        "operand": [
+                          {
+                            "localId": "996",
+                            "name": "ToString",
+                            "libraryName": "FHIRHelpers",
+                            "type": "FunctionRef",
+                            "signature": [],
+                            "operand": [
+                              {
+                                "localId": "994",
+                                "locator": "219:63-219:83",
+                                "path": "reference",
+                                "type": "Property",
+                                "source": {
+                                  "localId": "993",
+                                  "locator": "219:63-219:73",
+                                  "path": "condition",
+                                  "scope": "D",
+                                  "type": "Property"
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "operand": [
+            {
+              "localId": "981",
+              "name": "Encounter",
+              "operandTypeSpecifier": {
+                "localId": "980",
+                "locator": "217:48-217:56",
+                "name": "{http://hl7.org/fhir}Encounter",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "localId": "1000",
+          "locator": "223:1-225:84",
+          "name": "PrincipalDiagnosis",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "1000",
+                "s": [
+                  {
+                    "value": [
+                      "// Returns the condition that is specified as the principal diagnosis for the encounter\n// TODO: BTR 2019-07-30: Shouldn't need the FHIRHelpers reference here, investigate\n",
+                      "define function \"PrincipalDiagnosis\"(Encounter Encounter):\n\t"
+                    ]
+                  },
+                  {
+                    "r": "1029",
+                    "s": [
+                      {
+                        "r": "1029",
+                        "s": [
+                          {
+                            "s": [
+                              {
+                                "r": "1003",
+                                "s": [
+                                  {
+                                    "r": "1004",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "("
+                                        ]
+                                      },
+                                      {
+                                        "r": "1004",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "singleton from "
+                                            ]
+                                          },
+                                          {
+                                            "r": "1014",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "("
+                                                ]
+                                              },
+                                              {
+                                                "r": "1014",
+                                                "s": [
+                                                  {
+                                                    "s": [
+                                                      {
+                                                        "r": "1005",
+                                                        "s": [
+                                                          {
+                                                            "r": "1007",
+                                                            "s": [
+                                                              {
+                                                                "s": [
+                                                                  {
+                                                                    "value": [
+                                                                      "Encounter",
+                                                                      ".",
+                                                                      "diagnosis"
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "value": [
+                                                              " ",
+                                                              "D"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "value": [
+                                                      " "
+                                                    ]
+                                                  },
+                                                  {
+                                                    "r": "1008",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "where "
+                                                        ]
+                                                      },
+                                                      {
+                                                        "r": "1008",
+                                                        "s": [
+                                                          {
+                                                            "r": "1012",
+                                                            "s": [
+                                                              {
+                                                                "r": "1009",
+                                                                "s": [
+                                                                  {
+                                                                    "value": [
+                                                                      "FHIRHelpers"
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "value": [
+                                                                  "."
+                                                                ]
+                                                              },
+                                                              {
+                                                                "r": "1012",
+                                                                "s": [
+                                                                  {
+                                                                    "value": [
+                                                                      "ToInteger",
+                                                                      "("
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "r": "1011",
+                                                                    "s": [
+                                                                      {
+                                                                        "r": "1010",
+                                                                        "s": [
+                                                                          {
+                                                                            "value": [
+                                                                              "D"
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "value": [
+                                                                          "."
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "r": "1011",
+                                                                        "s": [
+                                                                          {
+                                                                            "value": [
+                                                                              "rank"
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "value": [
+                                                                      ")"
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "r": "1013",
+                                                            "value": [
+                                                              " ",
+                                                              "=",
+                                                              " ",
+                                                              "1"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  ")"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          ")"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      " ",
+                                      "PD"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              "\n\t\t"
+                            ]
+                          },
+                          {
+                            "r": "1015",
+                            "s": [
+                              {
+                                "value": [
+                                  "return "
+                                ]
+                              },
+                              {
+                                "r": "1016",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "singleton from "
+                                    ]
+                                  },
+                                  {
+                                    "r": "1028",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "("
+                                        ]
+                                      },
+                                      {
+                                        "r": "1028",
+                                        "s": [
+                                          {
+                                            "s": [
+                                              {
+                                                "r": "1017",
+                                                "s": [
+                                                  {
+                                                    "r": "1018",
+                                                    "s": [
+                                                      {
+                                                        "r": "1018",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "[",
+                                                              "Condition",
+                                                              "]"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "value": [
+                                                      " ",
+                                                      "C"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              " "
+                                            ]
+                                          },
+                                          {
+                                            "r": "1019",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "where "
+                                                ]
+                                              },
+                                              {
+                                                "r": "1019",
+                                                "s": [
+                                                  {
+                                                    "r": "1021",
+                                                    "s": [
+                                                      {
+                                                        "r": "1020",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "C"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "value": [
+                                                          "."
+                                                        ]
+                                                      },
+                                                      {
+                                                        "r": "1021",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "id"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "value": [
+                                                      " ",
+                                                      "=",
+                                                      " "
+                                                    ]
+                                                  },
+                                                  {
+                                                    "r": "1025",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "\"GetId\"",
+                                                          "("
+                                                        ]
+                                                      },
+                                                      {
+                                                        "r": "1024",
+                                                        "s": [
+                                                          {
+                                                            "r": "1023",
+                                                            "s": [
+                                                              {
+                                                                "r": "1022",
+                                                                "s": [
+                                                                  {
+                                                                    "value": [
+                                                                      "PD"
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "value": [
+                                                                  "."
+                                                                ]
+                                                              },
+                                                              {
+                                                                "r": "1023",
+                                                                "s": [
+                                                                  {
+                                                                    "value": [
+                                                                      "condition"
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "value": [
+                                                              "."
+                                                            ]
+                                                          },
+                                                          {
+                                                            "r": "1024",
+                                                            "s": [
+                                                              {
+                                                                "value": [
+                                                                  "reference"
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "value": [
+                                                          ")"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          ")"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "1029",
+            "locator": "224:2-225:84",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "1003",
+                "locator": "224:2-224:84",
+                "alias": "PD",
+                "expression": {
+                  "localId": "1004",
+                  "locator": "224:2-224:81",
+                  "type": "SingletonFrom",
+                  "signature": [],
+                  "operand": {
+                    "localId": "1014",
+                    "locator": "224:18-224:80",
+                    "type": "Query",
+                    "source": [
+                      {
+                        "localId": "1005",
+                        "locator": "224:19-224:39",
+                        "alias": "D",
+                        "expression": {
+                          "localId": "1007",
+                          "locator": "224:19-224:37",
+                          "path": "diagnosis",
+                          "type": "Property",
+                          "source": {
+                            "localId": "1006",
+                            "name": "Encounter",
+                            "type": "OperandRef"
+                          }
+                        }
+                      }
+                    ],
+                    "let": [],
+                    "relationship": [],
+                    "where": {
+                      "localId": "1008",
+                      "locator": "224:41-224:79",
+                      "type": "Equal",
+                      "signature": [],
+                      "operand": [
+                        {
+                          "localId": "1012",
+                          "locator": "224:47-224:75",
+                          "name": "ToInteger",
+                          "libraryName": "FHIRHelpers",
+                          "type": "FunctionRef",
+                          "signature": [],
+                          "operand": [
+                            {
+                              "localId": "1011",
+                              "locator": "224:69-224:74",
+                              "path": "rank",
+                              "scope": "D",
+                              "type": "Property"
+                            }
+                          ]
+                        },
+                        {
+                          "localId": "1013",
+                          "locator": "224:79",
+                          "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                          "value": "1",
+                          "type": "Literal"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            ],
+            "let": [],
+            "relationship": [],
+            "return": {
+              "localId": "1015",
+              "locator": "225:3-225:84",
+              "expression": {
+                "localId": "1016",
+                "locator": "225:10-225:84",
+                "type": "SingletonFrom",
+                "signature": [],
+                "operand": {
+                  "localId": "1028",
+                  "locator": "225:25-225:84",
+                  "type": "Query",
+                  "source": [
+                    {
+                      "localId": "1017",
+                      "locator": "225:26-225:38",
+                      "alias": "C",
+                      "expression": {
+                        "localId": "1018",
+                        "locator": "225:26-225:36",
+                        "dataType": "{http://hl7.org/fhir}Condition",
+                        "templateId": "http://hl7.org/fhir/StructureDefinition/Condition",
+                        "type": "Retrieve",
+                        "include": [],
+                        "codeFilter": [],
+                        "dateFilter": [],
+                        "otherFilter": []
+                      }
+                    }
+                  ],
+                  "let": [],
+                  "relationship": [],
+                  "where": {
+                    "localId": "1019",
+                    "locator": "225:40-225:83",
+                    "type": "Equal",
+                    "signature": [],
+                    "operand": [
+                      {
+                        "localId": "1027",
+                        "name": "ToString",
+                        "libraryName": "FHIRHelpers",
+                        "type": "FunctionRef",
+                        "signature": [],
+                        "operand": [
+                          {
+                            "localId": "1021",
+                            "locator": "225:46-225:49",
+                            "path": "id",
+                            "scope": "C",
+                            "type": "Property"
+                          }
+                        ]
+                      },
+                      {
+                        "localId": "1025",
+                        "locator": "225:53-225:83",
+                        "name": "GetId",
+                        "type": "FunctionRef",
+                        "signature": [],
+                        "operand": [
+                          {
+                            "localId": "1026",
+                            "name": "ToString",
+                            "libraryName": "FHIRHelpers",
+                            "type": "FunctionRef",
+                            "signature": [],
+                            "operand": [
+                              {
+                                "localId": "1024",
+                                "locator": "225:61-225:82",
+                                "path": "reference",
+                                "type": "Property",
+                                "source": {
+                                  "localId": "1023",
+                                  "locator": "225:61-225:72",
+                                  "path": "condition",
+                                  "scope": "PD",
+                                  "type": "Property"
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "operand": [
+            {
+              "localId": "1002",
+              "name": "Encounter",
+              "operandTypeSpecifier": {
+                "localId": "1001",
+                "locator": "223:48-223:56",
+                "name": "{http://hl7.org/fhir}Encounter",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "localId": "1030",
+          "locator": "228:1-231:3",
+          "name": "GetLocation",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "1030",
+                "s": [
+                  {
+                    "value": [
+                      "// Returns the location for the given location reference\n",
+                      "define function GetLocation(reference Reference):\n  "
+                    ]
+                  },
+                  {
+                    "r": "1033",
+                    "s": [
+                      {
+                        "r": "1033",
+                        "s": [
+                          {
+                            "value": [
+                              "singleton from "
+                            ]
+                          },
+                          {
+                            "r": "1044",
+                            "s": [
+                              {
+                                "value": [
+                                  "(\n    "
+                                ]
+                              },
+                              {
+                                "r": "1044",
+                                "s": [
+                                  {
+                                    "s": [
+                                      {
+                                        "r": "1034",
+                                        "s": [
+                                          {
+                                            "r": "1035",
+                                            "s": [
+                                              {
+                                                "r": "1035",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "[",
+                                                      "Location",
+                                                      "]"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              " ",
+                                              "L"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      " "
+                                    ]
+                                  },
+                                  {
+                                    "r": "1036",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "where "
+                                        ]
+                                      },
+                                      {
+                                        "r": "1036",
+                                        "s": [
+                                          {
+                                            "r": "1038",
+                                            "s": [
+                                              {
+                                                "r": "1037",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "L"
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  "."
+                                                ]
+                                              },
+                                              {
+                                                "r": "1038",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "id"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              " ",
+                                              "=",
+                                              " "
+                                            ]
+                                          },
+                                          {
+                                            "r": "1041",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "GetId",
+                                                  "("
+                                                ]
+                                              },
+                                              {
+                                                "r": "1040",
+                                                "s": [
+                                                  {
+                                                    "r": "1039",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "reference"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "value": [
+                                                      "."
+                                                    ]
+                                                  },
+                                                  {
+                                                    "r": "1040",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "reference"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  ")"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  "\n  )"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "1033",
+            "locator": "229:3-231:3",
+            "type": "SingletonFrom",
+            "signature": [],
+            "operand": {
+              "localId": "1044",
+              "locator": "229:18-231:3",
+              "type": "Query",
+              "source": [
+                {
+                  "localId": "1034",
+                  "locator": "230:5-230:16",
+                  "alias": "L",
+                  "expression": {
+                    "localId": "1035",
+                    "locator": "230:5-230:14",
+                    "dataType": "{http://hl7.org/fhir}Location",
+                    "templateId": "http://hl7.org/fhir/StructureDefinition/Location",
+                    "type": "Retrieve",
+                    "include": [],
+                    "codeFilter": [],
+                    "dateFilter": [],
+                    "otherFilter": []
+                  }
+                }
+              ],
+              "let": [],
+              "relationship": [],
+              "where": {
+                "localId": "1036",
+                "locator": "230:18-230:56",
+                "type": "Equal",
+                "signature": [],
+                "operand": [
+                  {
+                    "localId": "1043",
+                    "name": "ToString",
+                    "libraryName": "FHIRHelpers",
+                    "type": "FunctionRef",
+                    "signature": [],
+                    "operand": [
+                      {
+                        "localId": "1038",
+                        "locator": "230:24-230:27",
+                        "path": "id",
+                        "scope": "L",
+                        "type": "Property"
+                      }
+                    ]
+                  },
+                  {
+                    "localId": "1041",
+                    "locator": "230:31-230:56",
+                    "name": "GetId",
+                    "type": "FunctionRef",
+                    "signature": [],
+                    "operand": [
+                      {
+                        "localId": "1042",
+                        "name": "ToString",
+                        "libraryName": "FHIRHelpers",
+                        "type": "FunctionRef",
+                        "signature": [],
+                        "operand": [
+                          {
+                            "localId": "1040",
+                            "locator": "230:37-230:55",
+                            "path": "reference",
+                            "type": "Property",
+                            "source": {
+                              "localId": "1039",
+                              "locator": "230:37-230:45",
+                              "name": "reference",
+                              "type": "OperandRef"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "operand": [
+            {
+              "localId": "1032",
+              "name": "reference",
+              "operandTypeSpecifier": {
+                "localId": "1031",
+                "locator": "228:39-228:47",
+                "name": "{http://hl7.org/fhir}Reference",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "localId": "1045",
+          "locator": "238:1-241:10",
+          "name": "GetExtensions",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "1045",
+                "s": [
+                  {
+                    "value": [
+                      "/*\nNOTE: Extensions are not the preferred approach, but are used as a way to access\ncontent that is defined by extensions but not yet surfaced in the\nCQL model info.\n*/\n",
+                      "define function \"GetExtensions\"(domainResource DomainResource, url String):\n  "
+                    ]
+                  },
+                  {
+                    "r": "1063",
+                    "s": [
+                      {
+                        "r": "1063",
+                        "s": [
+                          {
+                            "s": [
+                              {
+                                "r": "1050",
+                                "s": [
+                                  {
+                                    "r": "1052",
+                                    "s": [
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "domainResource",
+                                              ".",
+                                              "extension"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      " ",
+                                      "E"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              "\n\t  "
+                            ]
+                          },
+                          {
+                            "r": "1053",
+                            "s": [
+                              {
+                                "value": [
+                                  "where "
+                                ]
+                              },
+                              {
+                                "r": "1053",
+                                "s": [
+                                  {
+                                    "r": "1055",
+                                    "s": [
+                                      {
+                                        "r": "1054",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "E"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "."
+                                        ]
+                                      },
+                                      {
+                                        "r": "1055",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "url"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      " ",
+                                      "=",
+                                      " "
+                                    ]
+                                  },
+                                  {
+                                    "r": "1059",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "("
+                                        ]
+                                      },
+                                      {
+                                        "r": "1059",
+                                        "s": [
+                                          {
+                                            "r": "1057",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "'http://hl7.org/fhir/us/qicore/StructureDefinition/'"
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              " + "
+                                            ]
+                                          },
+                                          {
+                                            "r": "1058",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "url"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          ")"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              "\n\t\t"
+                            ]
+                          },
+                          {
+                            "r": "1061",
+                            "s": [
+                              {
+                                "value": [
+                                  "return "
+                                ]
+                              },
+                              {
+                                "r": "1062",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "E"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "1063",
+            "locator": "239:3-241:10",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "1050",
+                "locator": "239:3-239:28",
+                "alias": "E",
+                "expression": {
+                  "localId": "1052",
+                  "locator": "239:3-239:26",
+                  "path": "extension",
+                  "type": "Property",
+                  "source": {
+                    "localId": "1051",
+                    "name": "domainResource",
+                    "type": "OperandRef"
+                  }
+                }
+              }
+            ],
+            "let": [],
+            "relationship": [],
+            "where": {
+              "localId": "1053",
+              "locator": "240:4-240:77",
+              "type": "Equal",
+              "signature": [],
+              "operand": [
+                {
+                  "localId": "1060",
+                  "name": "ToString",
+                  "libraryName": "FHIRHelpers",
+                  "type": "FunctionRef",
+                  "signature": [],
+                  "operand": [
+                    {
+                      "localId": "1055",
+                      "locator": "240:10-240:14",
+                      "path": "url",
+                      "scope": "E",
+                      "type": "Property"
+                    }
+                  ]
+                },
+                {
+                  "localId": "1059",
+                  "locator": "240:18-240:77",
+                  "type": "Concatenate",
+                  "signature": [],
+                  "operand": [
+                    {
+                      "localId": "1057",
+                      "locator": "240:19-240:70",
+                      "valueType": "{urn:hl7-org:elm-types:r1}String",
+                      "value": "http://hl7.org/fhir/us/qicore/StructureDefinition/",
+                      "type": "Literal"
+                    },
+                    {
+                      "localId": "1058",
+                      "locator": "240:74-240:76",
+                      "name": "url",
+                      "type": "OperandRef"
+                    }
+                  ]
+                }
+              ]
+            },
+            "return": {
+              "localId": "1061",
+              "locator": "241:3-241:10",
+              "expression": {
+                "localId": "1062",
+                "locator": "241:10",
+                "name": "E",
+                "type": "AliasRef"
+              }
+            }
+          },
+          "operand": [
+            {
+              "localId": "1047",
+              "name": "domainResource",
+              "operandTypeSpecifier": {
+                "localId": "1046",
+                "locator": "238:48-238:61",
+                "name": "{http://hl7.org/fhir}DomainResource",
+                "type": "NamedTypeSpecifier"
+              }
+            },
+            {
+              "localId": "1049",
+              "name": "url",
+              "operandTypeSpecifier": {
+                "localId": "1048",
+                "locator": "238:68-238:73",
+                "name": "{urn:hl7-org:elm-types:r1}String",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "localId": "1064",
+          "locator": "243:1-244:53",
+          "name": "GetExtension",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "1064",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define function \"GetExtension\"(domainResource DomainResource, url String):\n  "
+                    ]
+                  },
+                  {
+                    "r": "1069",
+                    "s": [
+                      {
+                        "r": "1069",
+                        "s": [
+                          {
+                            "value": [
+                              "singleton from "
+                            ]
+                          },
+                          {
+                            "r": "1077",
+                            "s": [
+                              {
+                                "value": [
+                                  "\"GetExtensions\"",
+                                  "("
+                                ]
+                              },
+                              {
+                                "r": "1070",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "domainResource"
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  ", "
+                                ]
+                              },
+                              {
+                                "r": "1071",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "url"
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  ")"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "1069",
+            "locator": "244:3-244:53",
+            "type": "SingletonFrom",
+            "signature": [],
+            "operand": {
+              "localId": "1077",
+              "locator": "244:18-244:53",
+              "name": "GetExtensions",
+              "type": "FunctionRef",
+              "signature": [],
+              "operand": [
+                {
+                  "localId": "1070",
+                  "locator": "244:34-244:47",
+                  "name": "domainResource",
+                  "type": "OperandRef"
+                },
+                {
+                  "localId": "1071",
+                  "locator": "244:50-244:52",
+                  "name": "url",
+                  "type": "OperandRef"
+                }
+              ]
+            }
+          },
+          "operand": [
+            {
+              "localId": "1066",
+              "name": "domainResource",
+              "operandTypeSpecifier": {
+                "localId": "1065",
+                "locator": "243:47-243:60",
+                "name": "{http://hl7.org/fhir}DomainResource",
+                "type": "NamedTypeSpecifier"
+              }
+            },
+            {
+              "localId": "1068",
+              "name": "url",
+              "operandTypeSpecifier": {
+                "localId": "1067",
+                "locator": "243:67-243:72",
+                "name": "{urn:hl7-org:elm-types:r1}String",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "localId": "1072",
+          "locator": "251:1-254:10",
+          "name": "GetExtensions",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "1072",
+                "s": [
+                  {
+                    "value": [
+                      "/*\nNOTE: Extensions are not the preferred approach, but are used as a way to access\ncontent that is defined by extensions but not yet surfaced in the\nCQL model info.\n*/\n",
+                      "define function \"GetExtensions\"(element Element, url String):\n  "
+                    ]
+                  },
+                  {
+                    "r": "1088",
+                    "s": [
+                      {
+                        "r": "1088",
+                        "s": [
+                          {
+                            "s": [
+                              {
+                                "r": "1078",
+                                "s": [
+                                  {
+                                    "r": "1080",
+                                    "s": [
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "element",
+                                              ".",
+                                              "extension"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      " ",
+                                      "E"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              "\n\t  "
+                            ]
+                          },
+                          {
+                            "r": "1081",
+                            "s": [
+                              {
+                                "value": [
+                                  "where "
+                                ]
+                              },
+                              {
+                                "r": "1081",
+                                "s": [
+                                  {
+                                    "r": "1083",
+                                    "s": [
+                                      {
+                                        "r": "1082",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "E"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "."
+                                        ]
+                                      },
+                                      {
+                                        "r": "1083",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "url"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      " ",
+                                      "=",
+                                      " "
+                                    ]
+                                  },
+                                  {
+                                    "r": "1084",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "("
+                                        ]
+                                      },
+                                      {
+                                        "r": "1084",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "url"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          ")"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              "\n\t\t"
+                            ]
+                          },
+                          {
+                            "r": "1086",
+                            "s": [
+                              {
+                                "value": [
+                                  "return "
+                                ]
+                              },
+                              {
+                                "r": "1087",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "E"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "1088",
+            "locator": "252:3-254:10",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "1078",
+                "locator": "252:3-252:21",
+                "alias": "E",
+                "expression": {
+                  "localId": "1080",
+                  "locator": "252:3-252:19",
+                  "path": "extension",
+                  "type": "Property",
+                  "source": {
+                    "localId": "1079",
+                    "name": "element",
+                    "type": "OperandRef"
+                  }
+                }
+              }
+            ],
+            "let": [],
+            "relationship": [],
+            "where": {
+              "localId": "1081",
+              "locator": "253:4-253:22",
+              "type": "Equal",
+              "signature": [],
+              "operand": [
+                {
+                  "localId": "1085",
+                  "name": "ToString",
+                  "libraryName": "FHIRHelpers",
+                  "type": "FunctionRef",
+                  "signature": [],
+                  "operand": [
+                    {
+                      "localId": "1083",
+                      "locator": "253:10-253:14",
+                      "path": "url",
+                      "scope": "E",
+                      "type": "Property"
+                    }
+                  ]
+                },
+                {
+                  "localId": "1084",
+                  "locator": "253:18-253:22",
+                  "name": "url",
+                  "type": "OperandRef"
+                }
+              ]
+            },
+            "return": {
+              "localId": "1086",
+              "locator": "254:3-254:10",
+              "expression": {
+                "localId": "1087",
+                "locator": "254:10",
+                "name": "E",
+                "type": "AliasRef"
+              }
+            }
+          },
+          "operand": [
+            {
+              "localId": "1074",
+              "name": "element",
+              "operandTypeSpecifier": {
+                "localId": "1073",
+                "locator": "251:41-251:47",
+                "name": "{http://hl7.org/fhir}Element",
+                "type": "NamedTypeSpecifier"
+              }
+            },
+            {
+              "localId": "1076",
+              "name": "url",
+              "operandTypeSpecifier": {
+                "localId": "1075",
+                "locator": "251:54-251:59",
+                "name": "{urn:hl7-org:elm-types:r1}String",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "localId": "1089",
+          "locator": "256:1-257:46",
+          "name": "GetExtension",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "1089",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define function \"GetExtension\"(element Element, url String):\n  "
+                    ]
+                  },
+                  {
+                    "r": "1094",
+                    "s": [
+                      {
+                        "r": "1094",
+                        "s": [
+                          {
+                            "value": [
+                              "singleton from "
+                            ]
+                          },
+                          {
+                            "r": "1097",
+                            "s": [
+                              {
+                                "value": [
+                                  "\"GetExtensions\"",
+                                  "("
+                                ]
+                              },
+                              {
+                                "r": "1095",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "element"
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  ", "
+                                ]
+                              },
+                              {
+                                "r": "1096",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "url"
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  ")"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "1094",
+            "locator": "257:3-257:46",
+            "type": "SingletonFrom",
+            "signature": [],
+            "operand": {
+              "localId": "1097",
+              "locator": "257:18-257:46",
+              "name": "GetExtensions",
+              "type": "FunctionRef",
+              "signature": [],
+              "operand": [
+                {
+                  "localId": "1095",
+                  "locator": "257:34-257:40",
+                  "name": "element",
+                  "type": "OperandRef"
+                },
+                {
+                  "localId": "1096",
+                  "locator": "257:43-257:45",
+                  "name": "url",
+                  "type": "OperandRef"
+                }
+              ]
+            }
+          },
+          "operand": [
+            {
+              "localId": "1091",
+              "name": "element",
+              "operandTypeSpecifier": {
+                "localId": "1090",
+                "locator": "256:40-256:46",
+                "name": "{http://hl7.org/fhir}Element",
+                "type": "NamedTypeSpecifier"
+              }
+            },
+            {
+              "localId": "1093",
+              "name": "url",
+              "operandTypeSpecifier": {
+                "localId": "1092",
+                "locator": "256:53-256:58",
+                "name": "{urn:hl7-org:elm-types:r1}String",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "localId": "1098",
+          "locator": "264:1-267:10",
+          "name": "GetBaseExtensions",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "1098",
+                "s": [
+                  {
+                    "value": [
+                      "/*\nNOTE: Extensions are not the preferred approach, but are used as a way to access\ncontent that is defined by extensions but not yet surfaced in the\nCQL model info.\n*/\n",
+                      "define function \"GetBaseExtensions\"(domainResource DomainResource, url String):\n  "
+                    ]
+                  },
+                  {
+                    "r": "1116",
+                    "s": [
+                      {
+                        "r": "1116",
+                        "s": [
+                          {
+                            "s": [
+                              {
+                                "r": "1103",
+                                "s": [
+                                  {
+                                    "r": "1105",
+                                    "s": [
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "domainResource",
+                                              ".",
+                                              "extension"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      " ",
+                                      "E"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              "\n\t  "
+                            ]
+                          },
+                          {
+                            "r": "1106",
+                            "s": [
+                              {
+                                "value": [
+                                  "where "
+                                ]
+                              },
+                              {
+                                "r": "1106",
+                                "s": [
+                                  {
+                                    "r": "1108",
+                                    "s": [
+                                      {
+                                        "r": "1107",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "E"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "."
+                                        ]
+                                      },
+                                      {
+                                        "r": "1108",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "url"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      " ",
+                                      "=",
+                                      " "
+                                    ]
+                                  },
+                                  {
+                                    "r": "1112",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "("
+                                        ]
+                                      },
+                                      {
+                                        "r": "1112",
+                                        "s": [
+                                          {
+                                            "r": "1110",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "'http://hl7.org/fhir/StructureDefinition/'"
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              " + "
+                                            ]
+                                          },
+                                          {
+                                            "r": "1111",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "url"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          ")"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              "\n\t\t"
+                            ]
+                          },
+                          {
+                            "r": "1114",
+                            "s": [
+                              {
+                                "value": [
+                                  "return "
+                                ]
+                              },
+                              {
+                                "r": "1115",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "E"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "1116",
+            "locator": "265:3-267:10",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "1103",
+                "locator": "265:3-265:28",
+                "alias": "E",
+                "expression": {
+                  "localId": "1105",
+                  "locator": "265:3-265:26",
+                  "path": "extension",
+                  "type": "Property",
+                  "source": {
+                    "localId": "1104",
+                    "name": "domainResource",
+                    "type": "OperandRef"
+                  }
+                }
+              }
+            ],
+            "let": [],
+            "relationship": [],
+            "where": {
+              "localId": "1106",
+              "locator": "266:4-266:67",
+              "type": "Equal",
+              "signature": [],
+              "operand": [
+                {
+                  "localId": "1113",
+                  "name": "ToString",
+                  "libraryName": "FHIRHelpers",
+                  "type": "FunctionRef",
+                  "signature": [],
+                  "operand": [
+                    {
+                      "localId": "1108",
+                      "locator": "266:10-266:14",
+                      "path": "url",
+                      "scope": "E",
+                      "type": "Property"
+                    }
+                  ]
+                },
+                {
+                  "localId": "1112",
+                  "locator": "266:18-266:67",
+                  "type": "Concatenate",
+                  "signature": [],
+                  "operand": [
+                    {
+                      "localId": "1110",
+                      "locator": "266:19-266:60",
+                      "valueType": "{urn:hl7-org:elm-types:r1}String",
+                      "value": "http://hl7.org/fhir/StructureDefinition/",
+                      "type": "Literal"
+                    },
+                    {
+                      "localId": "1111",
+                      "locator": "266:64-266:66",
+                      "name": "url",
+                      "type": "OperandRef"
+                    }
+                  ]
+                }
+              ]
+            },
+            "return": {
+              "localId": "1114",
+              "locator": "267:3-267:10",
+              "expression": {
+                "localId": "1115",
+                "locator": "267:10",
+                "name": "E",
+                "type": "AliasRef"
+              }
+            }
+          },
+          "operand": [
+            {
+              "localId": "1100",
+              "name": "domainResource",
+              "operandTypeSpecifier": {
+                "localId": "1099",
+                "locator": "264:52-264:65",
+                "name": "{http://hl7.org/fhir}DomainResource",
+                "type": "NamedTypeSpecifier"
+              }
+            },
+            {
+              "localId": "1102",
+              "name": "url",
+              "operandTypeSpecifier": {
+                "localId": "1101",
+                "locator": "264:72-264:77",
+                "name": "{urn:hl7-org:elm-types:r1}String",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "localId": "1117",
+          "locator": "269:1-270:57",
+          "name": "GetBaseExtension",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "1117",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define function \"GetBaseExtension\"(domainResource DomainResource, url String):\n  "
+                    ]
+                  },
+                  {
+                    "r": "1122",
+                    "s": [
+                      {
+                        "r": "1122",
+                        "s": [
+                          {
+                            "value": [
+                              "singleton from "
+                            ]
+                          },
+                          {
+                            "r": "1125",
+                            "s": [
+                              {
+                                "value": [
+                                  "\"GetBaseExtensions\"",
+                                  "("
+                                ]
+                              },
+                              {
+                                "r": "1123",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "domainResource"
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  ", "
+                                ]
+                              },
+                              {
+                                "r": "1124",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "url"
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  ")"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "1122",
+            "locator": "270:3-270:57",
+            "type": "SingletonFrom",
+            "signature": [],
+            "operand": {
+              "localId": "1125",
+              "locator": "270:18-270:57",
+              "name": "GetBaseExtensions",
+              "type": "FunctionRef",
+              "signature": [],
+              "operand": [
+                {
+                  "localId": "1123",
+                  "locator": "270:38-270:51",
+                  "name": "domainResource",
+                  "type": "OperandRef"
+                },
+                {
+                  "localId": "1124",
+                  "locator": "270:54-270:56",
+                  "name": "url",
+                  "type": "OperandRef"
+                }
+              ]
+            }
+          },
+          "operand": [
+            {
+              "localId": "1119",
+              "name": "domainResource",
+              "operandTypeSpecifier": {
+                "localId": "1118",
+                "locator": "269:51-269:64",
+                "name": "{http://hl7.org/fhir}DomainResource",
+                "type": "NamedTypeSpecifier"
+              }
+            },
+            {
+              "localId": "1121",
+              "name": "url",
+              "operandTypeSpecifier": {
+                "localId": "1120",
+                "locator": "269:71-269:76",
+                "name": "{urn:hl7-org:elm-types:r1}String",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "localId": "1126",
+          "locator": "276:1-277:54",
+          "name": "GetProvenance",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "1126",
+                "s": [
+                  {
+                    "value": [
+                      "/*\nNOTE: Provenance is not the preferred approach, this is provided only as an illustration\nfor what using Provenance could look like, and is not a tested pattern\n*/\n",
+                      "define function \"GetProvenance\"(resource Resource):\n  "
+                    ]
+                  },
+                  {
+                    "r": "1129",
+                    "s": [
+                      {
+                        "r": "1129",
+                        "s": [
+                          {
+                            "value": [
+                              "singleton from "
+                            ]
+                          },
+                          {
+                            "r": "1133",
+                            "s": [
+                              {
+                                "value": [
+                                  "("
+                                ]
+                              },
+                              {
+                                "r": "1133",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "[",
+                                      "Provenance",
+                                      ": "
+                                    ]
+                                  },
+                                  {
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "target"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      " ",
+                                      "in",
+                                      " "
+                                    ]
+                                  },
+                                  {
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "resource",
+                                          ".",
+                                          "id"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "]"
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  ")"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "1129",
+            "locator": "277:3-277:54",
+            "type": "SingletonFrom",
+            "signature": [],
+            "operand": {
+              "localId": "1133",
+              "locator": "277:18-277:54",
+              "dataType": "{http://hl7.org/fhir}Provenance",
+              "templateId": "http://hl7.org/fhir/StructureDefinition/Provenance",
+              "codeProperty": "target",
+              "codeComparator": "in",
+              "type": "Retrieve",
+              "codes": {
+                "localId": "1135",
+                "type": "ToList",
+                "signature": [],
+                "operand": {
+                  "localId": "1132",
+                  "locator": "277:42-277:52",
+                  "path": "id",
+                  "type": "Property",
+                  "source": {
+                    "localId": "1131",
+                    "name": "resource",
+                    "type": "OperandRef"
+                  }
+                }
+              },
+              "include": [],
+              "codeFilter": [],
+              "dateFilter": [],
+              "otherFilter": []
+            }
+          },
+          "operand": [
+            {
+              "localId": "1128",
+              "name": "resource",
+              "operandTypeSpecifier": {
+                "localId": "1127",
+                "locator": "276:42-276:49",
+                "name": "{http://hl7.org/fhir}Resource",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        },
+        {
+          "localId": "1136",
+          "locator": "279:1-283:105",
+          "name": "GetMedicationCode",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "type": "FunctionDef",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "1136",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define function \"GetMedicationCode\"(request MedicationRequest):\n  "
+                    ]
+                  },
+                  {
+                    "r": "1139",
+                    "s": [
+                      {
+                        "r": "1139",
+                        "s": [
+                          {
+                            "value": [
+                              "if "
+                            ]
+                          },
+                          {
+                            "r": "1140",
+                            "s": [
+                              {
+                                "r": "1142",
+                                "s": [
+                                  {
+                                    "r": "1141",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "request"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "."
+                                    ]
+                                  },
+                                  {
+                                    "r": "1142",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "medication"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " is "
+                                ]
+                              },
+                              {
+                                "r": "1143",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "CodeableConcept"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              " then\n\t  "
+                            ]
+                          },
+                          {
+                            "r": "1144",
+                            "s": [
+                              {
+                                "r": "1146",
+                                "s": [
+                                  {
+                                    "r": "1145",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "request"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "."
+                                    ]
+                                  },
+                                  {
+                                    "r": "1146",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "medication"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " as "
+                                ]
+                              },
+                              {
+                                "r": "1147",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "CodeableConcept"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              "\n\telse\n\t  "
+                            ]
+                          },
+                          {
+                            "r": "1163",
+                            "s": [
+                              {
+                                "r": "1148",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "("
+                                    ]
+                                  },
+                                  {
+                                    "r": "1148",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "singleton from "
+                                        ]
+                                      },
+                                      {
+                                        "r": "1162",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "("
+                                            ]
+                                          },
+                                          {
+                                            "r": "1162",
+                                            "s": [
+                                              {
+                                                "s": [
+                                                  {
+                                                    "r": "1149",
+                                                    "s": [
+                                                      {
+                                                        "r": "1150",
+                                                        "s": [
+                                                          {
+                                                            "r": "1150",
+                                                            "s": [
+                                                              {
+                                                                "value": [
+                                                                  "[",
+                                                                  "Medication",
+                                                                  "]"
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "value": [
+                                                          " ",
+                                                          "M"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  " "
+                                                ]
+                                              },
+                                              {
+                                                "r": "1151",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "where "
+                                                    ]
+                                                  },
+                                                  {
+                                                    "r": "1151",
+                                                    "s": [
+                                                      {
+                                                        "r": "1153",
+                                                        "s": [
+                                                          {
+                                                            "r": "1152",
+                                                            "s": [
+                                                              {
+                                                                "value": [
+                                                                  "M"
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "value": [
+                                                              "."
+                                                            ]
+                                                          },
+                                                          {
+                                                            "r": "1153",
+                                                            "s": [
+                                                              {
+                                                                "value": [
+                                                                  "id"
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "value": [
+                                                          " ",
+                                                          "=",
+                                                          " "
+                                                        ]
+                                                      },
+                                                      {
+                                                        "r": "1159",
+                                                        "s": [
+                                                          {
+                                                            "value": [
+                                                              "GetId",
+                                                              "("
+                                                            ]
+                                                          },
+                                                          {
+                                                            "r": "1158",
+                                                            "s": [
+                                                              {
+                                                                "r": "1154",
+                                                                "s": [
+                                                                  {
+                                                                    "value": [
+                                                                      "("
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "r": "1154",
+                                                                    "s": [
+                                                                      {
+                                                                        "r": "1156",
+                                                                        "s": [
+                                                                          {
+                                                                            "r": "1155",
+                                                                            "s": [
+                                                                              {
+                                                                                "value": [
+                                                                                  "request"
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          },
+                                                                          {
+                                                                            "value": [
+                                                                              "."
+                                                                            ]
+                                                                          },
+                                                                          {
+                                                                            "r": "1156",
+                                                                            "s": [
+                                                                              {
+                                                                                "value": [
+                                                                                  "medication"
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "value": [
+                                                                          " as "
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "r": "1157",
+                                                                        "s": [
+                                                                          {
+                                                                            "value": [
+                                                                              "Reference"
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "value": [
+                                                                      ")"
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "value": [
+                                                                  "."
+                                                                ]
+                                                              },
+                                                              {
+                                                                "r": "1158",
+                                                                "s": [
+                                                                  {
+                                                                    "value": [
+                                                                      "reference"
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "value": [
+                                                              ")"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              ")"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      ")"
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  "."
+                                ]
+                              },
+                              {
+                                "r": "1163",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "code"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "1139",
+            "locator": "280:3-283:105",
+            "type": "If",
+            "condition": {
+              "localId": "1140",
+              "locator": "280:6-280:42",
+              "type": "Is",
+              "signature": [],
+              "operand": {
+                "localId": "1142",
+                "locator": "280:6-280:23",
+                "path": "medication",
+                "type": "Property",
+                "source": {
+                  "localId": "1141",
+                  "locator": "280:6-280:12",
+                  "name": "request",
+                  "type": "OperandRef"
+                }
+              },
+              "isTypeSpecifier": {
+                "localId": "1143",
+                "locator": "280:28-280:42",
+                "name": "{http://hl7.org/fhir}CodeableConcept",
+                "type": "NamedTypeSpecifier"
+              }
+            },
+            "then": {
+              "localId": "1144",
+              "locator": "281:4-281:40",
+              "strict": false,
+              "type": "As",
+              "signature": [],
+              "operand": {
+                "localId": "1146",
+                "locator": "281:4-281:21",
+                "path": "medication",
+                "type": "Property",
+                "source": {
+                  "localId": "1145",
+                  "locator": "281:4-281:10",
+                  "name": "request",
+                  "type": "OperandRef"
+                }
+              },
+              "asTypeSpecifier": {
+                "localId": "1147",
+                "locator": "281:26-281:40",
+                "name": "{http://hl7.org/fhir}CodeableConcept",
+                "type": "NamedTypeSpecifier"
+              }
+            },
+            "else": {
+              "localId": "1163",
+              "locator": "283:4-283:105",
+              "path": "code",
+              "type": "Property",
+              "source": {
+                "localId": "1148",
+                "locator": "283:4-283:100",
+                "type": "SingletonFrom",
+                "signature": [],
+                "operand": {
+                  "localId": "1162",
+                  "locator": "283:20-283:99",
+                  "type": "Query",
+                  "source": [
+                    {
+                      "localId": "1149",
+                      "locator": "283:21-283:34",
+                      "alias": "M",
+                      "expression": {
+                        "localId": "1150",
+                        "locator": "283:21-283:32",
+                        "dataType": "{http://hl7.org/fhir}Medication",
+                        "templateId": "http://hl7.org/fhir/StructureDefinition/Medication",
+                        "type": "Retrieve",
+                        "include": [],
+                        "codeFilter": [],
+                        "dateFilter": [],
+                        "otherFilter": []
+                      }
+                    }
+                  ],
+                  "let": [],
+                  "relationship": [],
+                  "where": {
+                    "localId": "1151",
+                    "locator": "283:36-283:98",
+                    "type": "Equal",
+                    "signature": [],
+                    "operand": [
+                      {
+                        "localId": "1161",
+                        "name": "ToString",
+                        "libraryName": "FHIRHelpers",
+                        "type": "FunctionRef",
+                        "signature": [],
+                        "operand": [
+                          {
+                            "localId": "1153",
+                            "locator": "283:42-283:45",
+                            "path": "id",
+                            "scope": "M",
+                            "type": "Property"
+                          }
+                        ]
+                      },
+                      {
+                        "localId": "1159",
+                        "locator": "283:49-283:98",
+                        "name": "GetId",
+                        "type": "FunctionRef",
+                        "signature": [],
+                        "operand": [
+                          {
+                            "localId": "1160",
+                            "name": "ToString",
+                            "libraryName": "FHIRHelpers",
+                            "type": "FunctionRef",
+                            "signature": [],
+                            "operand": [
+                              {
+                                "localId": "1158",
+                                "locator": "283:55-283:97",
+                                "path": "reference",
+                                "type": "Property",
+                                "source": {
+                                  "localId": "1154",
+                                  "locator": "283:55-283:87",
+                                  "strict": false,
+                                  "type": "As",
+                                  "signature": [],
+                                  "operand": {
+                                    "localId": "1156",
+                                    "locator": "283:56-283:73",
+                                    "path": "medication",
+                                    "type": "Property",
+                                    "source": {
+                                      "localId": "1155",
+                                      "locator": "283:56-283:62",
+                                      "name": "request",
+                                      "type": "OperandRef"
+                                    }
+                                  },
+                                  "asTypeSpecifier": {
+                                    "localId": "1157",
+                                    "locator": "283:78-283:86",
+                                    "name": "{http://hl7.org/fhir}Reference",
+                                    "type": "NamedTypeSpecifier"
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "operand": [
+            {
+              "localId": "1138",
+              "name": "request",
+              "operandTypeSpecifier": {
+                "localId": "1137",
+                "locator": "279:45-279:61",
+                "name": "{http://hl7.org/fhir}MedicationRequest",
+                "type": "NamedTypeSpecifier"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/test/unit/fixtures/elm/3.15.0/NotEqual.json
+++ b/test/unit/fixtures/elm/3.15.0/NotEqual.json
@@ -1,0 +1,752 @@
+{
+  "library": {
+    "localId": "0",
+    "annotation": [
+      {
+        "translatorVersion": "3.15.0",
+        "translatorOptions": "EnableAnnotations,EnableLocators",
+        "signatureLevel": "None",
+        "type": "CqlToElmInfo"
+      },
+      {
+        "message": "The function FHIRHelpers.ToString has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "type": "Annotation",
+        "s": {
+          "r": "228",
+          "s": [
+            {
+              "value": [
+                "",
+                "library Test"
+              ]
+            }
+          ]
+        }
+      }
+    ],
+    "identifier": {
+      "id": "Test"
+    },
+    "schemaIdentifier": {
+      "id": "urn:hl7-org:elm",
+      "version": "r1"
+    },
+    "usings": {
+      "def": [
+        {
+          "localId": "1",
+          "localIdentifier": "System",
+          "uri": "urn:hl7-org:elm-types:r1"
+        },
+        {
+          "localId": "206",
+          "locator": "3:1-3:26",
+          "localIdentifier": "FHIR",
+          "uri": "http://hl7.org/fhir",
+          "version": "4.0.1",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "206",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "using "
+                    ]
+                  },
+                  {
+                    "s": [
+                      {
+                        "value": [
+                          "FHIR"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " version '4.0.1'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "includes": {
+      "def": [
+        {
+          "localId": "207",
+          "locator": "5:1-5:35",
+          "localIdentifier": "FHIRHelpers",
+          "path": "FHIRHelpers",
+          "version": "4.0.1",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "207",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "include "
+                    ]
+                  },
+                  {
+                    "s": [
+                      {
+                        "value": [
+                          "FHIRHelpers"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " version ",
+                      "'4.0.1'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "localId": "208",
+          "locator": "6:1-6:64",
+          "localIdentifier": "Global",
+          "path": "MATGlobalCommonFunctions",
+          "version": "5.0.000",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "208",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "include "
+                    ]
+                  },
+                  {
+                    "s": [
+                      {
+                        "value": [
+                          "MATGlobalCommonFunctions"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " version ",
+                      "'5.0.000'",
+                      " called ",
+                      "Global"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "codeSystems": {
+      "def": [
+        {
+          "localId": "209",
+          "locator": "8:1-8:42",
+          "name": "EXAMPLE",
+          "id": "http://example.com",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "209",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "codesystem ",
+                      "\"EXAMPLE\"",
+                      ": ",
+                      "'http://example.com'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "localId": "210",
+          "locator": "9:1-9:46",
+          "name": "EXAMPLE-2",
+          "id": "http://example.com/2",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "210",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "codesystem ",
+                      "\"EXAMPLE-2\"",
+                      ": ",
+                      "'http://example.com/2'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "localId": "211",
+          "locator": "10:1-10:101",
+          "name": "ConditionClinicalStatusCodes",
+          "id": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "211",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "codesystem ",
+                      "\"ConditionClinicalStatusCodes\"",
+                      ": ",
+                      "'http://terminology.hl7.org/CodeSystem/condition-clinical'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "valueSets": {
+      "def": [
+        {
+          "localId": "212",
+          "locator": "12:1-12:48",
+          "name": "test-vs",
+          "id": "http://example.com/test-vs",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "212",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "valueset ",
+                      "\"test-vs\"",
+                      ": ",
+                      "'http://example.com/test-vs'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": []
+        }
+      ]
+    },
+    "codes": {
+      "def": [
+        {
+          "localId": "213",
+          "locator": "14:1-14:59",
+          "name": "Active",
+          "id": "active",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "213",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "code ",
+                      "\"Active\"",
+                      ": ",
+                      "'active'",
+                      " from "
+                    ]
+                  },
+                  {
+                    "r": "214",
+                    "s": [
+                      {
+                        "value": [
+                          "\"ConditionClinicalStatusCodes\""
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": {
+            "localId": "214",
+            "locator": "14:30-14:59",
+            "name": "ConditionClinicalStatusCodes"
+          }
+        },
+        {
+          "localId": "215",
+          "locator": "15:1-15:67",
+          "name": "Recurrence",
+          "id": "recurrence",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "215",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "code ",
+                      "\"Recurrence\"",
+                      ": ",
+                      "'recurrence'",
+                      " from "
+                    ]
+                  },
+                  {
+                    "r": "216",
+                    "s": [
+                      {
+                        "value": [
+                          "\"ConditionClinicalStatusCodes\""
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": {
+            "localId": "216",
+            "locator": "15:38-15:67",
+            "name": "ConditionClinicalStatusCodes"
+          }
+        },
+        {
+          "localId": "217",
+          "locator": "16:1-16:61",
+          "name": "Relapse",
+          "id": "relapse",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "217",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "code ",
+                      "\"Relapse\"",
+                      ": ",
+                      "'relapse'",
+                      " from "
+                    ]
+                  },
+                  {
+                    "r": "218",
+                    "s": [
+                      {
+                        "value": [
+                          "\"ConditionClinicalStatusCodes\""
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": {
+            "localId": "218",
+            "locator": "16:32-16:61",
+            "name": "ConditionClinicalStatusCodes"
+          }
+        }
+      ]
+    },
+    "concepts": {
+      "def": [
+        {
+          "localId": "219",
+          "locator": "18:1-18:82",
+          "name": "Condition Active",
+          "display": "Active",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "219",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "concept ",
+                      "\"Condition Active\"",
+                      ": { "
+                    ]
+                  },
+                  {
+                    "r": "220",
+                    "s": [
+                      {
+                        "value": [
+                          "\"Active\""
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      ", "
+                    ]
+                  },
+                  {
+                    "r": "221",
+                    "s": [
+                      {
+                        "value": [
+                          "\"Recurrence\""
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      ", "
+                    ]
+                  },
+                  {
+                    "r": "222",
+                    "s": [
+                      {
+                        "value": [
+                          "\"Relapse\""
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " } display ",
+                      "'Active'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "code": [
+            {
+              "localId": "220",
+              "locator": "18:31-18:38",
+              "name": "Active"
+            },
+            {
+              "localId": "221",
+              "locator": "18:41-18:52",
+              "name": "Recurrence"
+            },
+            {
+              "localId": "222",
+              "locator": "18:55-18:63",
+              "name": "Relapse"
+            }
+          ]
+        }
+      ]
+    },
+    "contexts": {
+      "def": [
+        {
+          "localId": "226",
+          "locator": "20:1-20:15",
+          "name": "Patient"
+        }
+      ]
+    },
+    "statements": {
+      "def": [
+        {
+          "localId": "224",
+          "locator": "20:1-20:15",
+          "name": "Patient",
+          "context": "Patient",
+          "expression": {
+            "localId": "225",
+            "type": "SingletonFrom",
+            "signature": [],
+            "operand": {
+              "localId": "223",
+              "locator": "20:1-20:15",
+              "dataType": "{http://hl7.org/fhir}Patient",
+              "templateId": "http://hl7.org/fhir/StructureDefinition/Patient",
+              "type": "Retrieve",
+              "include": [],
+              "codeFilter": [],
+              "dateFilter": [],
+              "otherFilter": []
+            }
+          }
+        },
+        {
+          "localId": "228",
+          "locator": "22:1-24:29",
+          "name": "Not Equal Clause",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "228",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Not Equal Clause\"",
+                      ":\n    "
+                    ]
+                  },
+                  {
+                    "r": "241",
+                    "s": [
+                      {
+                        "s": [
+                          {
+                            "r": "229",
+                            "s": [
+                              {
+                                "r": "232",
+                                "s": [
+                                  {
+                                    "r": "232",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "[",
+                                          "Condition",
+                                          ": "
+                                        ]
+                                      },
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"test-vs\""
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "]"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "C"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "\n        "
+                        ]
+                      },
+                      {
+                        "r": "240",
+                        "s": [
+                          {
+                            "value": [
+                              "where "
+                            ]
+                          },
+                          {
+                            "r": "240",
+                            "s": [
+                              {
+                                "r": "237",
+                                "s": [
+                                  {
+                                    "r": "236",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "C"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "."
+                                    ]
+                                  },
+                                  {
+                                    "r": "237",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "id"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "!=",
+                                  " "
+                                ]
+                              },
+                              {
+                                "r": "238",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "'notId'"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "241",
+            "locator": "23:5-24:29",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "229",
+                "locator": "23:5-23:28",
+                "alias": "C",
+                "expression": {
+                  "localId": "232",
+                  "locator": "23:5-23:26",
+                  "dataType": "{http://hl7.org/fhir}Condition",
+                  "templateId": "http://hl7.org/fhir/StructureDefinition/Condition",
+                  "codeProperty": "code",
+                  "codeComparator": "in",
+                  "type": "Retrieve",
+                  "codes": {
+                    "localId": "231",
+                    "locator": "23:17-23:25",
+                    "name": "test-vs",
+                    "preserve": true,
+                    "type": "ValueSetRef"
+                  },
+                  "include": [],
+                  "codeFilter": [],
+                  "dateFilter": [],
+                  "otherFilter": []
+                }
+              }
+            ],
+            "let": [],
+            "relationship": [],
+            "where": {
+              "localId": "240",
+              "locator": "24:9-24:29",
+              "type": "Not",
+              "signature": [],
+              "operand": {
+                "localId": "235",
+                "locator": "24:15-24:29",
+                "type": "Equal",
+                "signature": [],
+                "operand": [
+                  {
+                    "localId": "239",
+                    "name": "ToString",
+                    "libraryName": "FHIRHelpers",
+                    "type": "FunctionRef",
+                    "signature": [],
+                    "operand": [
+                      {
+                        "localId": "237",
+                        "locator": "24:15-24:18",
+                        "path": "id",
+                        "scope": "C",
+                        "type": "Property"
+                      }
+                    ]
+                  },
+                  {
+                    "localId": "238",
+                    "locator": "24:23-24:29",
+                    "valueType": "{urn:hl7-org:elm-types:r1}String",
+                    "value": "notId",
+                    "type": "Literal"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/test/unit/fixtures/elm/3.15.0/NotEquivalent.json
+++ b/test/unit/fixtures/elm/3.15.0/NotEquivalent.json
@@ -1,0 +1,745 @@
+{
+  "library": {
+    "localId": "0",
+    "annotation": [
+      {
+        "translatorVersion": "3.15.0",
+        "translatorOptions": "EnableAnnotations,EnableLocators",
+        "signatureLevel": "None",
+        "type": "CqlToElmInfo"
+      },
+      {
+        "type": "Annotation",
+        "s": {
+          "r": "228",
+          "s": [
+            {
+              "value": [
+                "",
+                "library Test"
+              ]
+            }
+          ]
+        }
+      }
+    ],
+    "identifier": {
+      "id": "Test"
+    },
+    "schemaIdentifier": {
+      "id": "urn:hl7-org:elm",
+      "version": "r1"
+    },
+    "usings": {
+      "def": [
+        {
+          "localId": "1",
+          "localIdentifier": "System",
+          "uri": "urn:hl7-org:elm-types:r1"
+        },
+        {
+          "localId": "206",
+          "locator": "3:1-3:26",
+          "localIdentifier": "FHIR",
+          "uri": "http://hl7.org/fhir",
+          "version": "4.0.1",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "206",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "using "
+                    ]
+                  },
+                  {
+                    "s": [
+                      {
+                        "value": [
+                          "FHIR"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " version '4.0.1'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "includes": {
+      "def": [
+        {
+          "localId": "207",
+          "locator": "5:1-5:35",
+          "localIdentifier": "FHIRHelpers",
+          "path": "FHIRHelpers",
+          "version": "4.0.1",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "207",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "include "
+                    ]
+                  },
+                  {
+                    "s": [
+                      {
+                        "value": [
+                          "FHIRHelpers"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " version ",
+                      "'4.0.1'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "localId": "208",
+          "locator": "6:1-6:64",
+          "localIdentifier": "Global",
+          "path": "MATGlobalCommonFunctions",
+          "version": "5.0.000",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "208",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "include "
+                    ]
+                  },
+                  {
+                    "s": [
+                      {
+                        "value": [
+                          "MATGlobalCommonFunctions"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " version ",
+                      "'5.0.000'",
+                      " called ",
+                      "Global"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "codeSystems": {
+      "def": [
+        {
+          "localId": "209",
+          "locator": "8:1-8:42",
+          "name": "EXAMPLE",
+          "id": "http://example.com",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "209",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "codesystem ",
+                      "\"EXAMPLE\"",
+                      ": ",
+                      "'http://example.com'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "localId": "210",
+          "locator": "9:1-9:46",
+          "name": "EXAMPLE-2",
+          "id": "http://example.com/2",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "210",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "codesystem ",
+                      "\"EXAMPLE-2\"",
+                      ": ",
+                      "'http://example.com/2'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "localId": "211",
+          "locator": "10:1-10:101",
+          "name": "ConditionClinicalStatusCodes",
+          "id": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "211",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "codesystem ",
+                      "\"ConditionClinicalStatusCodes\"",
+                      ": ",
+                      "'http://terminology.hl7.org/CodeSystem/condition-clinical'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "valueSets": {
+      "def": [
+        {
+          "localId": "212",
+          "locator": "12:1-12:48",
+          "name": "test-vs",
+          "id": "http://example.com/test-vs",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "212",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "valueset ",
+                      "\"test-vs\"",
+                      ": ",
+                      "'http://example.com/test-vs'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": []
+        }
+      ]
+    },
+    "codes": {
+      "def": [
+        {
+          "localId": "213",
+          "locator": "14:1-14:59",
+          "name": "Active",
+          "id": "active",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "213",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "code ",
+                      "\"Active\"",
+                      ": ",
+                      "'active'",
+                      " from "
+                    ]
+                  },
+                  {
+                    "r": "214",
+                    "s": [
+                      {
+                        "value": [
+                          "\"ConditionClinicalStatusCodes\""
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": {
+            "localId": "214",
+            "locator": "14:30-14:59",
+            "name": "ConditionClinicalStatusCodes"
+          }
+        },
+        {
+          "localId": "215",
+          "locator": "15:1-15:67",
+          "name": "Recurrence",
+          "id": "recurrence",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "215",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "code ",
+                      "\"Recurrence\"",
+                      ": ",
+                      "'recurrence'",
+                      " from "
+                    ]
+                  },
+                  {
+                    "r": "216",
+                    "s": [
+                      {
+                        "value": [
+                          "\"ConditionClinicalStatusCodes\""
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": {
+            "localId": "216",
+            "locator": "15:38-15:67",
+            "name": "ConditionClinicalStatusCodes"
+          }
+        },
+        {
+          "localId": "217",
+          "locator": "16:1-16:61",
+          "name": "Relapse",
+          "id": "relapse",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "217",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "code ",
+                      "\"Relapse\"",
+                      ": ",
+                      "'relapse'",
+                      " from "
+                    ]
+                  },
+                  {
+                    "r": "218",
+                    "s": [
+                      {
+                        "value": [
+                          "\"ConditionClinicalStatusCodes\""
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": {
+            "localId": "218",
+            "locator": "16:32-16:61",
+            "name": "ConditionClinicalStatusCodes"
+          }
+        }
+      ]
+    },
+    "concepts": {
+      "def": [
+        {
+          "localId": "219",
+          "locator": "18:1-18:82",
+          "name": "Condition Active",
+          "display": "Active",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "219",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "concept ",
+                      "\"Condition Active\"",
+                      ": { "
+                    ]
+                  },
+                  {
+                    "r": "220",
+                    "s": [
+                      {
+                        "value": [
+                          "\"Active\""
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      ", "
+                    ]
+                  },
+                  {
+                    "r": "221",
+                    "s": [
+                      {
+                        "value": [
+                          "\"Recurrence\""
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      ", "
+                    ]
+                  },
+                  {
+                    "r": "222",
+                    "s": [
+                      {
+                        "value": [
+                          "\"Relapse\""
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " } display ",
+                      "'Active'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "code": [
+            {
+              "localId": "220",
+              "locator": "18:31-18:38",
+              "name": "Active"
+            },
+            {
+              "localId": "221",
+              "locator": "18:41-18:52",
+              "name": "Recurrence"
+            },
+            {
+              "localId": "222",
+              "locator": "18:55-18:63",
+              "name": "Relapse"
+            }
+          ]
+        }
+      ]
+    },
+    "contexts": {
+      "def": [
+        {
+          "localId": "226",
+          "locator": "20:1-20:15",
+          "name": "Patient"
+        }
+      ]
+    },
+    "statements": {
+      "def": [
+        {
+          "localId": "224",
+          "locator": "20:1-20:15",
+          "name": "Patient",
+          "context": "Patient",
+          "expression": {
+            "localId": "225",
+            "type": "SingletonFrom",
+            "signature": [],
+            "operand": {
+              "localId": "223",
+              "locator": "20:1-20:15",
+              "dataType": "{http://hl7.org/fhir}Patient",
+              "templateId": "http://hl7.org/fhir/StructureDefinition/Patient",
+              "type": "Retrieve",
+              "include": [],
+              "codeFilter": [],
+              "dateFilter": [],
+              "otherFilter": []
+            }
+          }
+        },
+        {
+          "localId": "228",
+          "locator": "22:1-24:52",
+          "name": "Not Equivalent Clause",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "228",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Not Equivalent Clause\"",
+                      ":\n    "
+                    ]
+                  },
+                  {
+                    "r": "241",
+                    "s": [
+                      {
+                        "s": [
+                          {
+                            "r": "229",
+                            "s": [
+                              {
+                                "r": "232",
+                                "s": [
+                                  {
+                                    "r": "232",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "[",
+                                          "Condition",
+                                          ": "
+                                        ]
+                                      },
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"test-vs\""
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "]"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "C"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "\n        "
+                        ]
+                      },
+                      {
+                        "r": "240",
+                        "s": [
+                          {
+                            "value": [
+                              "where "
+                            ]
+                          },
+                          {
+                            "r": "240",
+                            "s": [
+                              {
+                                "r": "237",
+                                "s": [
+                                  {
+                                    "r": "236",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "C"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "."
+                                    ]
+                                  },
+                                  {
+                                    "r": "237",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "clinicalStatus"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "!~",
+                                  " "
+                                ]
+                              },
+                              {
+                                "r": "238",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "\"Condition Active\""
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "241",
+            "locator": "23:5-24:52",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "229",
+                "locator": "23:5-23:28",
+                "alias": "C",
+                "expression": {
+                  "localId": "232",
+                  "locator": "23:5-23:26",
+                  "dataType": "{http://hl7.org/fhir}Condition",
+                  "templateId": "http://hl7.org/fhir/StructureDefinition/Condition",
+                  "codeProperty": "code",
+                  "codeComparator": "in",
+                  "type": "Retrieve",
+                  "codes": {
+                    "localId": "231",
+                    "locator": "23:17-23:25",
+                    "name": "test-vs",
+                    "preserve": true,
+                    "type": "ValueSetRef"
+                  },
+                  "include": [],
+                  "codeFilter": [],
+                  "dateFilter": [],
+                  "otherFilter": []
+                }
+              }
+            ],
+            "let": [],
+            "relationship": [],
+            "where": {
+              "localId": "240",
+              "locator": "24:9-24:52",
+              "type": "Not",
+              "signature": [],
+              "operand": {
+                "localId": "235",
+                "locator": "24:15-24:52",
+                "type": "Equivalent",
+                "signature": [],
+                "operand": [
+                  {
+                    "localId": "239",
+                    "name": "ToConcept",
+                    "libraryName": "FHIRHelpers",
+                    "type": "FunctionRef",
+                    "signature": [],
+                    "operand": [
+                      {
+                        "localId": "237",
+                        "locator": "24:15-24:30",
+                        "path": "clinicalStatus",
+                        "scope": "C",
+                        "type": "Property"
+                      }
+                    ]
+                  },
+                  {
+                    "localId": "238",
+                    "locator": "24:35-24:52",
+                    "name": "Condition Active",
+                    "type": "ConceptRef"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/test/unit/fixtures/elm/3.15.0/NotNull.json
+++ b/test/unit/fixtures/elm/3.15.0/NotNull.json
@@ -1,0 +1,716 @@
+{
+  "library": {
+    "localId": "0",
+    "annotation": [
+      {
+        "translatorVersion": "3.15.0",
+        "translatorOptions": "EnableAnnotations,EnableLocators",
+        "signatureLevel": "None",
+        "type": "CqlToElmInfo"
+      },
+      {
+        "type": "Annotation",
+        "s": {
+          "r": "228",
+          "s": [
+            {
+              "value": [
+                "",
+                "library Test"
+              ]
+            }
+          ]
+        }
+      }
+    ],
+    "identifier": {
+      "id": "Test"
+    },
+    "schemaIdentifier": {
+      "id": "urn:hl7-org:elm",
+      "version": "r1"
+    },
+    "usings": {
+      "def": [
+        {
+          "localId": "1",
+          "localIdentifier": "System",
+          "uri": "urn:hl7-org:elm-types:r1"
+        },
+        {
+          "localId": "206",
+          "locator": "3:1-3:26",
+          "localIdentifier": "FHIR",
+          "uri": "http://hl7.org/fhir",
+          "version": "4.0.1",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "206",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "using "
+                    ]
+                  },
+                  {
+                    "s": [
+                      {
+                        "value": [
+                          "FHIR"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " version '4.0.1'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "includes": {
+      "def": [
+        {
+          "localId": "207",
+          "locator": "5:1-5:35",
+          "localIdentifier": "FHIRHelpers",
+          "path": "FHIRHelpers",
+          "version": "4.0.1",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "207",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "include "
+                    ]
+                  },
+                  {
+                    "s": [
+                      {
+                        "value": [
+                          "FHIRHelpers"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " version ",
+                      "'4.0.1'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "localId": "208",
+          "locator": "6:1-6:64",
+          "localIdentifier": "Global",
+          "path": "MATGlobalCommonFunctions",
+          "version": "5.0.000",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "208",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "include "
+                    ]
+                  },
+                  {
+                    "s": [
+                      {
+                        "value": [
+                          "MATGlobalCommonFunctions"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " version ",
+                      "'5.0.000'",
+                      " called ",
+                      "Global"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "codeSystems": {
+      "def": [
+        {
+          "localId": "209",
+          "locator": "8:1-8:42",
+          "name": "EXAMPLE",
+          "id": "http://example.com",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "209",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "codesystem ",
+                      "\"EXAMPLE\"",
+                      ": ",
+                      "'http://example.com'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "localId": "210",
+          "locator": "9:1-9:46",
+          "name": "EXAMPLE-2",
+          "id": "http://example.com/2",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "210",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "codesystem ",
+                      "\"EXAMPLE-2\"",
+                      ": ",
+                      "'http://example.com/2'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "localId": "211",
+          "locator": "10:1-10:101",
+          "name": "ConditionClinicalStatusCodes",
+          "id": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "211",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "codesystem ",
+                      "\"ConditionClinicalStatusCodes\"",
+                      ": ",
+                      "'http://terminology.hl7.org/CodeSystem/condition-clinical'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "valueSets": {
+      "def": [
+        {
+          "localId": "212",
+          "locator": "12:1-12:48",
+          "name": "test-vs",
+          "id": "http://example.com/test-vs",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "212",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "valueset ",
+                      "\"test-vs\"",
+                      ": ",
+                      "'http://example.com/test-vs'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": []
+        }
+      ]
+    },
+    "codes": {
+      "def": [
+        {
+          "localId": "213",
+          "locator": "14:1-14:59",
+          "name": "Active",
+          "id": "active",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "213",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "code ",
+                      "\"Active\"",
+                      ": ",
+                      "'active'",
+                      " from "
+                    ]
+                  },
+                  {
+                    "r": "214",
+                    "s": [
+                      {
+                        "value": [
+                          "\"ConditionClinicalStatusCodes\""
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": {
+            "localId": "214",
+            "locator": "14:30-14:59",
+            "name": "ConditionClinicalStatusCodes"
+          }
+        },
+        {
+          "localId": "215",
+          "locator": "15:1-15:67",
+          "name": "Recurrence",
+          "id": "recurrence",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "215",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "code ",
+                      "\"Recurrence\"",
+                      ": ",
+                      "'recurrence'",
+                      " from "
+                    ]
+                  },
+                  {
+                    "r": "216",
+                    "s": [
+                      {
+                        "value": [
+                          "\"ConditionClinicalStatusCodes\""
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": {
+            "localId": "216",
+            "locator": "15:38-15:67",
+            "name": "ConditionClinicalStatusCodes"
+          }
+        },
+        {
+          "localId": "217",
+          "locator": "16:1-16:61",
+          "name": "Relapse",
+          "id": "relapse",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "217",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "code ",
+                      "\"Relapse\"",
+                      ": ",
+                      "'relapse'",
+                      " from "
+                    ]
+                  },
+                  {
+                    "r": "218",
+                    "s": [
+                      {
+                        "value": [
+                          "\"ConditionClinicalStatusCodes\""
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": {
+            "localId": "218",
+            "locator": "16:32-16:61",
+            "name": "ConditionClinicalStatusCodes"
+          }
+        }
+      ]
+    },
+    "concepts": {
+      "def": [
+        {
+          "localId": "219",
+          "locator": "18:1-18:82",
+          "name": "Condition Active",
+          "display": "Active",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "219",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "concept ",
+                      "\"Condition Active\"",
+                      ": { "
+                    ]
+                  },
+                  {
+                    "r": "220",
+                    "s": [
+                      {
+                        "value": [
+                          "\"Active\""
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      ", "
+                    ]
+                  },
+                  {
+                    "r": "221",
+                    "s": [
+                      {
+                        "value": [
+                          "\"Recurrence\""
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      ", "
+                    ]
+                  },
+                  {
+                    "r": "222",
+                    "s": [
+                      {
+                        "value": [
+                          "\"Relapse\""
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " } display ",
+                      "'Active'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "code": [
+            {
+              "localId": "220",
+              "locator": "18:31-18:38",
+              "name": "Active"
+            },
+            {
+              "localId": "221",
+              "locator": "18:41-18:52",
+              "name": "Recurrence"
+            },
+            {
+              "localId": "222",
+              "locator": "18:55-18:63",
+              "name": "Relapse"
+            }
+          ]
+        }
+      ]
+    },
+    "contexts": {
+      "def": [
+        {
+          "localId": "226",
+          "locator": "20:1-20:15",
+          "name": "Patient"
+        }
+      ]
+    },
+    "statements": {
+      "def": [
+        {
+          "localId": "224",
+          "locator": "20:1-20:15",
+          "name": "Patient",
+          "context": "Patient",
+          "expression": {
+            "localId": "225",
+            "type": "SingletonFrom",
+            "signature": [],
+            "operand": {
+              "localId": "223",
+              "locator": "20:1-20:15",
+              "dataType": "{http://hl7.org/fhir}Patient",
+              "templateId": "http://hl7.org/fhir/StructureDefinition/Patient",
+              "type": "Retrieve",
+              "include": [],
+              "codeFilter": [],
+              "dateFilter": [],
+              "otherFilter": []
+            }
+          }
+        },
+        {
+          "localId": "228",
+          "locator": "22:1-24:30",
+          "name": "Not Null Clause",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "228",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Not Null Clause\"",
+                      ":\n    "
+                    ]
+                  },
+                  {
+                    "r": "239",
+                    "s": [
+                      {
+                        "s": [
+                          {
+                            "r": "229",
+                            "s": [
+                              {
+                                "r": "232",
+                                "s": [
+                                  {
+                                    "r": "232",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "[",
+                                          "Condition",
+                                          ": "
+                                        ]
+                                      },
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"test-vs\""
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "]"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "C"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "\n        "
+                        ]
+                      },
+                      {
+                        "r": "238",
+                        "s": [
+                          {
+                            "value": [
+                              "where "
+                            ]
+                          },
+                          {
+                            "r": "238",
+                            "s": [
+                              {
+                                "r": "236",
+                                "s": [
+                                  {
+                                    "r": "235",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "C"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "."
+                                    ]
+                                  },
+                                  {
+                                    "r": "236",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "id"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " is not null"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "239",
+            "locator": "23:5-24:30",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "229",
+                "locator": "23:5-23:28",
+                "alias": "C",
+                "expression": {
+                  "localId": "232",
+                  "locator": "23:5-23:26",
+                  "dataType": "{http://hl7.org/fhir}Condition",
+                  "templateId": "http://hl7.org/fhir/StructureDefinition/Condition",
+                  "codeProperty": "code",
+                  "codeComparator": "in",
+                  "type": "Retrieve",
+                  "codes": {
+                    "localId": "231",
+                    "locator": "23:17-23:25",
+                    "name": "test-vs",
+                    "preserve": true,
+                    "type": "ValueSetRef"
+                  },
+                  "include": [],
+                  "codeFilter": [],
+                  "dateFilter": [],
+                  "otherFilter": []
+                }
+              }
+            ],
+            "let": [],
+            "relationship": [],
+            "where": {
+              "localId": "238",
+              "locator": "24:9-24:30",
+              "type": "Not",
+              "signature": [],
+              "operand": {
+                "localId": "237",
+                "locator": "24:15-24:30",
+                "type": "IsNull",
+                "signature": [],
+                "operand": {
+                  "localId": "236",
+                  "locator": "24:15-24:18",
+                  "path": "id",
+                  "scope": "C",
+                  "type": "Property"
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/test/unit/fixtures/elm/3.15.0/QICoreQuery.json
+++ b/test/unit/fixtures/elm/3.15.0/QICoreQuery.json
@@ -1,0 +1,418 @@
+{
+  "library": {
+    "localId": "0",
+    "annotation": [
+      {
+        "translatorVersion": "3.15.0",
+        "translatorOptions": "EnableAnnotations,EnableLocators",
+        "signatureLevel": "None",
+        "type": "CqlToElmInfo"
+      },
+      {
+        "type": "Annotation",
+        "s": {
+          "r": "215",
+          "s": [
+            {
+              "value": [
+                "",
+                "library QICoreQuery"
+              ]
+            }
+          ]
+        }
+      }
+    ],
+    "identifier": {
+      "id": "QICoreQuery"
+    },
+    "schemaIdentifier": {
+      "id": "urn:hl7-org:elm",
+      "version": "r1"
+    },
+    "usings": {
+      "def": [
+        {
+          "localId": "1",
+          "localIdentifier": "System",
+          "uri": "urn:hl7-org:elm-types:r1"
+        },
+        {
+          "localId": "206",
+          "locator": "3:1-3:28",
+          "localIdentifier": "QICore",
+          "uri": "http://hl7.org/fhir",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "206",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "using "
+                    ]
+                  },
+                  {
+                    "s": [
+                      {
+                        "value": [
+                          "QICore"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " version '4.1.1'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "includes": {
+      "def": [
+        {
+          "localId": "207",
+          "locator": "5:1-5:35",
+          "localIdentifier": "FHIRHelpers",
+          "path": "FHIRHelpers",
+          "version": "4.0.1",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "207",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "include "
+                    ]
+                  },
+                  {
+                    "s": [
+                      {
+                        "value": [
+                          "FHIRHelpers"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " version ",
+                      "'4.0.1'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "codeSystems": {
+      "def": [
+        {
+          "localId": "208",
+          "locator": "7:1-7:42",
+          "name": "EXAMPLE",
+          "id": "http://example.com",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "208",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "codesystem ",
+                      "\"EXAMPLE\"",
+                      ": ",
+                      "'http://example.com'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "valueSets": {
+      "def": [
+        {
+          "localId": "209",
+          "locator": "9:1-9:48",
+          "name": "test-vs",
+          "id": "http://example.com/test-vs",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "209",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "valueset ",
+                      "\"test-vs\"",
+                      ": ",
+                      "'http://example.com/test-vs'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": []
+        }
+      ]
+    },
+    "contexts": {
+      "def": [
+        {
+          "localId": "213",
+          "locator": "11:1-11:15",
+          "name": "Patient"
+        }
+      ]
+    },
+    "statements": {
+      "def": [
+        {
+          "localId": "211",
+          "locator": "11:1-11:15",
+          "name": "Patient",
+          "context": "Patient",
+          "expression": {
+            "localId": "212",
+            "type": "SingletonFrom",
+            "signature": [],
+            "operand": {
+              "localId": "210",
+              "locator": "11:1-11:15",
+              "dataType": "{http://hl7.org/fhir}Patient",
+              "templateId": "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient",
+              "type": "Retrieve",
+              "include": [],
+              "codeFilter": [],
+              "dateFilter": [],
+              "otherFilter": []
+            }
+          }
+        },
+        {
+          "localId": "215",
+          "locator": "13:1-14:75",
+          "name": "Query",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "215",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Query\"",
+                      ":\n    "
+                    ]
+                  },
+                  {
+                    "r": "227",
+                    "s": [
+                      {
+                        "s": [
+                          {
+                            "r": "216",
+                            "s": [
+                              {
+                                "r": "217",
+                                "s": [
+                                  {
+                                    "r": "217",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "[",
+                                          "Encounter",
+                                          "]"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "ValidEncounter"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          " "
+                        ]
+                      },
+                      {
+                        "r": "226",
+                        "s": [
+                          {
+                            "value": [
+                              "where "
+                            ]
+                          },
+                          {
+                            "r": "226",
+                            "s": [
+                              {
+                                "r": "220",
+                                "s": [
+                                  {
+                                    "r": "218",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "ValidEncounter"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "."
+                                    ]
+                                  },
+                                  {
+                                    "r": "220",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "reasonCode"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " in "
+                                ]
+                              },
+                              {
+                                "r": "225",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "\"test-vs\""
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "227",
+            "locator": "14:5-14:75",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "216",
+                "locator": "14:5-14:30",
+                "alias": "ValidEncounter",
+                "expression": {
+                  "localId": "217",
+                  "locator": "14:5-14:15",
+                  "dataType": "{http://hl7.org/fhir}Encounter",
+                  "templateId": "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter",
+                  "type": "Retrieve",
+                  "include": [],
+                  "codeFilter": [],
+                  "dateFilter": [],
+                  "otherFilter": []
+                }
+              }
+            ],
+            "let": [],
+            "relationship": [],
+            "where": {
+              "localId": "226",
+              "locator": "14:32-14:75",
+              "type": "AnyInValueSet",
+              "signature": [],
+              "codes": {
+                "localId": "220",
+                "locator": "14:38-14:62",
+                "type": "Query",
+                "source": [
+                  {
+                    "localId": "221",
+                    "alias": "$this",
+                    "expression": {
+                      "localId": "219",
+                      "path": "reasonCode",
+                      "scope": "ValidEncounter",
+                      "type": "Property"
+                    }
+                  }
+                ],
+                "let": [],
+                "relationship": [],
+                "return": {
+                  "localId": "224",
+                  "distinct": false,
+                  "expression": {
+                    "localId": "222",
+                    "name": "ToConcept",
+                    "libraryName": "FHIRHelpers",
+                    "type": "FunctionRef",
+                    "signature": [],
+                    "operand": [
+                      {
+                        "localId": "223",
+                        "name": "$this",
+                        "type": "AliasRef"
+                      }
+                    ]
+                  }
+                }
+              },
+              "valueset": {
+                "localId": "225",
+                "locator": "14:67-14:75",
+                "name": "test-vs",
+                "preserve": true
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/test/unit/fixtures/elm/3.15.0/SimpleQueries.json
+++ b/test/unit/fixtures/elm/3.15.0/SimpleQueries.json
@@ -1,0 +1,1882 @@
+{
+  "library": {
+    "localId": "0",
+    "annotation": [
+      {
+        "translatorVersion": "3.15.0",
+        "translatorOptions": "EnableAnnotations,EnableLocators",
+        "signatureLevel": "None",
+        "type": "CqlToElmInfo"
+      },
+      {
+        "message": "The function FHIRHelpers.ToString has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToString has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToString has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToString has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "type": "Annotation",
+        "s": {
+          "r": "320",
+          "s": [
+            {
+              "value": [
+                "",
+                "library SimpleQueries version '0.0.1'"
+              ]
+            }
+          ]
+        }
+      }
+    ],
+    "identifier": {
+      "id": "SimpleQueries",
+      "version": "0.0.1"
+    },
+    "schemaIdentifier": {
+      "id": "urn:hl7-org:elm",
+      "version": "r1"
+    },
+    "usings": {
+      "def": [
+        {
+          "localId": "1",
+          "localIdentifier": "System",
+          "uri": "urn:hl7-org:elm-types:r1"
+        },
+        {
+          "localId": "206",
+          "locator": "3:1-3:26",
+          "localIdentifier": "FHIR",
+          "uri": "http://hl7.org/fhir",
+          "version": "4.0.1",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "206",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "using "
+                    ]
+                  },
+                  {
+                    "s": [
+                      {
+                        "value": [
+                          "FHIR"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " version '4.0.1'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "includes": {
+      "def": [
+        {
+          "localId": "207",
+          "locator": "5:1-5:35",
+          "localIdentifier": "FHIRHelpers",
+          "path": "FHIRHelpers",
+          "version": "4.0.1",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "207",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "include "
+                    ]
+                  },
+                  {
+                    "s": [
+                      {
+                        "value": [
+                          "FHIRHelpers"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " version ",
+                      "'4.0.1'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "localId": "208",
+          "locator": "6:1-6:33",
+          "localIdentifier": "SimpleDep",
+          "path": "SimpleDep",
+          "version": "0.0.1",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "208",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "include "
+                    ]
+                  },
+                  {
+                    "s": [
+                      {
+                        "value": [
+                          "SimpleDep"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " version ",
+                      "'0.0.1'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "codeSystems": {
+      "def": [
+        {
+          "localId": "209",
+          "locator": "8:1-8:42",
+          "name": "EXAMPLE",
+          "id": "http://example.com",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "209",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "codesystem ",
+                      "\"EXAMPLE\"",
+                      ": ",
+                      "'http://example.com'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "localId": "210",
+          "locator": "9:1-9:46",
+          "name": "EXAMPLE-2",
+          "id": "http://example.com/2",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "210",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "codesystem ",
+                      "\"EXAMPLE-2\"",
+                      ": ",
+                      "'http://example.com/2'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "valueSets": {
+      "def": [
+        {
+          "localId": "211",
+          "locator": "11:1-11:48",
+          "name": "test-vs",
+          "id": "http://example.com/test-vs",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "211",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "valueset ",
+                      "\"test-vs\"",
+                      ": ",
+                      "'http://example.com/test-vs'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": []
+        }
+      ]
+    },
+    "codes": {
+      "def": [
+        {
+          "localId": "212",
+          "locator": "13:1-13:39",
+          "name": "test-code",
+          "id": "test",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "212",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "code ",
+                      "\"test-code\"",
+                      ": ",
+                      "'test'",
+                      " from "
+                    ]
+                  },
+                  {
+                    "r": "213",
+                    "s": [
+                      {
+                        "value": [
+                          "\"EXAMPLE\""
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": {
+            "localId": "213",
+            "locator": "13:31-13:39",
+            "name": "EXAMPLE"
+          }
+        },
+        {
+          "localId": "214",
+          "locator": "14:1-14:45",
+          "name": "test-code-2",
+          "id": "test-2",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "214",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "code ",
+                      "\"test-code-2\"",
+                      ": ",
+                      "'test-2'",
+                      " from "
+                    ]
+                  },
+                  {
+                    "r": "215",
+                    "s": [
+                      {
+                        "value": [
+                          "\"EXAMPLE-2\""
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": {
+            "localId": "215",
+            "locator": "14:35-14:45",
+            "name": "EXAMPLE-2"
+          }
+        }
+      ]
+    },
+    "concepts": {
+      "def": [
+        {
+          "localId": "216",
+          "locator": "16:1-16:77",
+          "name": "test-concept",
+          "display": "test-concept",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "216",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "concept ",
+                      "\"test-concept\"",
+                      ": { "
+                    ]
+                  },
+                  {
+                    "r": "217",
+                    "s": [
+                      {
+                        "value": [
+                          "\"test-code\""
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      ", "
+                    ]
+                  },
+                  {
+                    "r": "218",
+                    "s": [
+                      {
+                        "value": [
+                          "\"test-code-2\""
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " } display ",
+                      "'test-concept'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "code": [
+            {
+              "localId": "217",
+              "locator": "16:27-16:37",
+              "name": "test-code"
+            },
+            {
+              "localId": "218",
+              "locator": "16:40-16:52",
+              "name": "test-code-2"
+            }
+          ]
+        }
+      ]
+    },
+    "statements": {
+      "def": [
+        {
+          "localId": "220",
+          "locator": "18:1-19:24",
+          "name": "SimpleVSRetrieve",
+          "context": "Unfiltered",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "220",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"SimpleVSRetrieve\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "223",
+                    "s": [
+                      {
+                        "value": [
+                          "[",
+                          "Condition",
+                          ": "
+                        ]
+                      },
+                      {
+                        "s": [
+                          {
+                            "value": [
+                              "\"test-vs\""
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "]"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "223",
+            "locator": "19:3-19:24",
+            "dataType": "{http://hl7.org/fhir}Condition",
+            "templateId": "http://hl7.org/fhir/StructureDefinition/Condition",
+            "codeProperty": "code",
+            "codeComparator": "in",
+            "type": "Retrieve",
+            "codes": {
+              "localId": "222",
+              "locator": "19:15-19:23",
+              "name": "test-vs",
+              "preserve": true,
+              "type": "ValueSetRef"
+            },
+            "include": [],
+            "codeFilter": [],
+            "dateFilter": [],
+            "otherFilter": []
+          }
+        },
+        {
+          "localId": "227",
+          "locator": "21:1-22:26",
+          "name": "SimpleCodeRetrieve",
+          "context": "Unfiltered",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "227",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"SimpleCodeRetrieve\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "230",
+                    "s": [
+                      {
+                        "value": [
+                          "[",
+                          "Procedure",
+                          ": "
+                        ]
+                      },
+                      {
+                        "s": [
+                          {
+                            "value": [
+                              "\"test-code\""
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "]"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "230",
+            "locator": "22:3-22:26",
+            "dataType": "{http://hl7.org/fhir}Procedure",
+            "templateId": "http://hl7.org/fhir/StructureDefinition/Procedure",
+            "codeProperty": "code",
+            "codeComparator": "~",
+            "type": "Retrieve",
+            "codes": {
+              "localId": "235",
+              "type": "ToList",
+              "signature": [],
+              "operand": {
+                "localId": "229",
+                "locator": "22:15-22:25",
+                "name": "test-code",
+                "type": "CodeRef"
+              }
+            },
+            "include": [],
+            "codeFilter": [],
+            "dateFilter": [],
+            "otherFilter": []
+          }
+        },
+        {
+          "localId": "237",
+          "locator": "24:1-25:46",
+          "name": "SimpleQuery",
+          "context": "Unfiltered",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "237",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"SimpleQuery\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "249",
+                    "s": [
+                      {
+                        "s": [
+                          {
+                            "r": "238",
+                            "s": [
+                              {
+                                "r": "241",
+                                "s": [
+                                  {
+                                    "r": "241",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "[",
+                                          "Condition",
+                                          ": "
+                                        ]
+                                      },
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"test-vs\""
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "]"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "C"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          " "
+                        ]
+                      },
+                      {
+                        "r": "244",
+                        "s": [
+                          {
+                            "value": [
+                              "where "
+                            ]
+                          },
+                          {
+                            "r": "244",
+                            "s": [
+                              {
+                                "r": "246",
+                                "s": [
+                                  {
+                                    "r": "245",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "C"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "."
+                                    ]
+                                  },
+                                  {
+                                    "r": "246",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "id"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "=",
+                                  " "
+                                ]
+                              },
+                              {
+                                "r": "247",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "'test'"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "249",
+            "locator": "25:3-25:46",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "238",
+                "locator": "25:3-25:26",
+                "alias": "C",
+                "expression": {
+                  "localId": "241",
+                  "locator": "25:3-25:24",
+                  "dataType": "{http://hl7.org/fhir}Condition",
+                  "templateId": "http://hl7.org/fhir/StructureDefinition/Condition",
+                  "codeProperty": "code",
+                  "codeComparator": "in",
+                  "type": "Retrieve",
+                  "codes": {
+                    "localId": "240",
+                    "locator": "25:15-25:23",
+                    "name": "test-vs",
+                    "preserve": true,
+                    "type": "ValueSetRef"
+                  },
+                  "include": [],
+                  "codeFilter": [],
+                  "dateFilter": [],
+                  "otherFilter": []
+                }
+              }
+            ],
+            "let": [],
+            "relationship": [],
+            "where": {
+              "localId": "244",
+              "locator": "25:28-25:46",
+              "type": "Equal",
+              "signature": [],
+              "operand": [
+                {
+                  "localId": "248",
+                  "name": "ToString",
+                  "libraryName": "FHIRHelpers",
+                  "type": "FunctionRef",
+                  "signature": [],
+                  "operand": [
+                    {
+                      "localId": "246",
+                      "locator": "25:34-25:37",
+                      "path": "id",
+                      "scope": "C",
+                      "type": "Property"
+                    }
+                  ]
+                },
+                {
+                  "localId": "247",
+                  "locator": "25:41-25:46",
+                  "valueType": "{urn:hl7-org:elm-types:r1}String",
+                  "value": "test",
+                  "type": "Literal"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "localId": "251",
+          "locator": "27:1-28:20",
+          "name": "SimpleExpressionRef",
+          "context": "Unfiltered",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "251",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"SimpleExpressionRef\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "252",
+                    "s": [
+                      {
+                        "value": [
+                          "\"SimpleVSRetrieve\""
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "252",
+            "locator": "28:3-28:20",
+            "name": "SimpleVSRetrieve",
+            "type": "ExpressionRef"
+          }
+        },
+        {
+          "localId": "254",
+          "locator": "30:1-31:30",
+          "name": "DepExpressionRef",
+          "context": "Unfiltered",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "254",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"DepExpressionRef\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "256",
+                    "s": [
+                      {
+                        "r": "255",
+                        "s": [
+                          {
+                            "value": [
+                              "\"SimpleDep\""
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "."
+                        ]
+                      },
+                      {
+                        "r": "256",
+                        "s": [
+                          {
+                            "value": [
+                              "\"SimpleRetrieve\""
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "256",
+            "locator": "31:3-31:30",
+            "name": "SimpleRetrieve",
+            "libraryName": "SimpleDep",
+            "type": "ExpressionRef"
+          }
+        },
+        {
+          "localId": "258",
+          "locator": "33:1-34:29",
+          "name": "SimpleConceptRetrieve",
+          "context": "Unfiltered",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "258",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"SimpleConceptRetrieve\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "261",
+                    "s": [
+                      {
+                        "value": [
+                          "[",
+                          "Procedure",
+                          ": "
+                        ]
+                      },
+                      {
+                        "s": [
+                          {
+                            "value": [
+                              "\"test-concept\""
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "]"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "261",
+            "locator": "34:3-34:29",
+            "dataType": "{http://hl7.org/fhir}Procedure",
+            "templateId": "http://hl7.org/fhir/StructureDefinition/Procedure",
+            "codeProperty": "code",
+            "codeComparator": "~",
+            "type": "Retrieve",
+            "codes": {
+              "localId": "265",
+              "path": "codes",
+              "type": "Property",
+              "source": {
+                "localId": "260",
+                "locator": "34:15-34:28",
+                "name": "test-concept",
+                "type": "ConceptRef"
+              }
+            },
+            "include": [],
+            "codeFilter": [],
+            "dateFilter": [],
+            "otherFilter": []
+          }
+        },
+        {
+          "localId": "273",
+          "locator": "43:1-45:32",
+          "name": "Retrieve Query",
+          "context": "Unfiltered",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "273",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Retrieve Query\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "285",
+                    "s": [
+                      {
+                        "s": [
+                          {
+                            "r": "274",
+                            "s": [
+                              {
+                                "r": "277",
+                                "s": [
+                                  {
+                                    "r": "277",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "[",
+                                          "Procedure",
+                                          ": "
+                                        ]
+                                      },
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"test-vs\""
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "]"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "P"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "\n    "
+                        ]
+                      },
+                      {
+                        "r": "280",
+                        "s": [
+                          {
+                            "value": [
+                              "where "
+                            ]
+                          },
+                          {
+                            "r": "280",
+                            "s": [
+                              {
+                                "r": "282",
+                                "s": [
+                                  {
+                                    "r": "281",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "P"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "."
+                                    ]
+                                  },
+                                  {
+                                    "r": "282",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "status"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "=",
+                                  " "
+                                ]
+                              },
+                              {
+                                "r": "283",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "'completed'"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "285",
+            "locator": "44:3-45:32",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "274",
+                "locator": "44:3-44:26",
+                "alias": "P",
+                "expression": {
+                  "localId": "277",
+                  "locator": "44:3-44:24",
+                  "dataType": "{http://hl7.org/fhir}Procedure",
+                  "templateId": "http://hl7.org/fhir/StructureDefinition/Procedure",
+                  "codeProperty": "code",
+                  "codeComparator": "in",
+                  "type": "Retrieve",
+                  "codes": {
+                    "localId": "276",
+                    "locator": "44:15-44:23",
+                    "name": "test-vs",
+                    "preserve": true,
+                    "type": "ValueSetRef"
+                  },
+                  "include": [],
+                  "codeFilter": [],
+                  "dateFilter": [],
+                  "otherFilter": []
+                }
+              }
+            ],
+            "let": [],
+            "relationship": [],
+            "where": {
+              "localId": "280",
+              "locator": "45:5-45:32",
+              "type": "Equal",
+              "signature": [],
+              "operand": [
+                {
+                  "localId": "284",
+                  "name": "ToString",
+                  "libraryName": "FHIRHelpers",
+                  "type": "FunctionRef",
+                  "signature": [],
+                  "operand": [
+                    {
+                      "localId": "282",
+                      "locator": "45:11-45:18",
+                      "path": "status",
+                      "scope": "P",
+                      "type": "Property"
+                    }
+                  ]
+                },
+                {
+                  "localId": "283",
+                  "locator": "45:22-45:32",
+                  "valueType": "{urn:hl7-org:elm-types:r1}String",
+                  "value": "completed",
+                  "type": "Literal"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "localId": "270",
+          "locator": "39:1-41:31",
+          "name": "Further Filtering Query",
+          "context": "Unfiltered",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "270",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Further Filtering Query\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "291",
+                    "s": [
+                      {
+                        "s": [
+                          {
+                            "r": "271",
+                            "s": [
+                              {
+                                "r": "286",
+                                "s": [
+                                  {
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "\"Retrieve Query\""
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "P"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "\n    "
+                        ]
+                      },
+                      {
+                        "r": "290",
+                        "s": [
+                          {
+                            "value": [
+                              "where "
+                            ]
+                          },
+                          {
+                            "r": "290",
+                            "s": [
+                              {
+                                "r": "288",
+                                "s": [
+                                  {
+                                    "r": "287",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "P"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "."
+                                    ]
+                                  },
+                                  {
+                                    "r": "288",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "outcome"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " is not null"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "291",
+            "locator": "40:3-41:31",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "271",
+                "locator": "40:3-40:20",
+                "alias": "P",
+                "expression": {
+                  "localId": "286",
+                  "locator": "40:3-40:18",
+                  "name": "Retrieve Query",
+                  "type": "ExpressionRef"
+                }
+              }
+            ],
+            "let": [],
+            "relationship": [],
+            "where": {
+              "localId": "290",
+              "locator": "41:5-41:31",
+              "type": "Not",
+              "signature": [],
+              "operand": {
+                "localId": "289",
+                "locator": "41:11-41:31",
+                "type": "IsNull",
+                "signature": [],
+                "operand": {
+                  "localId": "288",
+                  "locator": "41:11-41:19",
+                  "path": "outcome",
+                  "scope": "P",
+                  "type": "Property"
+                }
+              }
+            }
+          }
+        },
+        {
+          "localId": "267",
+          "locator": "36:1-37:34",
+          "name": "Use Further Filtering",
+          "context": "Unfiltered",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "267",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Use Further Filtering\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "268",
+                    "s": [
+                      {
+                        "value": [
+                          "exists "
+                        ]
+                      },
+                      {
+                        "r": "292",
+                        "s": [
+                          {
+                            "value": [
+                              "\"Further Filtering Query\""
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "268",
+            "locator": "37:3-37:34",
+            "type": "Exists",
+            "signature": [],
+            "operand": {
+              "localId": "292",
+              "locator": "37:10-37:34",
+              "name": "Further Filtering Query",
+              "type": "ExpressionRef"
+            }
+          }
+        },
+        {
+          "localId": "294",
+          "locator": "47:1-49:32",
+          "name": "Retrieve Using ValueSet In Dependency",
+          "context": "Unfiltered",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "294",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Retrieve Using ValueSet In Dependency\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "307",
+                    "s": [
+                      {
+                        "s": [
+                          {
+                            "r": "295",
+                            "s": [
+                              {
+                                "r": "299",
+                                "s": [
+                                  {
+                                    "r": "299",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "[",
+                                          "Procedure",
+                                          ": "
+                                        ]
+                                      },
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "SimpleDep",
+                                              ".",
+                                              "\"test-vs-2\""
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "]"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "P"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "\n    "
+                        ]
+                      },
+                      {
+                        "r": "302",
+                        "s": [
+                          {
+                            "value": [
+                              "where "
+                            ]
+                          },
+                          {
+                            "r": "302",
+                            "s": [
+                              {
+                                "r": "304",
+                                "s": [
+                                  {
+                                    "r": "303",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "P"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "."
+                                    ]
+                                  },
+                                  {
+                                    "r": "304",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "status"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "=",
+                                  " "
+                                ]
+                              },
+                              {
+                                "r": "305",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "'completed'"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "307",
+            "locator": "48:3-49:32",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "295",
+                "locator": "48:3-48:38",
+                "alias": "P",
+                "expression": {
+                  "localId": "299",
+                  "locator": "48:3-48:36",
+                  "dataType": "{http://hl7.org/fhir}Procedure",
+                  "templateId": "http://hl7.org/fhir/StructureDefinition/Procedure",
+                  "codeProperty": "code",
+                  "codeComparator": "in",
+                  "type": "Retrieve",
+                  "codes": {
+                    "localId": "298",
+                    "locator": "48:15-48:35",
+                    "name": "test-vs-2",
+                    "libraryName": "SimpleDep",
+                    "preserve": true,
+                    "type": "ValueSetRef"
+                  },
+                  "include": [],
+                  "codeFilter": [],
+                  "dateFilter": [],
+                  "otherFilter": []
+                }
+              }
+            ],
+            "let": [],
+            "relationship": [],
+            "where": {
+              "localId": "302",
+              "locator": "49:5-49:32",
+              "type": "Equal",
+              "signature": [],
+              "operand": [
+                {
+                  "localId": "306",
+                  "name": "ToString",
+                  "libraryName": "FHIRHelpers",
+                  "type": "FunctionRef",
+                  "signature": [],
+                  "operand": [
+                    {
+                      "localId": "304",
+                      "locator": "49:11-49:18",
+                      "path": "status",
+                      "scope": "P",
+                      "type": "Property"
+                    }
+                  ]
+                },
+                {
+                  "localId": "305",
+                  "locator": "49:22-49:32",
+                  "valueType": "{urn:hl7-org:elm-types:r1}String",
+                  "value": "completed",
+                  "type": "Literal"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "localId": "309",
+          "locator": "51:1-53:32",
+          "name": "Nested Query From Another Library",
+          "context": "Unfiltered",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "309",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Nested Query From Another Library\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "318",
+                    "s": [
+                      {
+                        "s": [
+                          {
+                            "r": "310",
+                            "s": [
+                              {
+                                "r": "312",
+                                "s": [
+                                  {
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "SimpleDep",
+                                          ".",
+                                          "\"SimpleQuery\""
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "S"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "\n    "
+                        ]
+                      },
+                      {
+                        "r": "313",
+                        "s": [
+                          {
+                            "value": [
+                              "where "
+                            ]
+                          },
+                          {
+                            "r": "313",
+                            "s": [
+                              {
+                                "r": "315",
+                                "s": [
+                                  {
+                                    "r": "314",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "S"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "."
+                                    ]
+                                  },
+                                  {
+                                    "r": "315",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "status"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "=",
+                                  " "
+                                ]
+                              },
+                              {
+                                "r": "316",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "'completed'"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "318",
+            "locator": "52:3-53:32",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "310",
+                "locator": "52:3-52:27",
+                "alias": "S",
+                "expression": {
+                  "localId": "312",
+                  "locator": "52:3-52:25",
+                  "name": "SimpleQuery",
+                  "libraryName": "SimpleDep",
+                  "type": "ExpressionRef"
+                }
+              }
+            ],
+            "let": [],
+            "relationship": [],
+            "where": {
+              "localId": "313",
+              "locator": "53:5-53:32",
+              "type": "Equal",
+              "signature": [],
+              "operand": [
+                {
+                  "localId": "317",
+                  "name": "ToString",
+                  "libraryName": "FHIRHelpers",
+                  "type": "FunctionRef",
+                  "signature": [],
+                  "operand": [
+                    {
+                      "localId": "315",
+                      "locator": "53:11-53:18",
+                      "path": "status",
+                      "scope": "S",
+                      "type": "Property"
+                    }
+                  ]
+                },
+                {
+                  "localId": "316",
+                  "locator": "53:22-53:32",
+                  "valueType": "{urn:hl7-org:elm-types:r1}String",
+                  "value": "completed",
+                  "type": "Literal"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "localId": "320",
+          "locator": "55:1-56:42",
+          "name": "Last of Referenced Query is Null",
+          "context": "Unfiltered",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "320",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Last of Referenced Query is Null\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "326",
+                    "s": [
+                      {
+                        "r": "325",
+                        "s": [
+                          {
+                            "r": "324",
+                            "s": [
+                              {
+                                "value": [
+                                  "Last",
+                                  "("
+                                ]
+                              },
+                              {
+                                "r": "321",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "\"SimpleQuery\""
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  ")"
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              "."
+                            ]
+                          },
+                          {
+                            "r": "325",
+                            "s": [
+                              {
+                                "value": [
+                                  "recordedDate"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          " is null"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "326",
+            "locator": "56:3-56:42",
+            "type": "IsNull",
+            "signature": [],
+            "operand": {
+              "localId": "325",
+              "locator": "56:3-56:34",
+              "path": "recordedDate",
+              "type": "Property",
+              "source": {
+                "localId": "324",
+                "locator": "56:3-56:21",
+                "type": "Last",
+                "signature": [],
+                "source": {
+                  "localId": "321",
+                  "locator": "56:8-56:20",
+                  "name": "SimpleQuery",
+                  "type": "ExpressionRef"
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/test/unit/fixtures/elm/3.15.0/SimpleQueriesDependency.json
+++ b/test/unit/fixtures/elm/3.15.0/SimpleQueriesDependency.json
@@ -1,0 +1,443 @@
+{
+  "library": {
+    "localId": "0",
+    "annotation": [
+      {
+        "translatorVersion": "3.15.0",
+        "translatorOptions": "EnableAnnotations,EnableLocators",
+        "signatureLevel": "None",
+        "type": "CqlToElmInfo"
+      },
+      {
+        "message": "The function FHIRHelpers.ToString has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "type": "Annotation",
+        "s": {
+          "r": "217",
+          "s": [
+            {
+              "value": [
+                "",
+                "library SimpleDep version '0.0.1'"
+              ]
+            }
+          ]
+        }
+      }
+    ],
+    "identifier": {
+      "id": "SimpleDep",
+      "version": "0.0.1"
+    },
+    "schemaIdentifier": {
+      "id": "urn:hl7-org:elm",
+      "version": "r1"
+    },
+    "usings": {
+      "def": [
+        {
+          "localId": "1",
+          "localIdentifier": "System",
+          "uri": "urn:hl7-org:elm-types:r1"
+        },
+        {
+          "localId": "206",
+          "locator": "3:1-3:26",
+          "localIdentifier": "FHIR",
+          "uri": "http://hl7.org/fhir",
+          "version": "4.0.1",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "206",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "using "
+                    ]
+                  },
+                  {
+                    "s": [
+                      {
+                        "value": [
+                          "FHIR"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " version '4.0.1'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "includes": {
+      "def": [
+        {
+          "localId": "207",
+          "locator": "5:1-5:35",
+          "localIdentifier": "FHIRHelpers",
+          "path": "FHIRHelpers",
+          "version": "4.0.1",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "207",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "include "
+                    ]
+                  },
+                  {
+                    "s": [
+                      {
+                        "value": [
+                          "FHIRHelpers"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " version ",
+                      "'4.0.1'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "valueSets": {
+      "def": [
+        {
+          "localId": "208",
+          "locator": "7:1-7:52",
+          "name": "test-vs-2",
+          "id": "http://example.com/test-vs-2",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "208",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "valueset ",
+                      "\"test-vs-2\"",
+                      ": ",
+                      "'http://example.com/test-vs-2'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": []
+        }
+      ]
+    },
+    "statements": {
+      "def": [
+        {
+          "localId": "210",
+          "locator": "9:1-10:26",
+          "name": "SimpleRetrieve",
+          "context": "Unfiltered",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "210",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"SimpleRetrieve\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "213",
+                    "s": [
+                      {
+                        "value": [
+                          "[",
+                          "Condition",
+                          ": "
+                        ]
+                      },
+                      {
+                        "s": [
+                          {
+                            "value": [
+                              "\"test-vs-2\""
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "]"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "213",
+            "locator": "10:3-10:26",
+            "dataType": "{http://hl7.org/fhir}Condition",
+            "templateId": "http://hl7.org/fhir/StructureDefinition/Condition",
+            "codeProperty": "code",
+            "codeComparator": "in",
+            "type": "Retrieve",
+            "codes": {
+              "localId": "212",
+              "locator": "10:15-10:25",
+              "name": "test-vs-2",
+              "preserve": true,
+              "type": "ValueSetRef"
+            },
+            "include": [],
+            "codeFilter": [],
+            "dateFilter": [],
+            "otherFilter": []
+          }
+        },
+        {
+          "localId": "217",
+          "locator": "13:1-15:25",
+          "name": "SimpleQuery",
+          "context": "Unfiltered",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "217",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"SimpleQuery\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "229",
+                    "s": [
+                      {
+                        "s": [
+                          {
+                            "r": "218",
+                            "s": [
+                              {
+                                "r": "221",
+                                "s": [
+                                  {
+                                    "r": "221",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "[",
+                                          "Procedure",
+                                          ": "
+                                        ]
+                                      },
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "\"test-vs-2\""
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "]"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "P"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "\n    "
+                        ]
+                      },
+                      {
+                        "r": "224",
+                        "s": [
+                          {
+                            "value": [
+                              "where "
+                            ]
+                          },
+                          {
+                            "r": "224",
+                            "s": [
+                              {
+                                "r": "226",
+                                "s": [
+                                  {
+                                    "r": "225",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "P"
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "."
+                                    ]
+                                  },
+                                  {
+                                    "r": "226",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "id"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " ",
+                                  "=",
+                                  " "
+                                ]
+                              },
+                              {
+                                "r": "227",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "'test-2'"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "229",
+            "locator": "14:3-15:25",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "218",
+                "locator": "14:3-14:28",
+                "alias": "P",
+                "expression": {
+                  "localId": "221",
+                  "locator": "14:3-14:26",
+                  "dataType": "{http://hl7.org/fhir}Procedure",
+                  "templateId": "http://hl7.org/fhir/StructureDefinition/Procedure",
+                  "codeProperty": "code",
+                  "codeComparator": "in",
+                  "type": "Retrieve",
+                  "codes": {
+                    "localId": "220",
+                    "locator": "14:15-14:25",
+                    "name": "test-vs-2",
+                    "preserve": true,
+                    "type": "ValueSetRef"
+                  },
+                  "include": [],
+                  "codeFilter": [],
+                  "dateFilter": [],
+                  "otherFilter": []
+                }
+              }
+            ],
+            "let": [],
+            "relationship": [],
+            "where": {
+              "localId": "224",
+              "locator": "15:5-15:25",
+              "type": "Equal",
+              "signature": [],
+              "operand": [
+                {
+                  "localId": "228",
+                  "name": "ToString",
+                  "libraryName": "FHIRHelpers",
+                  "type": "FunctionRef",
+                  "signature": [],
+                  "operand": [
+                    {
+                      "localId": "226",
+                      "locator": "15:11-15:14",
+                      "path": "id",
+                      "scope": "P",
+                      "type": "Property"
+                    }
+                  ]
+                },
+                {
+                  "localId": "227",
+                  "locator": "15:18-15:25",
+                  "valueType": "{urn:hl7-org:elm-types:r1}String",
+                  "value": "test-2",
+                  "type": "Literal"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/test/unit/fixtures/elm/3.15.0/ValueQueries.json
+++ b/test/unit/fixtures/elm/3.15.0/ValueQueries.json
@@ -1,0 +1,1101 @@
+{
+  "library": {
+    "localId": "0",
+    "annotation": [
+      {
+        "translatorVersion": "3.15.0",
+        "translatorOptions": "EnableAnnotations,EnableLocators",
+        "signatureLevel": "None",
+        "type": "CqlToElmInfo"
+      },
+      {
+        "message": "The function FHIRHelpers.ToString has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "message": "The function FHIRHelpers.ToString has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.",
+        "errorType": "semantic",
+        "errorSeverity": "warning",
+        "type": "CqlToElmError"
+      },
+      {
+        "type": "Annotation",
+        "s": {
+          "r": "243",
+          "s": [
+            {
+              "value": [
+                "",
+                "library ValueQuery version '0.0.1'"
+              ]
+            }
+          ]
+        }
+      }
+    ],
+    "identifier": {
+      "id": "ValueQuery",
+      "version": "0.0.1"
+    },
+    "schemaIdentifier": {
+      "id": "urn:hl7-org:elm",
+      "version": "r1"
+    },
+    "usings": {
+      "def": [
+        {
+          "localId": "1",
+          "localIdentifier": "System",
+          "uri": "urn:hl7-org:elm-types:r1"
+        },
+        {
+          "localId": "206",
+          "locator": "3:1-3:26",
+          "localIdentifier": "FHIR",
+          "uri": "http://hl7.org/fhir",
+          "version": "4.0.1",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "206",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "using "
+                    ]
+                  },
+                  {
+                    "s": [
+                      {
+                        "value": [
+                          "FHIR"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " version '4.0.1'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "includes": {
+      "def": [
+        {
+          "localId": "207",
+          "locator": "5:1-5:35",
+          "localIdentifier": "FHIRHelpers",
+          "path": "FHIRHelpers",
+          "version": "4.0.1",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "207",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "include "
+                    ]
+                  },
+                  {
+                    "s": [
+                      {
+                        "value": [
+                          "FHIRHelpers"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " version ",
+                      "'4.0.1'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "valueSets": {
+      "def": [
+        {
+          "localId": "208",
+          "locator": "7:1-7:48",
+          "name": "test-vs",
+          "id": "http://example.com/test-vs",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "208",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "valueset ",
+                      "\"test-vs\"",
+                      ": ",
+                      "'http://example.com/test-vs'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "codeSystem": []
+        }
+      ]
+    },
+    "contexts": {
+      "def": [
+        {
+          "localId": "212",
+          "locator": "9:1-9:15",
+          "name": "Patient"
+        }
+      ]
+    },
+    "statements": {
+      "def": [
+        {
+          "localId": "210",
+          "locator": "9:1-9:15",
+          "name": "Patient",
+          "context": "Patient",
+          "expression": {
+            "localId": "211",
+            "type": "SingletonFrom",
+            "signature": [],
+            "operand": {
+              "localId": "209",
+              "locator": "9:1-9:15",
+              "dataType": "{http://hl7.org/fhir}Patient",
+              "templateId": "http://hl7.org/fhir/StructureDefinition/Patient",
+              "type": "Retrieve",
+              "include": [],
+              "codeFilter": [],
+              "dateFilter": [],
+              "otherFilter": []
+            }
+          }
+        },
+        {
+          "localId": "218",
+          "locator": "14:1-16:58",
+          "name": "Simple Observation Query",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "218",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Simple Observation Query\"",
+                      ":\n    "
+                    ]
+                  },
+                  {
+                    "r": "236",
+                    "s": [
+                      {
+                        "value": [
+                          "Last",
+                          "("
+                        ]
+                      },
+                      {
+                        "r": "233",
+                        "s": [
+                          {
+                            "s": [
+                              {
+                                "r": "219",
+                                "s": [
+                                  {
+                                    "r": "222",
+                                    "s": [
+                                      {
+                                        "r": "222",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "[",
+                                              "Observation",
+                                              ": "
+                                            ]
+                                          },
+                                          {
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "\"test-vs\""
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              "]"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      " ",
+                                      "O"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              "\n      "
+                            ]
+                          },
+                          {
+                            "r": "231",
+                            "s": [
+                              {
+                                "value": [
+                                  "where "
+                                ]
+                              },
+                              {
+                                "r": "231",
+                                "s": [
+                                  {
+                                    "r": "226",
+                                    "s": [
+                                      {
+                                        "r": "225",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "O"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "."
+                                        ]
+                                      },
+                                      {
+                                        "r": "226",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "status"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      " in "
+                                    ]
+                                  },
+                                  {
+                                    "r": "227",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "{"
+                                        ]
+                                      },
+                                      {
+                                        "r": "228",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "'final'"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          ", "
+                                        ]
+                                      },
+                                      {
+                                        "r": "229",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "'amended'"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          ", "
+                                        ]
+                                      },
+                                      {
+                                        "r": "230",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "'corrected'"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "}"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          ")"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "236",
+            "locator": "15:5-16:58",
+            "type": "Last",
+            "signature": [],
+            "source": {
+              "localId": "233",
+              "locator": "15:10-16:57",
+              "type": "Query",
+              "source": [
+                {
+                  "localId": "219",
+                  "locator": "15:10-15:35",
+                  "alias": "O",
+                  "expression": {
+                    "localId": "222",
+                    "locator": "15:10-15:33",
+                    "dataType": "{http://hl7.org/fhir}Observation",
+                    "templateId": "http://hl7.org/fhir/StructureDefinition/Observation",
+                    "codeProperty": "code",
+                    "codeComparator": "in",
+                    "type": "Retrieve",
+                    "codes": {
+                      "localId": "221",
+                      "locator": "15:24-15:32",
+                      "name": "test-vs",
+                      "preserve": true,
+                      "type": "ValueSetRef"
+                    },
+                    "include": [],
+                    "codeFilter": [],
+                    "dateFilter": [],
+                    "otherFilter": []
+                  }
+                }
+              ],
+              "let": [],
+              "relationship": [],
+              "where": {
+                "localId": "231",
+                "locator": "16:7-16:57",
+                "type": "In",
+                "signature": [],
+                "operand": [
+                  {
+                    "localId": "232",
+                    "name": "ToString",
+                    "libraryName": "FHIRHelpers",
+                    "type": "FunctionRef",
+                    "signature": [],
+                    "operand": [
+                      {
+                        "localId": "226",
+                        "locator": "16:13-16:20",
+                        "path": "status",
+                        "scope": "O",
+                        "type": "Property"
+                      }
+                    ]
+                  },
+                  {
+                    "localId": "227",
+                    "locator": "16:25-16:57",
+                    "type": "List",
+                    "element": [
+                      {
+                        "localId": "228",
+                        "locator": "16:26-16:32",
+                        "valueType": "{urn:hl7-org:elm-types:r1}String",
+                        "value": "final",
+                        "type": "Literal"
+                      },
+                      {
+                        "localId": "229",
+                        "locator": "16:35-16:43",
+                        "valueType": "{urn:hl7-org:elm-types:r1}String",
+                        "value": "amended",
+                        "type": "Literal"
+                      },
+                      {
+                        "localId": "230",
+                        "locator": "16:46-16:56",
+                        "valueType": "{urn:hl7-org:elm-types:r1}String",
+                        "value": "corrected",
+                        "type": "Literal"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "localId": "214",
+          "locator": "11:1-12:56",
+          "name": "Query ExpressionRef with Value Comparison",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "214",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Query ExpressionRef with Value Comparison\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "215",
+                    "s": [
+                      {
+                        "r": "216",
+                        "s": [
+                          {
+                            "value": [
+                              "("
+                            ]
+                          },
+                          {
+                            "r": "216",
+                            "s": [
+                              {
+                                "r": "238",
+                                "s": [
+                                  {
+                                    "r": "237",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "\"Simple Observation Query\""
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "."
+                                    ]
+                                  },
+                                  {
+                                    "r": "238",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "value"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  " as "
+                                ]
+                              },
+                              {
+                                "r": "239",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "Quantity"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              ")"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          " ",
+                          ">",
+                          " "
+                        ]
+                      },
+                      {
+                        "r": "240",
+                        "s": [
+                          {
+                            "value": [
+                              "9 ",
+                              "'%'"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "215",
+            "locator": "12:3-12:56",
+            "type": "Greater",
+            "signature": [],
+            "operand": [
+              {
+                "localId": "241",
+                "name": "ToQuantity",
+                "libraryName": "FHIRHelpers",
+                "type": "FunctionRef",
+                "signature": [],
+                "operand": [
+                  {
+                    "localId": "216",
+                    "locator": "12:3-12:48",
+                    "strict": false,
+                    "type": "As",
+                    "signature": [],
+                    "operand": {
+                      "localId": "238",
+                      "locator": "12:4-12:35",
+                      "path": "value",
+                      "type": "Property",
+                      "source": {
+                        "localId": "237",
+                        "locator": "12:4-12:29",
+                        "name": "Simple Observation Query",
+                        "type": "ExpressionRef"
+                      }
+                    },
+                    "asTypeSpecifier": {
+                      "localId": "239",
+                      "locator": "12:40-12:47",
+                      "name": "{http://hl7.org/fhir}Quantity",
+                      "type": "NamedTypeSpecifier"
+                    }
+                  }
+                ]
+              },
+              {
+                "localId": "240",
+                "locator": "12:52-12:56",
+                "value": 9,
+                "unit": "%",
+                "type": "Quantity"
+              }
+            ]
+          }
+        },
+        {
+          "localId": "243",
+          "locator": "18:1-21:40",
+          "name": "Has Elevated Value With Where",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "243",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Has Elevated Value With Where\"",
+                      ":\n    "
+                    ]
+                  },
+                  {
+                    "r": "269",
+                    "s": [
+                      {
+                        "value": [
+                          "Last",
+                          "("
+                        ]
+                      },
+                      {
+                        "r": "266",
+                        "s": [
+                          {
+                            "s": [
+                              {
+                                "r": "244",
+                                "s": [
+                                  {
+                                    "r": "247",
+                                    "s": [
+                                      {
+                                        "r": "247",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "[",
+                                              "Observation",
+                                              ": "
+                                            ]
+                                          },
+                                          {
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "\"test-vs\""
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              "]"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      " ",
+                                      "O"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              "\n      "
+                            ]
+                          },
+                          {
+                            "r": "250",
+                            "s": [
+                              {
+                                "value": [
+                                  "where "
+                                ]
+                              },
+                              {
+                                "r": "250",
+                                "s": [
+                                  {
+                                    "r": "257",
+                                    "s": [
+                                      {
+                                        "r": "252",
+                                        "s": [
+                                          {
+                                            "r": "251",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "O"
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              "."
+                                            ]
+                                          },
+                                          {
+                                            "r": "252",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "status"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          " in "
+                                        ]
+                                      },
+                                      {
+                                        "r": "253",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "{"
+                                            ]
+                                          },
+                                          {
+                                            "r": "254",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "'final'"
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              ", "
+                                            ]
+                                          },
+                                          {
+                                            "r": "255",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "'amended'"
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              ", "
+                                            ]
+                                          },
+                                          {
+                                            "r": "256",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "'corrected'"
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              "}"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "\n      and "
+                                    ]
+                                  },
+                                  {
+                                    "r": "259",
+                                    "s": [
+                                      {
+                                        "r": "260",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "("
+                                            ]
+                                          },
+                                          {
+                                            "r": "260",
+                                            "s": [
+                                              {
+                                                "r": "262",
+                                                "s": [
+                                                  {
+                                                    "r": "261",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "O"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "value": [
+                                                      "."
+                                                    ]
+                                                  },
+                                                  {
+                                                    "r": "262",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "value"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "value": [
+                                                  " as "
+                                                ]
+                                              },
+                                              {
+                                                "r": "263",
+                                                "s": [
+                                                  {
+                                                    "value": [
+                                                      "Quantity"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "value": [
+                                              ")"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          " ",
+                                          ">",
+                                          " "
+                                        ]
+                                      },
+                                      {
+                                        "r": "264",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "9 ",
+                                              "'%'"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          ")"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "269",
+            "locator": "19:5-21:40",
+            "type": "Last",
+            "signature": [],
+            "source": {
+              "localId": "266",
+              "locator": "19:10-21:39",
+              "type": "Query",
+              "source": [
+                {
+                  "localId": "244",
+                  "locator": "19:10-19:35",
+                  "alias": "O",
+                  "expression": {
+                    "localId": "247",
+                    "locator": "19:10-19:33",
+                    "dataType": "{http://hl7.org/fhir}Observation",
+                    "templateId": "http://hl7.org/fhir/StructureDefinition/Observation",
+                    "codeProperty": "code",
+                    "codeComparator": "in",
+                    "type": "Retrieve",
+                    "codes": {
+                      "localId": "246",
+                      "locator": "19:24-19:32",
+                      "name": "test-vs",
+                      "preserve": true,
+                      "type": "ValueSetRef"
+                    },
+                    "include": [],
+                    "codeFilter": [],
+                    "dateFilter": [],
+                    "otherFilter": []
+                  }
+                }
+              ],
+              "let": [],
+              "relationship": [],
+              "where": {
+                "localId": "250",
+                "locator": "20:7-21:39",
+                "type": "And",
+                "signature": [],
+                "operand": [
+                  {
+                    "localId": "257",
+                    "locator": "20:13-20:57",
+                    "type": "In",
+                    "signature": [],
+                    "operand": [
+                      {
+                        "localId": "258",
+                        "name": "ToString",
+                        "libraryName": "FHIRHelpers",
+                        "type": "FunctionRef",
+                        "signature": [],
+                        "operand": [
+                          {
+                            "localId": "252",
+                            "locator": "20:13-20:20",
+                            "path": "status",
+                            "scope": "O",
+                            "type": "Property"
+                          }
+                        ]
+                      },
+                      {
+                        "localId": "253",
+                        "locator": "20:25-20:57",
+                        "type": "List",
+                        "element": [
+                          {
+                            "localId": "254",
+                            "locator": "20:26-20:32",
+                            "valueType": "{urn:hl7-org:elm-types:r1}String",
+                            "value": "final",
+                            "type": "Literal"
+                          },
+                          {
+                            "localId": "255",
+                            "locator": "20:35-20:43",
+                            "valueType": "{urn:hl7-org:elm-types:r1}String",
+                            "value": "amended",
+                            "type": "Literal"
+                          },
+                          {
+                            "localId": "256",
+                            "locator": "20:46-20:56",
+                            "valueType": "{urn:hl7-org:elm-types:r1}String",
+                            "value": "corrected",
+                            "type": "Literal"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "localId": "259",
+                    "locator": "21:11-21:39",
+                    "type": "Greater",
+                    "signature": [],
+                    "operand": [
+                      {
+                        "localId": "265",
+                        "name": "ToQuantity",
+                        "libraryName": "FHIRHelpers",
+                        "type": "FunctionRef",
+                        "signature": [],
+                        "operand": [
+                          {
+                            "localId": "260",
+                            "locator": "21:11-21:31",
+                            "strict": false,
+                            "type": "As",
+                            "signature": [],
+                            "operand": {
+                              "localId": "262",
+                              "locator": "21:12-21:18",
+                              "path": "value",
+                              "scope": "O",
+                              "type": "Property"
+                            },
+                            "asTypeSpecifier": {
+                              "localId": "263",
+                              "locator": "21:23-21:30",
+                              "name": "{http://hl7.org/fhir}Quantity",
+                              "type": "NamedTypeSpecifier"
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "localId": "264",
+                        "locator": "21:35-21:39",
+                        "value": 9,
+                        "unit": "%",
+                        "type": "Quantity"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/test/unit/fixtures/elm/queries/README.md
+++ b/test/unit/fixtures/elm/queries/README.md
@@ -8,7 +8,7 @@
 
 To use the `Makefile` provided in this directory to translate CQL into ELM JSON:
 
-* Navigate to the `test/fixtures/elm/queries` directory in the command line
+* Navigate to the `test/unit/fixtures/elm/queries` directory in the command line
 * Put your CQL in a file (or multiple files) in the `queries` directory, with the `.cql` extension
 * run `make` in this directory. `make` will:
     * Start the translation service in Docker (if not already started)


### PR DESCRIPTION
# Summary
Implements an annotation-based coverage approach that only uses local ids that are also in the annotation (and therefore can be seen in the cql coverage highlighting). This mitigates updates in version 3.14.0 of the translator which added many additional local ids that could otherwise impact coverage.

## New behavior
Coverage calculations will be approximately the same as for translator 3.3.2. There may be some very small differences in in coverage percentages since this is a new coverage approach, but any coverage gaps should be identifiable for the end user.

## Code changes

- Small README updates
- `ClauseResultsHelpers.ts` Update to add `findAnnotationLocalIds` function that identifies all "r"-keyed local ids within an annotation structure. Uses this to limit the final localIds to the ones that can be found in the annotation.
- `ClauseResultsHelpers.test.ts` Updates to "Not Equivalent" and "Not Equal" and addition of a "Not Null" unit test to align with new localid approach
- Adds `3.15.0` folder for new translations of existing easily translatable cql unit test fixtures (some existing cql fixtures do not have the right dependency library versions to be easily re-translated)

# Testing guidance
- Test with the 3.14.0 measures provided in https://github.com/projecttacoma/fqm-execution/issues/313 and confirm coverage percentages are restored. Maybe test with other measures with known past coverage issues.