### PR TITLE
Wrap QueryParsers Interval exec in try/catch. Fixing dataRequirements for difficult CQL

### DIFF
--- a/src/helpers/elm/QueryFilterParser.ts
+++ b/src/helpers/elm/QueryFilterParser.ts
@@ -976,14 +976,19 @@ export async function executeIntervalELM(
   // build an expression that has the interval creation and
   const intervalExecExpr = new Expression({ operand: intervalExpr });
   const ctx = new PatientContext(new Library(library), null, undefined, parameters);
-  const interval: Interval = await intervalExecExpr.arg?.execute(ctx);
-  if (interval != null && interval.start() != null && interval.end() != null) {
-    return {
-      start: interval.start().toString().replace('+00:00', 'Z'),
-      end: interval.end().toString().replace('+00:00', 'Z'),
-      interval
-    };
-  } else {
+  try {
+    const interval: Interval = await intervalExecExpr.arg?.execute(ctx);
+    if (interval != null && interval.start() != null && interval.end() != null) {
+      return {
+        start: interval.start().toString().replace('+00:00', 'Z'),
+        end: interval.end().toString().replace('+00:00', 'Z'),
+        interval
+      };
+    } else {
+      return withError;
+    }
+  } catch (e) {
+    withError.message += `\n ${e}`;
     return withError;
   }
 }


### PR DESCRIPTION
# Summary

Quick patch to a bizarre issue with query parsers where if an interval execution fails due to the interval args being from another library it doesn't have libraries properly loaded and throws a runtime error. This completely blocks dataRequirements from completing.

## New behavior

Wraps the execution in a try catch as it would be too much effort at the moment to have libraries properly loaded in here. Anyways, it is likely to be unable to properly calculate the interval due to other issues.

## Code changes
-`src/helpers/elm/QueryFilterParser.ts` - Wrap the execution in a try catch and add to the graceful error that gets returned.

# Testing guidance

Run dataRequirements with the attached package. The debug `gaps.json` output should have the CQL execution error text in the query info. Alternatively load with with fqm-testify using this branch and make sure it loads up and is able to go to the test case edit screen.

[CMS832FHIR-v0.1.000-FHIR-HOSSFIX-with-vs.json](https://github.com/user-attachments/files/19577453/CMS832FHIR-v0.1.000-FHIR-HOSSFIX-with-vs.json)


