### PR TITLE
Fix handling of function without library for Equal

### DIFF
--- a/src/helpers/elm/QueryFilterParser.ts
+++ b/src/helpers/elm/QueryFilterParser.ts
@@ -720,6 +720,11 @@ export function interpretEqual(equal: ELMEqual, library: ELM): EqualsFilter | Un
     propRef = equal.operand[0] as ELMProperty;
   }
 
+  if (propRef == null) {
+    withError.message = `could not resolve property ref for Equal:${equal.localId}. first operand is a ${equal.operand[0].type}`;
+    return { type: 'unknown', withError };
+  }
+
   if (isOfTypeGracefulError(propRef)) {
     return { type: 'unknown', withError: propRef };
   }

--- a/src/types/errors/GracefulError.ts
+++ b/src/types/errors/GracefulError.ts
@@ -6,7 +6,7 @@ export interface GracefulError {
 }
 
 export const isOfTypeGracefulError = (tbd: any): tbd is GracefulError => {
-  if ((tbd as GracefulError).message) {
+  if ((tbd as GracefulError)?.message) {
     return true;
   }
   return false;


### PR DESCRIPTION
# Summary
CMS334 https://github.com/cqframework/ecqm-content-qicore-2024/tree/main/bundles/measure/CesareanBirthFHIR has an `ELMFunctionRef` without a libraryName that gets hit by `interpretEqual`. This makes `interpretFunctionRef` return an undefined which makes `isOfTypeGracefulError` choke.

I would prefer to fix this by making `interpretFunctionRef` return definitive types, but it looks like everywhere else (and now in `interpretEqual`) we do a check for undefined via a lovely `== null` check after it's called. So that's what we're doing here for now, but it would be nice to clean some of this up further in the future... should we add a ticket?
This PR also makes `isOfTypeGracefulError` a bit more robust.

## New behavior
No longer breaks on CMS334.

## Code changes

- See summary

# Testing guidance

- npm run check
- npm run cli -- dataRequirements -m {path2CMS334-VS.json} (I added valuesets to the measure locally, but you can also use the command line option to fetch valuesets during calculation)
