### PR TITLE
Fix Numex for ratio measures

### DIFF
--- a/src/calculation/DetailedResultsBuilder.ts
+++ b/src/calculation/DetailedResultsBuilder.ts
@@ -244,9 +244,9 @@ export function handleCVPopulationValues(populationResults: PopulationResult[]):
     // Short-circuit return since no more processing needs to be done if IPP is false with only one IPP
     return populationResultsHandled;
   }
-  // Cannot be in most populations if not in DENOM or MSRPOPL
+  // Cannot be in most populations if not in MSRPOPL
   if (hasResult(PopulationType.MSRPOPL, populationResults) && !getResult(PopulationType.MSRPOPL, populationResults)) {
-    // If there is a MSRPOPL, all observations point to it, so null them out
+    // If a result exists for the MSRPOPL, all observations point to it, so null them out
     const popResult = populationResults.find(result => result.populationType === PopulationType.OBSERV);
     if (popResult) {
       popResult.result = false;

--- a/src/calculation/DetailedResultsBuilder.ts
+++ b/src/calculation/DetailedResultsBuilder.ts
@@ -133,6 +133,8 @@ export function handlePopulationValues(
   measureScoringCode?: string
 ): PopulationResult[] {
   /* Population logic guidance: https://mmshub.cms.gov/sites/default/files/Measure-Calculations.pdf
+   * Follows population requirements in table 3-1 here: https://hl7.org/fhir/us/cqfmeasures/measure-conformance.html#data-criteria
+   *
    * For proportional: Setting values of populations if the correct populations are not set based on the following logic guidelines
    * Initial Population (IPP): The set of patients or episodes of care to be evaluated by the measure.
    * Denominator (DENOM): A subset of the IPP.
@@ -143,9 +145,28 @@ export function handlePopulationValues(
    * procedure, or other unit of measurement defined in the Denominator.
    * Numerator Exclusions (NUMEX): A subset of the Numerator that should not be considered for calculation.
    *
-   * Measure Population Exclusions (MSRPOPLEX): Identify that subset of the MSRPOPL that meet the MSRPOPLEX criteria.
+   * For Ratio: the NUMER and DENOM are independent, and there may be multiple IPPs.
+   *
+   * For CV:
+   * Measure Population Exclusions (MSRPOPL): A subset of the IPP for continuous variable measures.
+   * Measure Population Exclusions (MSRPOPLEX): A subset of the MSRPOPL that should not be considered for calculation.
    */
+
+  if (MeasureBundleHelpers.isRatioMeasure(group, measureScoringCode)) {
+    return handleRatioPopulationValues(populationResults, group);
+  } else if (MeasureBundleHelpers.isCVMeasure(group, measureScoringCode)) {
+    return handleCVPopulationValues(populationResults);
+  } else {
+    return handleStandardPopulationValues(populationResults, group);
+  }
+}
+
+export function handleRatioPopulationValues(
+  populationResults: PopulationResult[],
+  group: fhir4.MeasureGroup
+): PopulationResult[] {
   const populationResultsHandled = populationResults;
+
   // Cannot be in all populations if not in IPP.
   if (MeasureBundleHelpers.hasMultipleIPPs(group)) {
     const numerRelevantIPP = MeasureBundleHelpers.getRelevantIPPFromPopulation(group, PopulationType.NUMER);
@@ -168,6 +189,15 @@ export function handlePopulationValues(
         DetailedResultsHelpers.nullCriteriaRefMeasureObs(group, populationResults, PopulationType.DENOM);
       }
     }
+    if (
+      numerRelevantIPP &&
+      !getResult(PopulationType.IPP, populationResults, numerRelevantIPP.criteria.expression) &&
+      denomRelevantIPP &&
+      !getResult(PopulationType.IPP, populationResults, denomRelevantIPP.criteria.expression)
+    ) {
+      // Short-circuit return since no more processing needs to be done if both IPPs are false
+      return populationResultsHandled;
+    }
   } else if (!getResult(PopulationType.IPP, populationResults)) {
     populationResults.forEach(result => {
       if (result.populationType === PopulationType.OBSERV) {
@@ -180,83 +210,110 @@ export function handlePopulationValues(
     return populationResultsHandled;
   }
 
-  if (MeasureBundleHelpers.isRatioMeasure(group, measureScoringCode)) {
-    // ratio measurement treats denom and numer as independent
-    if (hasResult(PopulationType.DENOM, populationResults) && !getResult(PopulationType.DENOM, populationResults)) {
-      setResult(PopulationType.DENEX, false, populationResults);
-      setResult(PopulationType.DENEXCEP, false, populationResults);
-      DetailedResultsHelpers.nullCriteriaRefMeasureObs(group, populationResults, PopulationType.DENOM);
+  // ratio measurement treats denom and numer as independent
+  if (hasResult(PopulationType.DENOM, populationResults) && !getResult(PopulationType.DENOM, populationResults)) {
+    setResult(PopulationType.DENEX, false, populationResults);
+    setResult(PopulationType.DENEXCEP, false, populationResults);
+    DetailedResultsHelpers.nullCriteriaRefMeasureObs(group, populationResults, PopulationType.DENOM);
 
-      // Cannot be in the denominator exception if they are excluded from the denominator
-    } else if (getResult(PopulationType.DENEX, populationResults)) {
-      setResult(PopulationType.DENEXCEP, false, populationResults);
-    }
-
-    // Cannot be in the NUMEX if not in the NUMER
-    if (!getResult(PopulationType.NUMER, populationResults)) {
-      setResult(PopulationType.NUMEX, false, populationResults);
-      // Not in NUMER, so no need for NUMER observations
-      DetailedResultsHelpers.nullCriteriaRefMeasureObs(group, populationResults, PopulationType.NUMER);
-    }
-  } else if (MeasureBundleHelpers.isCVMeasure(group, measureScoringCode)) {
-    // Cannot be in most populations if not in DENOM or MSRPOPL
-    if (
-      (hasResult(PopulationType.MSRPOPL, populationResults) && !getResult(PopulationType.MSRPOPL, populationResults))
-    ) {
-      // If there is a MSRPOPL, all observations point to it, so null them out
-      const popResult = populationResults.find(result => result.populationType === PopulationType.OBSERV);
-      if (popResult) {
-        popResult.result = false;
-        popResult.observations = null;
-      }
-      setResult(PopulationType.MSRPOPLEX, false, populationResults);
-
-      // Cannot have observations if in the MSRPOPLEX
-    } else if (getResult(PopulationType.MSRPOPLEX, populationResults)) {
-      const popResult = populationResults.find(result => result.populationType === PopulationType.OBSERV);
-      if (popResult) {
-        popResult.result = false;
-        popResult.observations = null;
-      }
-    } 
-  } else {
-    // proportional handling
-    // Cannot be in most populations if not in DENOM or MSRPOPL
-    if (
-      hasResult(PopulationType.DENOM, populationResults) && !getResult(PopulationType.DENOM, populationResults)
-    ) {
-      setResult(PopulationType.DENEX, false, populationResults);
-      setResult(PopulationType.DENEXCEP, false, populationResults);
-      DetailedResultsHelpers.nullCriteriaRefMeasureObs(group, populationResults, PopulationType.DENOM);
-
-      // If the numer is influenced by the DENOM, false it out and its observations since we are not in the DENOM for this branch of logic
-      setResult(PopulationType.NUMER, false, populationResults);
-      setResult(PopulationType.NUMEX, false, populationResults);
-      // If there are not multiple IPPs, then NUMER depends on DENOM. We're not in the DENOM, so let's null out NUMER observations
-      DetailedResultsHelpers.nullCriteriaRefMeasureObs(group, populationResults, PopulationType.NUMER);
-
-      // Cannot be in the numerator if they are excluded from the denominator
-    } else if (getResult(PopulationType.DENEX, populationResults)) {
-      setResult(PopulationType.NUMER, false, populationResults);
-      setResult(PopulationType.NUMEX, false, populationResults);
-      // Since we can't be in the numerator, null out numerator observations
-      DetailedResultsHelpers.nullCriteriaRefMeasureObs(group, populationResults, PopulationType.NUMER);
-
-      // Cannot be in the denominator exception if in the denominator exclusion
-      setResult(PopulationType.DENEXCEP, false, populationResults);
-
-      // Cannot be in the NUMEX if not in the NUMER
-    } else if (!getResult(PopulationType.NUMER, populationResults)) {
-      setResult(PopulationType.NUMEX, false, populationResults);
-      // Not in NUMER, so no need for NUMER observations
-      DetailedResultsHelpers.nullCriteriaRefMeasureObs(group, populationResults, PopulationType.NUMER);
-
-      // Cannot be in the DENEXCEP if in the NUMER
-    } else if (getResult(PopulationType.NUMER, populationResults)) {
-      setResult(PopulationType.DENEXCEP, false, populationResults);
-    }
+    // Cannot be in the denominator exception if they are excluded from the denominator
+  } else if (getResult(PopulationType.DENEX, populationResults)) {
+    setResult(PopulationType.DENEXCEP, false, populationResults);
   }
 
+  // Cannot be in the NUMEX if not in the NUMER
+  if (!getResult(PopulationType.NUMER, populationResults)) {
+    setResult(PopulationType.NUMEX, false, populationResults);
+    // Not in NUMER, so no need for NUMER observations
+    DetailedResultsHelpers.nullCriteriaRefMeasureObs(group, populationResults, PopulationType.NUMER);
+  }
+
+  return populationResultsHandled;
+}
+
+export function handleCVPopulationValues(populationResults: PopulationResult[]): PopulationResult[] {
+  const populationResultsHandled = populationResults;
+  // Cannot be in all populations if not in IPP.
+  if (!getResult(PopulationType.IPP, populationResults)) {
+    populationResults.forEach(result => {
+      if (result.populationType === PopulationType.OBSERV) {
+        result.observations = null;
+      }
+      result.result = false;
+    });
+    // Short-circuit return since no more processing needs to be done if IPP is false with only one IPP
+    return populationResultsHandled;
+  }
+  // Cannot be in most populations if not in DENOM or MSRPOPL
+  if (hasResult(PopulationType.MSRPOPL, populationResults) && !getResult(PopulationType.MSRPOPL, populationResults)) {
+    // If there is a MSRPOPL, all observations point to it, so null them out
+    const popResult = populationResults.find(result => result.populationType === PopulationType.OBSERV);
+    if (popResult) {
+      popResult.result = false;
+      popResult.observations = null;
+    }
+    setResult(PopulationType.MSRPOPLEX, false, populationResults);
+
+    // Cannot have observations if in the MSRPOPLEX
+  } else if (getResult(PopulationType.MSRPOPLEX, populationResults)) {
+    const popResult = populationResults.find(result => result.populationType === PopulationType.OBSERV);
+    if (popResult) {
+      popResult.result = false;
+      popResult.observations = null;
+    }
+  }
+  return populationResultsHandled;
+}
+
+export function handleStandardPopulationValues(
+  populationResults: PopulationResult[],
+  group: fhir4.MeasureGroup
+): PopulationResult[] {
+  // proportional/cohort handling
+  const populationResultsHandled = populationResults;
+  // Cannot be in all populations if not in IPP.
+  if (!getResult(PopulationType.IPP, populationResults)) {
+    populationResults.forEach(result => {
+      if (result.populationType === PopulationType.OBSERV) {
+        result.observations = null;
+      }
+      result.result = false;
+    });
+    // Short-circuit return since no more processing needs to be done if IPP is false with only one IPP
+    return populationResultsHandled;
+  }
+  // Cannot be in most populations if not in DENOM or MSRPOPL
+  if (hasResult(PopulationType.DENOM, populationResults) && !getResult(PopulationType.DENOM, populationResults)) {
+    setResult(PopulationType.DENEX, false, populationResults);
+    setResult(PopulationType.DENEXCEP, false, populationResults);
+    DetailedResultsHelpers.nullCriteriaRefMeasureObs(group, populationResults, PopulationType.DENOM);
+
+    // If the numer is influenced by the DENOM, false it out and its observations since we are not in the DENOM for this branch of logic
+    setResult(PopulationType.NUMER, false, populationResults);
+    setResult(PopulationType.NUMEX, false, populationResults);
+    // If there are not multiple IPPs, then NUMER depends on DENOM. We're not in the DENOM, so let's null out NUMER observations
+    DetailedResultsHelpers.nullCriteriaRefMeasureObs(group, populationResults, PopulationType.NUMER);
+
+    // Cannot be in the numerator if they are excluded from the denominator
+  } else if (getResult(PopulationType.DENEX, populationResults)) {
+    setResult(PopulationType.NUMER, false, populationResults);
+    setResult(PopulationType.NUMEX, false, populationResults);
+    // Since we can't be in the numerator, null out numerator observations
+    DetailedResultsHelpers.nullCriteriaRefMeasureObs(group, populationResults, PopulationType.NUMER);
+
+    // Cannot be in the denominator exception if in the denominator exclusion
+    setResult(PopulationType.DENEXCEP, false, populationResults);
+
+    // Cannot be in the NUMEX if not in the NUMER
+  } else if (!getResult(PopulationType.NUMER, populationResults)) {
+    setResult(PopulationType.NUMEX, false, populationResults);
+    // Not in NUMER, so no need for NUMER observations
+    DetailedResultsHelpers.nullCriteriaRefMeasureObs(group, populationResults, PopulationType.NUMER);
+
+    // Cannot be in the DENEXCEP if in the NUMER
+  } else if (getResult(PopulationType.NUMER, populationResults)) {
+    setResult(PopulationType.DENEXCEP, false, populationResults);
+  }
   return populationResultsHandled;
 }
 

--- a/src/calculation/DetailedResultsBuilder.ts
+++ b/src/calculation/DetailedResultsBuilder.ts
@@ -148,7 +148,7 @@ export function handlePopulationValues(
    * For Ratio: the NUMER and DENOM are independent, and there may be multiple IPPs.
    *
    * For CV:
-   * Measure Population Exclusions (MSRPOPL): A subset of the IPP for continuous variable measures.
+   * Measure Population (MSRPOPL): A subset of the IPP for continuous variable measures.
    * Measure Population Exclusions (MSRPOPLEX): A subset of the MSRPOPL that should not be considered for calculation.
    */
 

--- a/src/helpers/MeasureBundleHelpers.ts
+++ b/src/helpers/MeasureBundleHelpers.ts
@@ -220,6 +220,16 @@ export function isRatioMeasure(group?: fhir4.MeasureGroup, measureScoringCode?: 
 }
 
 /**
+ * Checks if a given measure/measure group has scoring code 'cv.' (continuous variable)
+ * @param group measure group (used to extract scoring code if present on the group)
+ * @param measureScoringCode scoring code for measure (used if scoring code not provided at the group level)
+ * @returns true if scoring code is 'cv' for the group or at the measure root, false otherwise
+ */
+export function isCVMeasure(group?: fhir4.MeasureGroup, measureScoringCode?: string): boolean {
+  return getScoringCodeFromGroup(group) === MeasureScoreType.CV || measureScoringCode === MeasureScoreType.CV;
+}
+
+/**
  * Check if a measure is an episode of care measure or not. Look for the cqfm-populationBasis extension.
  * If it is found return true if valueCode is not 'boolean' otherwise return false.
  *

--- a/src/helpers/MeasureBundleHelpers.ts
+++ b/src/helpers/MeasureBundleHelpers.ts
@@ -220,7 +220,7 @@ export function isRatioMeasure(group?: fhir4.MeasureGroup, measureScoringCode?: 
 }
 
 /**
- * Checks if a given measure/measure group has scoring code 'cv.' (continuous variable)
+ * Checks if a given measure/measure group has scoring code 'cv' (continuous variable)
  * @param group measure group (used to extract scoring code if present on the group)
  * @param measureScoringCode scoring code for measure (used if scoring code not provided at the group level)
  * @returns true if scoring code is 'cv' for the group or at the measure root, false otherwise

--- a/test/unit/DetailedResultsBuilder.test.ts
+++ b/test/unit/DetailedResultsBuilder.test.ts
@@ -1112,6 +1112,26 @@ describe('DetailedResultsBuilder', () => {
       test('should false out NUMEX when NUMER is false for ratio measure', () => {
         const populationResults: PopulationResult[] = [
           { populationType: PopulationType.IPP, criteriaExpression: 'ipp', result: true },
+          { populationType: PopulationType.DENOM, criteriaExpression: 'denom', result: true },
+          { populationType: PopulationType.NUMER, criteriaExpression: 'numer', result: false },
+          { populationType: PopulationType.NUMEX, criteriaExpression: 'numex', result: true }
+        ];
+
+        const expectedHandledResults: PopulationResult[] = [
+          { populationType: PopulationType.IPP, criteriaExpression: 'ipp', result: true },
+          { populationType: PopulationType.DENOM, criteriaExpression: 'denom', result: true },
+          { populationType: PopulationType.NUMER, criteriaExpression: 'numer', result: false },
+          { populationType: PopulationType.NUMEX, criteriaExpression: 'numex', result: false }
+        ];
+
+        expect(
+          DetailedResultsBuilder.handlePopulationValues(populationResults, ratioMeasureGroup, MeasureScoreType.RATIO)
+        ).toEqual(expectedHandledResults);
+      });
+
+      test('should false out NUMEX when NUMER is false for ratio measure independent of DENOM value', () => {
+        const populationResults: PopulationResult[] = [
+          { populationType: PopulationType.IPP, criteriaExpression: 'ipp', result: true },
           { populationType: PopulationType.DENOM, criteriaExpression: 'denom', result: false },
           { populationType: PopulationType.NUMER, criteriaExpression: 'numer', result: false },
           { populationType: PopulationType.NUMEX, criteriaExpression: 'numex', result: true }

--- a/test/unit/DetailedResultsBuilder.test.ts
+++ b/test/unit/DetailedResultsBuilder.test.ts
@@ -997,7 +997,7 @@ describe('DetailedResultsBuilder', () => {
           DetailedResultsBuilder.handlePopulationValues(
             populationResults,
             groupWithMeasurePopulation,
-            MeasureScoreType.PROP
+            MeasureScoreType.CV
           )
         ).toEqual(expectedHandledResults);
       });
@@ -1082,7 +1082,7 @@ describe('DetailedResultsBuilder', () => {
           DetailedResultsBuilder.handlePopulationValues(
             populationResults,
             groupWithMeasurePopulation,
-            MeasureScoreType.PROP
+            MeasureScoreType.CV
           )
         ).toEqual(expectedHandledResults);
       });
@@ -1102,6 +1102,26 @@ describe('DetailedResultsBuilder', () => {
           { populationType: PopulationType.DENOM, criteriaExpression: 'denom', result: false },
           { populationType: PopulationType.NUMER, criteriaExpression: 'numer', result: true },
           { populationType: PopulationType.NUMEX, criteriaExpression: 'numex', result: true }
+        ];
+
+        expect(
+          DetailedResultsBuilder.handlePopulationValues(populationResults, ratioMeasureGroup, MeasureScoreType.RATIO)
+        ).toEqual(expectedHandledResults);
+      });
+
+      test('should false out NUMEX when NUMER is false for ratio measure', () => {
+        const populationResults: PopulationResult[] = [
+          { populationType: PopulationType.IPP, criteriaExpression: 'ipp', result: true },
+          { populationType: PopulationType.DENOM, criteriaExpression: 'denom', result: false },
+          { populationType: PopulationType.NUMER, criteriaExpression: 'numer', result: false },
+          { populationType: PopulationType.NUMEX, criteriaExpression: 'numex', result: true }
+        ];
+
+        const expectedHandledResults: PopulationResult[] = [
+          { populationType: PopulationType.IPP, criteriaExpression: 'ipp', result: true },
+          { populationType: PopulationType.DENOM, criteriaExpression: 'denom', result: false },
+          { populationType: PopulationType.NUMER, criteriaExpression: 'numer', result: false },
+          { populationType: PopulationType.NUMEX, criteriaExpression: 'numex', result: false }
         ];
 
         expect(


### PR DESCRIPTION
# Summary
Reorganizes population nulling logic by measure score calculation type to provide better readability and fix issue https://github.com/projecttacoma/fqm-execution/issues/337

## New behavior
When a ratio measure has a false numerator, its numex (numerator exclusions) should be false as well.

## Code changes

- In `DetailedResultsBuilder.ts`, update comments with logic source references and addition descriptions, reorganize population nulling logic by measure score type with a different function for each score type. Reduce out unnecessary logic and short cut logic as able based on the score type. This reorganization lets us especially makes sure `// Cannot be in the NUMEX if not in the NUMER` is enforced for all cases of relevance for ratio measures.
- Add convenience method `isCVMeasure` in `MeasureBundleHelpers.ts`
- Add and update tests in `DetailedResultsBuilder.test.ts`

# Testing guidance

- `npm run check`
-  With the test information provided in the issue linked above, `npm run cli -- detailed -m {path to CMS871FHIR-v0.2.001-FHIR.json} --patients-directory {path to CMS871FHIR-v0.2.001-FHIR6-TestCases } -o --debug --vs-api-key {api key}` - all `numerator-exclusion` in output should be false
- Run `./regression/run-regression.sh` to check regression tests!
