### PR TITLE
Gaps groupscore

### DIFF
--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -519,7 +519,7 @@ export async function calculateGapsInCare<T extends OneOrMultiPatient>(
         measureResource.improvementNotation?.coding?.[0].code;
 
       if (!improvementNotation) {
-        throw new UnexpectedProperty('Could not find improvement notation code for this group or measure');
+        throw new UnexpectedProperty('Unable to find improvement notation code for this group or measure');
       }
 
       // If positive improvement measure, consider patients in denominator but not numerator for gaps

--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -499,9 +499,12 @@ export async function calculateGapsInCare<T extends OneOrMultiPatient>(
 
     const drPromises = res.detailedResults?.map(async (dr, i) => {
       const measureResource = MeasureBundleHelpers.extractMeasureFromBundle(measureBundle);
+      const matchingGroup = measureResource.group?.find(g => g.id === dr.groupId) || measureResource.group?.[i];
 
       // Gaps only supported for proportion/ratio measures
-      const scoringCode = MeasureBundleHelpers.getScoringCodeFromMeasure(measureResource);
+      const scoringCode =
+        MeasureBundleHelpers.getScoringCodeFromGroup(matchingGroup) ??
+        MeasureBundleHelpers.getScoringCodeFromMeasure(measureResource);
 
       if (scoringCode !== MeasureScoreType.PROP) {
         throw new UnsupportedProperty(`Gaps in care not supported for measure scoring type ${scoringCode}`);
@@ -511,14 +514,12 @@ export async function calculateGapsInCare<T extends OneOrMultiPatient>(
       const numerResult = dr.populationResults?.find(pr => pr.populationType === PopulationType.NUMER)?.result;
       const numerRelevance = dr.populationRelevance?.find(pr => pr.populationType === PopulationType.NUMER)?.result;
 
-      if (!measureResource.improvementNotation?.coding) {
-        throw new UnexpectedProperty('Measure resource must include improvement notation');
-      }
-
-      const improvementNotation = measureResource.improvementNotation.coding[0].code;
+      const improvementNotation =
+        MeasureBundleHelpers.getImprovementNotationFromGroup(matchingGroup) ??
+        measureResource.improvementNotation?.coding?.[0].code;
 
       if (!improvementNotation) {
-        throw new UnexpectedProperty('Improvement notation code not present on measure');
+        throw new UnexpectedProperty('Could not find improvement notation code for this group or measure');
       }
 
       // If positive improvement measure, consider patients in denominator but not numerator for gaps
@@ -528,8 +529,6 @@ export async function calculateGapsInCare<T extends OneOrMultiPatient>(
         numerRelevance &&
         (improvementNotation === ImprovementNotation.POSITIVE ? denomResult && !numerResult : numerResult);
       if (populationCriteria) {
-        const matchingGroup = measureResource.group?.find(g => g.id === dr.groupId) || measureResource.group?.[i];
-
         if (!matchingGroup) {
           throw new Error(`Could not find group with id ${dr.groupId} in measure resource`);
         }

--- a/src/helpers/MeasureBundleHelpers.ts
+++ b/src/helpers/MeasureBundleHelpers.ts
@@ -12,6 +12,13 @@ import { ExtractedLibrary } from '../types/CQLTypes';
  */
 const POPULATION_BASIS_EXT = 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis';
 const SCORING_CODE_EXT = 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-scoring';
+const IMPROVEMENT_NOTATION_EXT = 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-improvementNotation';
+
+export function getImprovementNotationFromGroup(group?: fhir4.MeasureGroup): string | null {
+  return (
+    group?.extension?.find(ext => ext.url === IMPROVEMENT_NOTATION_EXT)?.valueCodeableConcept?.coding?.[0].code ?? null
+  );
+}
 
 export function getScoringCodeFromGroup(group?: fhir4.MeasureGroup): string | null {
   return group?.extension?.find(ext => ext.url === SCORING_CODE_EXT)?.valueCodeableConcept?.coding?.[0].code ?? null;

--- a/test/unit/helpers/MeasureBundleHelpers.test.ts
+++ b/test/unit/helpers/MeasureBundleHelpers.test.ts
@@ -19,7 +19,8 @@ import {
   extractCompositeMeasure,
   getGroupIdForComponent,
   filterComponentResults,
-  getWeightForComponent
+  getWeightForComponent,
+  getImprovementNotationFromGroup
 } from '../../../src/helpers/MeasureBundleHelpers';
 import { PopulationType } from '../../../src/types/Enums';
 import { ValueSetResolver } from '../../../src/execution/ValueSetResolver';
@@ -31,6 +32,34 @@ import { UnexpectedResource } from '../../../src/types/errors/CustomErrors';
 const GROUP_NUMER_AND_DENOM_CRITERIA = getJSONFixture('measure/groups/groupNumerAndDenomCriteria.json');
 
 describe('MeasureBundleHelpers tests', () => {
+  describe('getImprovementNotationFromGroup', () => {
+    it('should return the code when extension is defined', () => {
+      const group: fhir4.MeasureGroup = {
+        extension: [
+          {
+            url: 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-improvementNotation',
+            valueCodeableConcept: {
+              coding: [
+                {
+                  system: 'http://terminology.hl7.org/CodeSystem/measure-improvement-notation',
+                  code: 'increase'
+                }
+              ]
+            }
+          }
+        ]
+      };
+
+      expect(getImprovementNotationFromGroup(group)).toEqual('increase');
+    });
+
+    it('should return null with no matching extension', () => {
+      const group: fhir4.MeasureGroup = {};
+
+      expect(getImprovementNotationFromGroup(group)).toBeNull();
+    });
+  });
+
   describe('getScoringCodeFromGroup', () => {
     it('should return the code when extension is defined', () => {
       const group: fhir4.MeasureGroup = {


### PR DESCRIPTION
# Summary
A [cqf computable measure](https://hl7.org/fhir/us/cqfmeasures/StructureDefinition-computable-measure-cqfm.html) can define the measure scoring and improvement notation on a specific group rather than a measure as a whole. This PR updates gaps in care to be able to pull this information from the group as a primary source, with the measure as a backup source.

## New behavior
Does not error when scoring and group notation are on the group definition rather than the top measure definition.

## Code changes
- Updates to MeasureBundleHelper (and tests) to provide a helper function for getting the group improvement notation
- Updates to the `calculateGapsInCare` function in `Calculator.ts` to identify the current group earlier, and use that as the primary source for the scoring and improvement notation with a fallback to the measure's main scoring and improvement notation. Throws an error if neither are available.

# Testing guidance
Note: Coverage script bundles will still fail to calculate for gaps because they have no improvement notation (at least the ones I spot checked). Improvement notation is 0..1, but I could not find anything in the spec about what the assumed value should be, so I believe we should continue to reject measure bundles without an improvement notation.
Latest bundles, on the other hand, appear to appropriately have a group improvement notation, so I have updated the code to handle the group-based improvement notation, and I will provide a test bundle in slack.

- `npm run check`
- `npm run cli -- gaps -m [path2]/CMS130FHIR-v0.3.000-FHIR-with-vs.json -p [path2]/CMS130FHIR-v0.3.000-FHIR-with-vs-test-cases/DENOM\ Patient-denom-EXM130.json`
- Should return a guidance response (which should be interesting since this is a denominator patient).
