### PR TITLE
Enhanced CalculateQueryInfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,6 +470,7 @@ The options that we support for calculation are as follows:
 - `[useValueSetCaching]`<[boolean](#calculation-options)>: If `true`, ValueSets retrieved from a terminology service will be cached and used in subsequent runs where this is also `true` (default: `false`)
 - `[verboseCalculationResults]`<[boolean](#calculation-options)>: If `false`, detailed results will only contain information necessary to interpreting simple population results (default: `true`)
 - `[vsAPIKey]`<[string](#calculation-options)>: API key, to be used to access a terminology service for downloading any missing ValueSets
+- `[focusedStatement]`<[string](#calculation-options)>: Top level statement expression, i.e. "Initial Population", used to narrow the focus of a queryInfo calculation to just that statement and any children
 
 **Note**: The measurement period calculation options are formatted using the UTC time format. Timezone offsets, if provided, are not taken into account for measure calculation.
 
@@ -502,6 +503,7 @@ Options:
   -s, --measurement-period-start <dateTime>       Start of measurement period as a valid FHIR dateTime. Can be formatted as a date, date-time, or partial date. Milliseconds are optionally allowed. Defaults to the `.effectivePeriod.start` on the `Measure` resource, but can be overridden or specified using this option, which will take precedence
   -e, --measurement-period-end <dateTime>         End of measurement period as a valid FHIR dateTime. Can be formatted as a date, date-time, or partial date. Milliseconds are optionally allowed. Defaults to the `.effectivePeriod.end` on the `Measure` resource, but can be overridden or specified using this option, which will take precedence
   --vs-api-key <key>                          API key, to authenticate against the ValueSet service to be used for resolving missing ValueSets.
+  --focused-statement <statement expression>  Top level statement expression, i.e. "Initial Population", used to narrow the focus of a queryInfo calculation to just that statement and any children
   --cache-valuesets                           Whether or not to cache ValueSets retrieved from the ValueSet service. (default: false)
   --trust-meta-profile                        To "trust" the content of meta.profile as a source of truth for what profiles the data that cql-exec-fhir grabs validates against. (default: false)
   -o, --out-file [file-path]                  Path to a file that fqm-execution will write the calculation results to (default: output.json)

--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -710,7 +710,18 @@ export async function calculateQueryInfo(
   const parameters = { 'Measurement Period': new Interval(startCql, endCql) };
   // get the retrieves for every statement in the root library
   const withErrors: GracefulError[] = [];
-  const allRetrieves = rootLib.library.statements.def.flatMap(statement => {
+
+  let statements = rootLib.library.statements.def;
+  if (options.focusedStatement) {
+    const focalStatement = rootLib.library.statements.def.find(s => s.name === options.focusedStatement);
+    // if focal statement isn't found, warn and stick with the default
+    if (focalStatement) {
+      statements = [focalStatement];
+    } else {
+      console.warn(`Focused statement \"${options.focusedStatement}\" not found in root library.`);
+    }
+  }
+  const allRetrieves = statements.flatMap(statement => {
     if (statement.expression && statement.name != 'Patient') {
       const retrievesOutput = RetrievesHelper.findRetrieves(rootLib, elmJSONs, statement.expression);
       withErrors.push(...retrievesOutput.withErrors);

--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -713,7 +713,7 @@ export async function calculateQueryInfo(
 
   let statements = rootLib.library.statements.def;
   if (options.focusedStatement) {
-    const focalStatement = rootLib.library.statements.def.find(s => s.name === options.focusedStatement);
+    const focalStatement = statements.find(s => s.name === options.focusedStatement);
     // if focal statement isn't found, warn and stick with the default
     if (focalStatement) {
       statements = [focalStatement];

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -82,6 +82,11 @@ program
     'Path to a file that fqm-execution will write the calculation results to (default: output.json)'
   )
   .option('--root-lib-ref <root-lib-ref>', 'Reference to the root library', undefined)
+  .option(
+    '--focused-statement <statement name>',
+    'To specify the name of the statement that should be focused on for query info calculation',
+    undefined
+  )
   .parse(process.argv);
 
 function parseBundle(filePath: string): fhir4.Bundle {
@@ -202,7 +207,8 @@ const calcOptions: CalculationOptions = {
   useValueSetCaching: program.cacheValuesets,
   verboseCalculationResults: !program.slim,
   trustMetaProfile: program.trustMetaProfile,
-  rootLibRef: program.rootLibRef
+  rootLibRef: program.rootLibRef,
+  focusedStatement: program.focusedStatement
 };
 
 // Override the measurement period start/end in the options only if the user specified them

--- a/src/helpers/elm/QueryFilterParser.ts
+++ b/src/helpers/elm/QueryFilterParser.ts
@@ -840,7 +840,7 @@ export async function interpretIn(
     propRef = interpretFunctionRef(inExpr.operand[0] as ELMFunctionRef, library);
   } else if (inExpr.operand[0].type == 'Property') {
     propRef = inExpr.operand[0] as ELMProperty;
-    // Extra check for for property pass through (i.e. alias.property.value, grab what's inside the .value)
+    // Extra check for property pass through (i.e. alias.property.value, grab what's inside the .value)
     if (propRef.path === 'value' && !propRef.scope && propRef.source && propRef.source?.type === 'Property') {
       propRef = propRef.source as ELMProperty;
     }

--- a/src/helpers/elm/QueryFilterParser.ts
+++ b/src/helpers/elm/QueryFilterParser.ts
@@ -1184,7 +1184,8 @@ export function interpretComparator(
 
   const valueFilter: ValueFilter = {
     type: 'value',
-    comparator: comparatorString
+    comparator: comparatorString,
+    attribute: propRef.path
   };
   const op = comparatorELM.operand[1];
 
@@ -1217,9 +1218,6 @@ export function interpretComparator(
 
   if (propRef.scope) {
     valueFilter.alias = propRef.scope;
-  }
-  if (propRef.path) {
-    valueFilter.attribute = propRef.path;
   }
   return valueFilter;
 }

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -52,6 +52,8 @@ export interface CalculationOptions {
   disableHTMLOrdering?: boolean;
   /** Builds and returns HTML at the statement level */
   buildStatementLevelHTML?: boolean;
+  /** The name of the statement to focus all results on for a queryInfo calculation. Will be ignored for other calculation types */
+  focusedStatement?: string;
 }
 
 /**

--- a/src/types/QueryFilterTypes.ts
+++ b/src/types/QueryFilterTypes.ts
@@ -158,7 +158,7 @@ export interface codeFilterQuery {
 
 export interface ValueFilter extends Filter {
   type: 'value';
-  attribute?: string;
+  attribute: string;
   alias?: string;
   comparator: ValueFilterComparator;
   valueBoolean?: boolean;
@@ -169,5 +169,5 @@ export interface ValueFilter extends Filter {
   valueRange?: fhir4.Range;
 }
 
-// Information on these comparators found here: http://build.fhir.org/ig/HL7/cqf-measures/ValueSet-value-filter-comparator.html
+// Information on these comparators found here: https://build.fhir.org/ig/HL7/fhir-extensions/StructureDefinition-cqf-valueFilter.html
 export type ValueFilterComparator = 'eq' | 'gt' | 'lt' | 'ge' | 'le' | 'sa' | 'eb';


### PR DESCRIPTION
# Summary
Adds focused statement calculation option for `calculateQueryInfo` and improves the queryinfo to provide more information for filtering data (and other small fixes).

## New behavior
New option for --focused-statement that limits the calculateQueryInfo function to just the retrieves in the top level statement, and additional information will be included in the queryInfo output when using the calculateQueryInfo function.

## Code changes

- `Calculator.ts`, `cli.ts` updates to handle the new option
- `Calculator.ts`, `QueryFilterTypes.ts`, `QueryFilterParser.ts` updates to make `attribute` required for ValueFilters (seems to have been an initial oversight
- `QueryFilterParser.ts` expands ExpressionRef source handling to also handle FunctionRefs, adds QICoreCommon with lowercase `toInterval` to the list of passthrough functions, digs one level deeper to the inner function on `as` expressions, and simple `.value` property passthrough

# Testing guidance

- `npm run check`
- `npm run cli -- queryInfo -m <path to measure bundle> --trust-meta-profile true -o --debug --focused-statement <top level expression, i.e. "Initial Population">` (should give some interesting queryInfo and limit the retrieve list to just those in the initial population)
