### PR TITLE
Sort by translator fix

### DIFF
--- a/src/helpers/ClauseResultsHelpers.ts
+++ b/src/helpers/ClauseResultsHelpers.ts
@@ -316,6 +316,9 @@ export function findAllLocalIdsInSort(
   emptyResultClauses.push({
     lib: libraryName,
     aliasLocalId: alId,
+    // In translator <= v3.3.2, a localId was added to the rootStatement of a sort clause
+    // Therefore, we need to map the sort by localId to the rootStatement.expression.localId
+    // if the rootStatement is an alias
     expressionLocalId: rootStatement.alias ? rootStatement.expression.localId : rootStatement.localId
   });
   return (() => {

--- a/test/unit/ClauseResultsHelper.test.ts
+++ b/test/unit/ClauseResultsHelper.test.ts
@@ -18,6 +18,19 @@ describe('ClauseResultsHelpers', () => {
       expect(localIds[24]).toBeDefined();
     });
 
+    test('finds localIds for sort by', () => {
+      const libraryElm: ELM = getJSONFixture('elm/SortBy.json');
+
+      const statementName = 'SortByTest';
+      const localIds = ClauseResultsHelpers.findLocalIdsInStatementByName(libraryElm, statementName);
+
+      // For the fixture loaded it is known that the rootStatement.expression.localId is 231
+      // 231 should be used as the sourceLocalId for the sort localId rather than
+      // the rootStatement.localId which is 238
+      expect(localIds[227]).toBeDefined();
+      expect(localIds[227]).toEqual({ localId: '227', sourceLocalId: '231' });
+    });
+
     test('finds localIds for an Equal comparison operator that is wrapped in a Not expression', () => {
       // ELM from test/unit/fixtures/cql/NotEqual.cql, but modified so that Equal has a localId of "100"
       // This will soon be the translator functionality, the Equal clause will get a localId (it currently

--- a/test/unit/fixtures/cql/SortBy.cql
+++ b/test/unit/fixtures/cql/SortBy.cql
@@ -1,0 +1,20 @@
+library SortClauseInQiCore version '0.0.000'
+
+using QICore version '4.1.1'
+
+include FHIRHelpers version '4.0.1'
+
+parameter "Measurement Period" Interval<DateTime>
+
+context Patient
+
+define "SortByTest":
+  ( ["Encounter"] Encounter
+      return all {
+        periodStart: start of Encounter.period
+      }
+      sort by periodStart
+  ).periodStart
+
+define "Encounter Presence":
+  [Encounter]

--- a/test/unit/fixtures/elm/SortBy.json
+++ b/test/unit/fixtures/elm/SortBy.json
@@ -1,0 +1,598 @@
+{
+  "library": {
+    "localId": "0",
+    "annotation": [
+      {
+        "translatorVersion": "3.18.0",
+        "translatorOptions": "EnableAnnotations,EnableLocators",
+        "signatureLevel": "None",
+        "type": "CqlToElmInfo"
+      },
+      {
+        "type": "Annotation",
+        "s": {
+          "r": "242",
+          "s": [
+            {
+              "value": [
+                "",
+                "library SortClauseInQiCore version '0.0.000'"
+              ]
+            }
+          ]
+        }
+      }
+    ],
+    "identifier": {
+      "id": "SortClauseInQiCore",
+      "version": "0.0.000"
+    },
+    "schemaIdentifier": {
+      "id": "urn:hl7-org:elm",
+      "version": "r1"
+    },
+    "usings": {
+      "def": [
+        {
+          "localId": "1",
+          "localIdentifier": "System",
+          "uri": "urn:hl7-org:elm-types:r1"
+        },
+        {
+          "localId": "206",
+          "locator": "3:1-3:28",
+          "localIdentifier": "QICore",
+          "uri": "http://hl7.org/fhir",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "206",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "using "
+                    ]
+                  },
+                  {
+                    "s": [
+                      {
+                        "value": [
+                          "QICore"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " version '4.1.1'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "includes": {
+      "def": [
+        {
+          "localId": "207",
+          "locator": "5:1-5:35",
+          "localIdentifier": "FHIRHelpers",
+          "path": "FHIRHelpers",
+          "version": "4.0.1",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "207",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "include "
+                    ]
+                  },
+                  {
+                    "s": [
+                      {
+                        "value": [
+                          "FHIRHelpers"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " version ",
+                      "'4.0.1'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "parameters": {
+      "def": [
+        {
+          "localId": "208",
+          "locator": "7:1-7:49",
+          "name": "Measurement Period",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "208",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "parameter ",
+                      "\"Measurement Period\"",
+                      " "
+                    ]
+                  },
+                  {
+                    "r": "209",
+                    "s": [
+                      {
+                        "value": [
+                          "Interval<"
+                        ]
+                      },
+                      {
+                        "r": "210",
+                        "s": [
+                          {
+                            "value": [
+                              "DateTime"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          ">"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "parameterTypeSpecifier": {
+            "localId": "209",
+            "locator": "7:32-7:49",
+            "type": "IntervalTypeSpecifier",
+            "pointType": {
+              "localId": "210",
+              "locator": "7:41-7:48",
+              "name": "{urn:hl7-org:elm-types:r1}DateTime",
+              "type": "NamedTypeSpecifier"
+            }
+          }
+        }
+      ]
+    },
+    "contexts": {
+      "def": [
+        {
+          "localId": "214",
+          "locator": "9:1-9:15",
+          "name": "Patient"
+        }
+      ]
+    },
+    "statements": {
+      "def": [
+        {
+          "localId": "212",
+          "locator": "9:1-9:15",
+          "name": "Patient",
+          "context": "Patient",
+          "expression": {
+            "localId": "213",
+            "type": "SingletonFrom",
+            "signature": [],
+            "operand": {
+              "localId": "211",
+              "locator": "9:1-9:15",
+              "dataType": "{http://hl7.org/fhir}Patient",
+              "templateId": "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient",
+              "type": "Retrieve",
+              "include": [],
+              "codeFilter": [],
+              "dateFilter": [],
+              "otherFilter": []
+            }
+          }
+        },
+        {
+          "localId": "216",
+          "locator": "11:1-17:15",
+          "name": "SortByTest",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "216",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"SortByTest\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "239",
+                    "s": [
+                      {
+                        "r": "231",
+                        "s": [
+                          {
+                            "value": [
+                              "( "
+                            ]
+                          },
+                          {
+                            "r": "231",
+                            "s": [
+                              {
+                                "s": [
+                                  {
+                                    "r": "217",
+                                    "s": [
+                                      {
+                                        "r": "218",
+                                        "s": [
+                                          {
+                                            "r": "218",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "[",
+                                                  "\"Encounter\"",
+                                                  "]"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          " ",
+                                          "Encounter"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  "\n      "
+                                ]
+                              },
+                              {
+                                "r": "219",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "return all "
+                                    ]
+                                  },
+                                  {
+                                    "r": "220",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "{\n        "
+                                        ]
+                                      },
+                                      {
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "periodStart",
+                                              ": "
+                                            ]
+                                          },
+                                          {
+                                            "r": "221",
+                                            "s": [
+                                              {
+                                                "value": [
+                                                  "start of "
+                                                ]
+                                              },
+                                              {
+                                                "r": "224",
+                                                "s": [
+                                                  {
+                                                    "r": "222",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "Encounter"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "value": [
+                                                      "."
+                                                    ]
+                                                  },
+                                                  {
+                                                    "r": "224",
+                                                    "s": [
+                                                      {
+                                                        "value": [
+                                                          "period"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "value": [
+                                          "\n      }"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "value": [
+                                  "\n      "
+                                ]
+                              },
+                              {
+                                "r": "227",
+                                "s": [
+                                  {
+                                    "value": [
+                                      "sort by "
+                                    ]
+                                  },
+                                  {
+                                    "r": "226",
+                                    "s": [
+                                      {
+                                        "r": "225",
+                                        "s": [
+                                          {
+                                            "value": [
+                                              "periodStart"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "value": [
+                              "\n  )"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "."
+                        ]
+                      },
+                      {
+                        "r": "239",
+                        "s": [
+                          {
+                            "value": [
+                              "periodStart"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "239",
+            "locator": "12:3-17:15",
+            "type": "Query",
+            "source": [
+              {
+                "localId": "238",
+                "alias": "$this",
+                "expression": {
+                  "localId": "231",
+                  "locator": "12:3-17:3",
+                  "type": "Query",
+                  "source": [
+                    {
+                      "localId": "217",
+                      "locator": "12:5-12:27",
+                      "alias": "Encounter",
+                      "expression": {
+                        "localId": "218",
+                        "locator": "12:5-12:17",
+                        "dataType": "{http://hl7.org/fhir}Encounter",
+                        "templateId": "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter",
+                        "type": "Retrieve",
+                        "include": [],
+                        "codeFilter": [],
+                        "dateFilter": [],
+                        "otherFilter": []
+                      }
+                    }
+                  ],
+                  "let": [],
+                  "relationship": [],
+                  "return": {
+                    "localId": "219",
+                    "locator": "13:7-15:7",
+                    "distinct": false,
+                    "expression": {
+                      "localId": "220",
+                      "locator": "13:18-15:7",
+                      "type": "Tuple",
+                      "element": [
+                        {
+                          "name": "periodStart",
+                          "value": {
+                            "localId": "221",
+                            "locator": "14:22-14:46",
+                            "type": "Start",
+                            "signature": [],
+                            "operand": {
+                              "localId": "224",
+                              "locator": "14:31-14:46",
+                              "name": "ToInterval",
+                              "libraryName": "FHIRHelpers",
+                              "type": "FunctionRef",
+                              "signature": [],
+                              "operand": [
+                                {
+                                  "localId": "223",
+                                  "path": "period",
+                                  "scope": "Encounter",
+                                  "type": "Property"
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "sort": {
+                    "localId": "227",
+                    "locator": "16:7-16:25",
+                    "by": [
+                      {
+                        "localId": "226",
+                        "locator": "16:15-16:25",
+                        "direction": "asc",
+                        "path": "periodStart",
+                        "type": "ByColumn"
+                      }
+                    ]
+                  }
+                }
+              }
+            ],
+            "let": [],
+            "relationship": [],
+            "where": {
+              "localId": "235",
+              "type": "Not",
+              "signature": [],
+              "operand": {
+                "localId": "234",
+                "type": "IsNull",
+                "signature": [],
+                "operand": {
+                  "localId": "233",
+                  "path": "periodStart",
+                  "type": "Property",
+                  "source": {
+                    "localId": "232",
+                    "name": "$this",
+                    "type": "AliasRef"
+                  }
+                }
+              }
+            },
+            "return": {
+              "localId": "240",
+              "distinct": false,
+              "expression": {
+                "localId": "237",
+                "path": "periodStart",
+                "type": "Property",
+                "source": {
+                  "localId": "236",
+                  "name": "$this",
+                  "type": "AliasRef"
+                }
+              }
+            }
+          }
+        },
+        {
+          "localId": "242",
+          "locator": "19:1-20:13",
+          "name": "Encounter Presence",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "s": {
+                "r": "242",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Encounter Presence\"",
+                      ":\n  "
+                    ]
+                  },
+                  {
+                    "r": "243",
+                    "s": [
+                      {
+                        "value": [
+                          "[",
+                          "Encounter",
+                          "]"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "localId": "243",
+            "locator": "20:3-20:13",
+            "dataType": "{http://hl7.org/fhir}Encounter",
+            "templateId": "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter",
+            "type": "Retrieve",
+            "include": [],
+            "codeFilter": [],
+            "dateFilter": [],
+            "otherFilter": []
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
# Summary
This PR fixes issue #328.

## New behavior
- In `findAllLocalIdsInSort()`, the function now assigns the `expressionLocalId` to the `rootStatement.expression.localId` if the `rootStatement.alias` exists. In translator version <= 3.3.2, the `rootStatement.localId` did not exist for aliases; therefore, there were no coverage highlighting gaps. Now that there is a `rootStatement.localId`, we need to add this logic so that the sort by clause localId is correctly mapped to its `rootStatement.expression.localId` for clause results.

## Code changes
- `src/helpers/ClauseResultsHelpers.ts` - if the rootStatement has an alias, assign the `rootStatement.expression.localId` to the `expressionLocalId`
- `test/unit/ClauseResultsHelpers.test.ts` - added a unit test for the sort by alias situation
- `test/unit/fixtures/cql/SortBy.cql` - added a cql file of the cql logic this change was made to support (for the unit test)
- `test/unit/fixtures/elm/SortBy.json` - added an elm json file that is a v3.18.0 translated version of `SortBy.cql` (for the unit test)

# Testing guidance
- `npm run check`
- Run coverage-regression and regular regression scripts
- Run `npm run detailed -m <path-to-SortClauseInQiCore> --patients-directory <path-to-SortClauseInQiCore-TestCases> --debug -o` (see fqm-execution issue for measure bundle and test cases)
- Make sure the highlighting is covered! 