### PR TITLE
Allow supplemental-data and risk-adjustment-factor to calc separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,6 +455,7 @@ The options that we support for calculation are as follows:
 - `[calculateCoverageDetails]`<[boolean](#calculation-options)>: Include details on logic clause coverage. (default: `false`)
 - `[calculateHTML]`<[boolean](#calculation-options)>: Include HTML structure for highlighting (default: `true`)
 - `[calculateSDEs]`<[boolean](#calculation-options)>: Include Supplemental Data Elements (SDEs) in calculation (default: `true`)
+- `[calculateRAVs]`<[boolean](#calculation-options)>: Include Risk Adjustment Variables (RAVs) in calculation (default: `true`)
 - `[clearElmJsonsCache]`<[boolean](#calculation-options)>: If `true`, clears ELM JSON cache before running calculation (default: `false`)
 - `[disableHTMLOrdering]`<[boolean](#calculation-options)>: Disables custom ordering of CQL statements in HTML output (default: `false`)
 - `[enableDebugOutput]`<[boolean](#calculation-options)>: Enable debug output including CQL, ELM, results (default: `false`)
@@ -663,7 +664,7 @@ import { Calculator } from 'fqm-execution';
 const { results } = await Calculator.calculate(measureBundle, patientBundles, { trustMetaProfile: false });
 ```
 
-## Supplemental Data Elements
+## Supplemental Data Elements and Risk Adjustment Variables
 
 `fqm-execution` supports the calculation of Supplemental Data Elements (SDEs) defined on the `Measure` resource per the [conformance requirements](https://build.fhir.org/ig/HL7/cqf-measures/measure-conformance.html#supplemental-data-elements) in the FHIR Quality Measure Implementation Guide. To enable calculation of SDEs, ensure the `calculateSDEs` option is set to `true` during calculation:
 
@@ -675,7 +676,7 @@ import { Calculator } from 'fqm-execution';
 const { results } = await Calculator.calculate(measureBundle, patientBundles, { calculateSDEs: true });
 ```
 
-When enabled, the overall patient-level results will contain the raw results of the SDE expressions when executed against the patient:
+When enabled, the overall patient-level results will contain the raw results of the supplemental data elements where usage is marked as `supplemental-data`. If there is no usage marked, it is assumed to be supplemental data. Results are structured as follows:
 
 ```typescript
 [
@@ -686,6 +687,31 @@ When enabled, the overall patient-level results will contain the raw results of 
       {
         name: 'SDE Expression Name',
         rawResult: 'sde-raw-result'
+      }
+    ]
+  }
+];
+```
+Risk Adjustment Variables (RAVs) are similarly calculated when the `calculateRAVs` option is set to `true`:
+
+```typescript
+import { Calculator } from 'fqm-execution';
+
+// ...
+
+const { results } = await Calculator.calculate(measureBundle, patientBundles, { calculateRAVs: true });
+```
+When enabled, the overall patient-level results will contain the raw results of the supplemental data elements where usage is marked as `risk-adjustment-factor`. Results are structured as follows:
+
+```typescript
+[
+  {
+    patientId: 'patient-1',
+    // ...
+    riskAdjustment: [
+      {
+        name: 'RAV Expression Name',
+        rawResult: 'rav-raw-result'
       }
     ]
   }

--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -70,6 +70,7 @@ export async function calculate<T extends CalculationOptions>(
   // Ensure the CalculationOptions have sane defaults, only if they're not set
   options.calculateHTML = options.calculateHTML ?? true;
   options.calculateSDEs = options.calculateSDEs ?? true;
+  options.calculateRAVs = options.calculateRAVs ?? true;
   options.calculateClauseCoverage = options.calculateClauseCoverage ?? true;
   options.calculateClauseUncoverage = options.calculateClauseUncoverage ?? false;
   options.calculateCoverageDetails = options.calculateCoverageDetails ?? false;
@@ -196,7 +197,8 @@ export async function calculate<T extends CalculationOptions>(
           mainLibraryName,
           executedELM,
           group,
-          options.calculateSDEs ?? false
+          options.calculateSDEs ?? false,
+          options.calculateRAVs ?? false
         );
 
         // adds result information to the statement results and builds up clause results
@@ -247,9 +249,18 @@ export async function calculate<T extends CalculationOptions>(
         }
       });
 
-      // put raw SDE values onto execution result
-      if (options.calculateSDEs) {
-        patientExecutionResult.supplementalData = ResultsHelpers.getSDEValues(measure, patientStatementResults);
+      if (options.calculateSDEs || options.calculateRAVs) {
+        const sdeValues = ResultsHelpers.getSDEValues(measure, patientStatementResults);
+
+        // put raw SDE values onto execution result
+        if (options.calculateSDEs) {
+          patientExecutionResult.supplementalData = sdeValues.filter(sd => sd.usage === 'supplemental-data');
+        }
+
+        // put raw RAV values onto execution result
+        if (options.calculateRAVs) {
+          patientExecutionResult.riskAdjustment = sdeValues.filter(sd => sd.usage === 'risk-adjustment-factor');
+        }
       }
     });
 

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -20,6 +20,8 @@ export interface CalculationOptions {
   patientSource?: DataProvider;
   /** Include SDEs in calculation */
   calculateSDEs?: boolean;
+  /** Include RAVs in calculation */
+  calculateRAVs?: boolean;
   /** Include HTML structure for highlighting (defaults to logic highlighting) */
   calculateHTML?: boolean;
   /** Include HTML structure with clause coverage highlighting */
@@ -95,6 +97,8 @@ export interface ExecutionResult<T extends PopulationGroupResult> {
   componentResults?: ComponentResults[];
   /** SDE values, if specified for calculation */
   supplementalData?: SDEResult[];
+  /** RAV values, if specified for calculation */
+  riskAdjustment?: SDEResult[];
   /** Resources evaluated during execution */
   evaluatedResource?: fhir4.Resource[];
   /**

--- a/test/unit/ClauseResultsBuilder.test.ts
+++ b/test/unit/ClauseResultsBuilder.test.ts
@@ -150,6 +150,7 @@ describe('ClauseResultsBuilder', () => {
         mainLibraryId,
         [exampleELM],
         simpleMeasure.group[0],
+        true,
         true
       );
 
@@ -790,8 +791,8 @@ describe('ClauseResultsBuilder', () => {
   });
 
   describe('getSDEValues', () => {
-    test('should create proper SDE results', () => {
-      const sdeStatementResults: cql.StatementResults = { SDE: [] };
+    test('should create proper SDE and RAV results', () => {
+      const sdeStatementResults: cql.StatementResults = { SDE: [], RAV: [] };
       const result = ClauseResultsBuilder.getSDEValues(simpleMeasure, sdeStatementResults);
       const expectedResult = [
         {
@@ -801,6 +802,14 @@ describe('ClauseResultsBuilder', () => {
           id: 'sde-id',
           criteriaExpression: 'SDE',
           usage: 'supplemental-data'
+        },
+        {
+          name: 'rav-code',
+          rawResult: [],
+          pretty: '[]',
+          id: 'rav-id',
+          criteriaExpression: 'RAV',
+          usage: 'risk-adjustment-factor'
         }
       ];
       expect(result).toEqual(expectedResult);

--- a/test/unit/MeasureReportBuilder.addSDE.test.ts
+++ b/test/unit/MeasureReportBuilder.addSDE.test.ts
@@ -71,7 +71,8 @@ describe('MeasureReportBuilder Class', () => {
   beforeEach(() => {
     builder = new MeasureReportBuilder(simpleMeasure, {
       reportType: 'individual',
-      calculateSDEs: true
+      calculateSDEs: true,
+      calculateRAVs: true
     });
     executionResult = JSON.parse(JSON.stringify(executionResultsTemplate[0]));
   });
@@ -92,6 +93,7 @@ describe('MeasureReportBuilder Class', () => {
           usage: 'supplemental-data'
         }
       ];
+      executionResult.riskAdjustment = [];
       builder.addPatientResults(executionResult);
       const report = builder.getReport();
 
@@ -127,6 +129,7 @@ describe('MeasureReportBuilder Class', () => {
           usage: 'supplemental-data'
         }
       ];
+      executionResult.riskAdjustment = [];
       builder.addPatientResults(executionResult);
       const report = builder.getReport();
 
@@ -167,6 +170,7 @@ describe('MeasureReportBuilder Class', () => {
           usage: 'supplemental-data'
         }
       ];
+      executionResult.riskAdjustment = [];
       builder.addPatientResults(executionResult);
       const report = builder.getReport();
 
@@ -195,10 +199,52 @@ describe('MeasureReportBuilder Class', () => {
           usage: 'supplemental-data'
         }
       ];
+      executionResult.riskAdjustment = [];
       builder.addPatientResults(executionResult);
       const report = builder.getReport();
 
       expect(report.contained as fhir4.FhirResource[]).toHaveLength(0);
+    });
+
+    test('Should allow for RAV supplemental data Results to be list of FHIR coding', () => {
+      executionResult.riskAdjustment = [
+        {
+          name: 'rav-code',
+          rawResult: [
+            {
+              system: {
+                value: 'urn:oid:2.16.840.1.113883.6.238'
+              },
+              code: {
+                value: '2028-9'
+              },
+              display: {
+                value: 'Asian'
+              }
+            }
+          ],
+          id: 'rav-id',
+          criteriaExpression: 'RAV',
+          usage: 'risk-adjustment-factor'
+        }
+      ];
+      executionResult.supplementalData = [];
+      builder.addPatientResults(executionResult);
+      const report = builder.getReport();
+
+      expect(report.contained as fhir4.FhirResource[]).toHaveLength(1);
+
+      const sdeObserv = (report.contained as fhir4.FhirResource[])[0] as fhir4.Observation;
+      expect(sdeObserv.code.text).toBe('rav-code');
+      expect(sdeObserv.valueCodeableConcept).toEqual({
+        coding: [
+          {
+            system: 'urn:oid:2.16.840.1.113883.6.238',
+            code: '2028-9',
+            display: 'Asian'
+          }
+        ]
+      });
     });
   });
 });

--- a/test/unit/fixtures/measure/simple-measure.json
+++ b/test/unit/fixtures/measure/simple-measure.json
@@ -141,6 +141,26 @@
         "language": "text/cql",
         "expression": "SDE"
       }
+    },
+    {
+      "id": "rav-id",
+      "code": {
+        "text": "rav-code"
+      },
+      "usage": [
+        {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/measure-data-usage",
+              "code": "risk-adjustment-factor"
+            }
+          ]
+        }
+      ],
+      "criteria": {
+        "language": "text/cql",
+        "expression": "RAV"
+      }
     }
   ]
 }

--- a/test/unit/helpers/DetailedResultsHelpers.test.ts
+++ b/test/unit/helpers/DetailedResultsHelpers.test.ts
@@ -30,12 +30,13 @@ describe('pruneDetailedResults', () => {
     expect(pruneDetailedResults(ers)).toEqual(ers);
   });
 
-  test('should persist patientObject and supplementalData', () => {
+  test('should persist patientObject and supplementalData and riskAdjustment', () => {
     const ers: ExecutionResult<DetailedPopulationGroupResult>[] = [
       {
         patientId: 'test-patient',
         patientObject: {} as CQLPatient,
-        supplementalData: []
+        supplementalData: [],
+        riskAdjustment: []
       }
     ];
 


### PR DESCRIPTION
# Summary
Supplemental data and risk adjustment are now calculated separately using their respective `calculateSDEs` and `calculateRAVs` flag. This is intended to address the enhancement request here https://github.com/projecttacoma/fqm-execution/issues/336. 
Note that we did not previously allow a lack of `usage` (responded with error), and we are continuing to do that.

## New behavior
When the `calculateSDEs` flag is used, additional data with usage `supplemental-data` is calculated and added to the detailed results in the `supplementalData` array. In a calculated measure report, these elements will be added to the `contained` as Observations. When the `calculateRAVs` flag is used, additional data with usage `risk-adjustment-variable` is calculated and added to the detailed results in the `riskAdjustment` array. In a calculated measure report, these elements will be added to the `contained` as Observations.

## Code changes

- Updates to the Calculator types to include the `calculateRAVs` option and the `riskAdjustment` array on the detailedResults.
- Updates to `Calculator.ts` separately add `supplementalData` and `riskAdjustment` elements to the execution results.
- Updates to `ClauseResultsBuilder.ts` to separately populate the statement relevance map.
- Updates to `MeasureReportBuilder.ts` to separately add sdes and ravs to the `contained` in the measure report.
- Updates to README and tests

# Testing guidance

- `npm run check`
- We don't have a cli flag for this, but you can do a detailed CLI run against issue https://github.com/projecttacoma/fqm-execution/issues/336 and calculateRAVs will be default true. Make sure RAVs and SDEs are in the `riskAdjustment` and `supplementalData` part of the detailed results, respectively. `npm run cli -- detailed -m {measure bundle path} -p {patient bundle path} -o --debug --vs-api-key {key}`
- You can also a reports CLI run `npm run cli -- reports -m {measure bundle path} -p {patient bundle path} -o --debug --vs-api-key {key}` to make sure that they are added to the contained as observations.
