### PR TITLE
Update trustMetaProfile to default to true

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,7 +465,7 @@ The options that we support for calculation are as follows:
 - `[reportType]`<['individual' | 'summary'](#calculation-options)>: The type of FHIR MeasureReport to return (default: `'individual'`)
 - `[returnELM]`<[boolean](#calculation-options)>: Enables the return of ELM Libraries and name of main library to be used for further processing (e.g. gaps in care) (default: `false`)
 - `[rootLibRef]`<[string](#calculation-options)>: Reference to root library to be used in `calculateLibraryDataRequirements`. Should be a canonical URL but resource ID will work if matching one exists in the bundle
-- `[trustMetaProfile]`<[boolean](#calculation-options)>: If `true`, trust the content of `meta.profile` as a source of truth for what profiles the data that `cql-exec-fhir` grabs validates against. **Use of this option will cause `cql-exec-fhir` to filter out resources that don't have a valid `meta.profile` attribute** (default: `false`)
+- `[trustMetaProfile]`<[boolean](#calculation-options)>: If `true`, trust the content of `meta.profile` as a source of truth for what profiles the data that `cql-exec-fhir` grabs validates against. **Use of this option will cause `cql-exec-fhir` to filter out resources that don't have a valid `meta.profile` attribute** (default: `true`)
 - `[useElmJsonsCaching]`<[boolean](#calculation-options)>: If `true`, cache ELM JSONs and associated data for access in subsequent runs within 10 minutes (default: `false`)
 - `[useValueSetCaching]`<[boolean](#calculation-options)>: If `true`, ValueSets retrieved from a terminology service will be cached and used in subsequent runs where this is also `true` (default: `false`)
 - `[verboseCalculationResults]`<[boolean](#calculation-options)>: If `false`, detailed results will only contain information necessary to interpreting simple population results (default: `true`)
@@ -505,7 +505,7 @@ Options:
   --vs-api-key <key>                          API key, to authenticate against the ValueSet service to be used for resolving missing ValueSets.
   --focused-statement <statement expression>  Top level statement expression, i.e. "Initial Population", used to narrow the focus of a queryInfo calculation to just that statement and any children
   --cache-valuesets                           Whether or not to cache ValueSets retrieved from the ValueSet service. (default: false)
-  --trust-meta-profile                        To "trust" the content of meta.profile as a source of truth for what profiles the data that cql-exec-fhir grabs validates against. (default: false)
+  --trust-meta-profile                        To "trust" the content of meta.profile as a source of truth for what profiles the data that cql-exec-fhir grabs validates against. (default: true)
   -o, --out-file [file-path]                  Path to a file that fqm-execution will write the calculation results to (default: output.json)
   --root-lib-ref <root-lib-ref>               Reference to the root Library
   -h, --help                                  display help for command
@@ -653,14 +653,14 @@ From these results, it can be seen that `"episode-1"` has a duration of `1` day,
 
 ## `meta.profile` Checking
 
-`fqm-execution` can be configured to use a [trusted environment with cql-exec-fhir](https://github.com/cqframework/cql-exec-fhir#optional-trusted-environment-with-metaprofile), where resources returned as the result of an ELM Retrieve expression will only be included if they have a `meta.profile` list that contains the canonical URL of the profile being asked for by the Retrieve. To enable this environment, use the `trustMetaProfile` calculation option during calculation:
+`fqm-execution` is configured by default to use a [trusted environment with cql-exec-fhir](https://github.com/cqframework/cql-exec-fhir#optional-trusted-environment-with-metaprofile), where resources returned as the result of an ELM Retrieve expression will only be included if they have a `meta.profile` list that contains the canonical URL of the profile being asked for by the Retrieve. To disable this environment, set the `trustMetaProfile` calculation option to false during calculation:
 
 ```typescript
 import { Calculator } from 'fqm-execution';
 
 // ...
 
-const { results } = await Calculator.calculate(measureBundle, patientBundles, { trustMetaProfile: true });
+const { results } = await Calculator.calculate(measureBundle, patientBundles, { trustMetaProfile: false });
 ```
 
 ## Supplemental Data Elements

--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -775,7 +775,7 @@ function resolvePatientSource(patientBundles: fhir4.Bundle[], options: Calculati
     if (patientBundles.filter(pb => pb.entry?.length).length === 0) {
       throw new UnexpectedResource('No entries found in passed patient bundles');
     }
-    const patientSource = PatientSource.FHIRv401({ requireProfileTagging: options.trustMetaProfile ?? false });
+    const patientSource = PatientSource.FHIRv401({ requireProfileTagging: options.trustMetaProfile ?? true });
     patientSource.loadBundles(patientBundles);
     return patientSource;
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -75,7 +75,7 @@ program
   .option(
     '--trust-meta-profile',
     'To "trust" the content of meta.profile as a source of truth for what profiles the data that cql-exec-fhir grabs validates against.',
-    false
+    true
   )
   .option(
     '-o, --out-file [file-path]',
@@ -164,7 +164,7 @@ async function populatePatientBundles() {
     // if we want to pass patient data into the fqm-execution API as a cql-exec-fhir patient source. Build patientSource
     // from patientBundles and wipe patientBundles to be an empty array.
     if (program.asPatientSource) {
-      const patientSource = PatientSource.FHIRv401({ requireProfileTagging: program.trustMetaProfile });
+      const patientSource = PatientSource.FHIRv401({ requireProfileTagging: program.trustMetaProfile ?? true });
       patientSource.loadBundles(patientBundles);
       calcOptions.patientSource = patientSource;
       patientBundles = [];


### PR DESCRIPTION
# Summary
Trust meta profile defaults to true
## New behavior
Same as if option `{trustMetaProfile: true}` is used, but not required to pass the option in explicitly
## Code changes

- Update README
- Update cli default
- Update patient source creation to default to true if the trustMetaProfile option is undefined

# Testing guidance

- `npm run check`
-  Run `npm run cli -- reports -m regression/bundles/coverage-script-bundles/measure/CMS1028/CMS1028-v314.json --patients-directory regression/bundles/coverage-script-bundles/measure/CMS1028/CMS1028-TestCases` (assumes you have CMS1028 in this location) ... previously errored, should now succeed

In deqm-test-server, 
- `npm uninstall fqm-execution`
- `npm install "https://github.com/projecttacoma/fqm-execution.git#trustmeta-default" --save`
- `npm run start`
- Use insomnia to post CMS1028-v314.json bundle and CMS1028FHIR-v0.1.000-RISKPass-RiskMultiplePregnancy.json test case bundle to http://localhost:3000/4_0_1/ 
- Use the front end or insomnia to evaluate the loaded patient against the loaded measure. Example preview: /Measure/a18d3293-bbba-42c7-b4e6-1e81150d91f1/$evaluate?periodStart=2025-01-01&periodEnd=2025-12-31&reportType=subject&subject=Patient/f22489f6-9150-405e-ad78-1ef7baf24d0f (should calculate without error)
