### PR TITLE
Bump cql-exec-fhir to 2.1.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@types/fhir": "0.0.34",
         "axios": "^0.21.1",
         "commander": "^6.1.0",
-        "cql-exec-fhir": "^2.1.3",
+        "cql-exec-fhir": "^2.1.6",
         "cql-execution": "^3.3.0",
         "fhir-spec-tools": "^0.4.0",
         "handlebars": "^4.7.7",
@@ -2497,11 +2497,12 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "node_modules/cql-exec-fhir": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/cql-exec-fhir/-/cql-exec-fhir-2.1.4.tgz",
-      "integrity": "sha512-84Fs2zAyxq6q6mxv9PtLm5zWR+rWv2Gtl0Hgm833kxjzrJBnclMVa2LSY/eqX0/zWAuAsyOLVf+F9Zq89n5rfQ==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/cql-exec-fhir/-/cql-exec-fhir-2.1.6.tgz",
+      "integrity": "sha512-P2H5yp+PukoaOtIS7Hos+RXZfc8ExNaV9q1jR2bX8DrCCgVOplP7loSLHRer9UOaYJf68CzXPyy5f3KIoEKG+w==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "xml2js": "^0.5.0"
+        "xml2js": "^0.6.2"
       },
       "peerDependencies": {
         "cql-execution": ">=1.3.0 || ^3.0.0-beta"
@@ -6233,9 +6234,10 @@
       "dev": true
     },
     "node_modules/sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+      "license": "ISC"
     },
     "node_modules/semver": {
       "version": "7.7.1",
@@ -7012,9 +7014,10 @@
       }
     },
     "node_modules/xml2js": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
-      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "license": "MIT",
       "dependencies": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~11.0.0"
@@ -7027,6 +7030,7 @@
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
       "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       }
@@ -8969,11 +8973,11 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "cql-exec-fhir": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/cql-exec-fhir/-/cql-exec-fhir-2.1.4.tgz",
-      "integrity": "sha512-84Fs2zAyxq6q6mxv9PtLm5zWR+rWv2Gtl0Hgm833kxjzrJBnclMVa2LSY/eqX0/zWAuAsyOLVf+F9Zq89n5rfQ==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/cql-exec-fhir/-/cql-exec-fhir-2.1.6.tgz",
+      "integrity": "sha512-P2H5yp+PukoaOtIS7Hos+RXZfc8ExNaV9q1jR2bX8DrCCgVOplP7loSLHRer9UOaYJf68CzXPyy5f3KIoEKG+w==",
       "requires": {
-        "xml2js": "^0.5.0"
+        "xml2js": "^0.6.2"
       }
     },
     "cql-execution": {
@@ -11666,9 +11670,9 @@
       "dev": true
     },
     "sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg=="
     },
     "semver": {
       "version": "7.7.1",
@@ -12229,9 +12233,9 @@
       }
     },
     "xml2js": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
-      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
       "requires": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~11.0.0"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@types/fhir": "0.0.34",
     "axios": "^0.21.1",
     "commander": "^6.1.0",
-    "cql-exec-fhir": "^2.1.3",
+    "cql-exec-fhir": "^2.1.6",
     "cql-execution": "^3.3.0",
     "fhir-spec-tools": "^0.4.0",
     "handlebars": "^4.7.7",


### PR DESCRIPTION
# Summary

Updates cql-exec-fhir to 2.1.6. Resolving #352.

## New behavior
## Code changes
# Testing guidance
