### PR TITLE
Add base case to findAllLocalIdsInStatement

### DIFF
--- a/src/helpers/ClauseResultsHelpers.ts
+++ b/src/helpers/ClauseResultsHelpers.ts
@@ -283,7 +283,10 @@ export function findAllLocalIdsInStatement(
       }
     } else if (k === 'localId') {
       // else if the key is localId, push the value
-      localIds[v] = { localId: v };
+      // unless the localId already exists in the structure
+      if (!localIds[v]) {
+        localIds[v] = { localId: v };
+      }
     } else if (Array.isArray(v) || typeof v === 'object') {
       // if the value is an array or object, recurse
       findAllLocalIdsInStatement(v, libraryName, annotation, localIds, aliasMap, emptyResultClauses, statement);

--- a/test/unit/ClauseResultsHelper.test.ts
+++ b/test/unit/ClauseResultsHelper.test.ts
@@ -105,6 +105,14 @@ describe('ClauseResultsHelpers', () => {
       expect(localIds[18]).toEqual({ localId: '18', isFalsyLiteral: true });
     });
 
+    test('finds localIds for null literals and properly sets isFalsyLiteral to true with kotlin translator ELM', () => {
+      // ELM from test/unit/elm/queries/CaseStatement.cql translated with kotlin translator 4.0.0-SNAPSHOT
+      const libraryElm: ELM = getJSONFixture('elm/queries/CaseStatement-kotlin.json');
+      const localIds = ClauseResultsHelpers.findLocalIdsInStatementByName(libraryElm, 'Case');
+
+      expect(localIds[241]).toEqual({ localId: '241', isFalsyLiteral: true });
+    });
+
     test('finds localIds for false literals and properly sets isFalsyLiteral to true', () => {
       // ELM from test/unit/elm/queries/CaseStatement.cql
       const libraryElm: ELM = getJSONFixture('elm/queries/CaseStatement.json');

--- a/test/unit/fixtures/elm/queries/CaseStatement-kotlin.json
+++ b/test/unit/fixtures/elm/queries/CaseStatement-kotlin.json
@@ -1,0 +1,552 @@
+{
+  "library": {
+    "localId": "0",
+    "annotation": [
+      {
+        "type": "CqlToElmInfo",
+        "translatorVersion": "4.0.0-SNAPSHOT",
+        "translatorOptions": "EnableLocators,EnableAnnotations",
+        "signatureLevel": "None"
+      },
+      {
+        "type": "Annotation",
+        "t": [],
+        "s": {
+          "r": "223",
+          "s": [
+            {
+              "value": [
+                "",
+                "library Test"
+              ]
+            }
+          ]
+        }
+      }
+    ],
+    "identifier": {
+      "id": "Test"
+    },
+    "schemaIdentifier": {
+      "id": "urn:hl7-org:elm",
+      "version": "r1"
+    },
+    "usings": {
+      "def": [
+        {
+          "localId": "1",
+          "localIdentifier": "System",
+          "uri": "urn:hl7-org:elm-types:r1",
+          "annotation": []
+        },
+        {
+          "localId": "206",
+          "locator": "3:1-3:26",
+          "localIdentifier": "FHIR",
+          "uri": "http://hl7.org/fhir",
+          "version": "4.0.1",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "t": [],
+              "s": {
+                "r": "206",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "using "
+                    ]
+                  },
+                  {
+                    "s": [
+                      {
+                        "value": [
+                          "FHIR"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " version '4.0.1'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "includes": {
+      "def": [
+        {
+          "localId": "208",
+          "locator": "5:1-5:35",
+          "localIdentifier": "FHIRHelpers",
+          "path": "FHIRHelpers",
+          "version": "4.0.1",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "t": [],
+              "s": {
+                "r": "208",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "include "
+                    ]
+                  },
+                  {
+                    "s": [
+                      {
+                        "value": [
+                          "FHIRHelpers"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "value": [
+                      " version ",
+                      "'4.0.1'"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "contexts": {
+      "def": [
+        {
+          "localId": "213",
+          "locator": "7:1-7:15",
+          "name": "Patient",
+          "annotation": []
+        }
+      ]
+    },
+    "statements": {
+      "def": [
+        {
+          "localId": "211",
+          "locator": "7:1-7:15",
+          "name": "Patient",
+          "context": "Patient",
+          "annotation": [],
+          "expression": {
+            "type": "SingletonFrom",
+            "localId": "212",
+            "annotation": [],
+            "signature": [],
+            "operand": {
+              "type": "Retrieve",
+              "localId": "210",
+              "locator": "7:1-7:15",
+              "dataType": "{http://hl7.org/fhir}Patient",
+              "templateId": "http://hl7.org/fhir/StructureDefinition/Patient",
+              "annotation": [],
+              "include": [],
+              "codeFilter": [],
+              "dateFilter": [],
+              "otherFilter": []
+            }
+          }
+        },
+        {
+          "localId": "216",
+          "locator": "9:1-10:24",
+          "name": "First Observation",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "t": [],
+              "s": {
+                "r": "216",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"First Observation\"",
+                      ":\n    "
+                    ]
+                  },
+                  {
+                    "r": "220",
+                    "s": [
+                      {
+                        "value": [
+                          "First",
+                          "("
+                        ]
+                      },
+                      {
+                        "r": "217",
+                        "s": [
+                          {
+                            "value": [
+                              "[",
+                              "Observation",
+                              "]"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          ")"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "type": "First",
+            "localId": "220",
+            "locator": "10:5-10:24",
+            "annotation": [],
+            "signature": [],
+            "source": {
+              "type": "Retrieve",
+              "localId": "217",
+              "locator": "10:11-10:23",
+              "dataType": "{http://hl7.org/fhir}Observation",
+              "templateId": "http://hl7.org/fhir/StructureDefinition/Observation",
+              "annotation": [],
+              "include": [],
+              "codeFilter": [],
+              "dateFilter": [],
+              "otherFilter": []
+            }
+          }
+        },
+        {
+          "localId": "223",
+          "locator": "12:1-17:7",
+          "name": "Case",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [
+            {
+              "type": "Annotation",
+              "t": [],
+              "s": {
+                "r": "223",
+                "s": [
+                  {
+                    "value": [
+                      "",
+                      "define ",
+                      "\"Case\"",
+                      ":\n    "
+                    ]
+                  },
+                  {
+                    "r": "224",
+                    "s": [
+                      {
+                        "value": [
+                          "case \n        "
+                        ]
+                      },
+                      {
+                        "r": "225",
+                        "s": [
+                          {
+                            "value": [
+                              "when "
+                            ]
+                          },
+                          {
+                            "r": "226",
+                            "s": [
+                              {
+                                "r": "228",
+                                "s": [
+                                  {
+                                    "r": "227",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "\"First Observation\""
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "."
+                                    ]
+                                  },
+                                  {
+                                    "r": "228",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "value"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "r": "229",
+                                "value": [
+                                  " ",
+                                  ">",
+                                  " ",
+                                  "10"
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "r": "232",
+                            "value": [
+                              " then ",
+                              "true"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "value": [
+                          "\n        "
+                        ]
+                      },
+                      {
+                        "r": "233",
+                        "s": [
+                          {
+                            "value": [
+                              "when "
+                            ]
+                          },
+                          {
+                            "r": "234",
+                            "s": [
+                              {
+                                "r": "236",
+                                "s": [
+                                  {
+                                    "r": "235",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "\"First Observation\""
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "value": [
+                                      "."
+                                    ]
+                                  },
+                                  {
+                                    "r": "236",
+                                    "s": [
+                                      {
+                                        "value": [
+                                          "value"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "r": "237",
+                                "value": [
+                                  " ",
+                                  "<",
+                                  " ",
+                                  "10"
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "r": "240",
+                            "value": [
+                              " then ",
+                              "false"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "r": "241",
+                        "value": [
+                          "\n        else ",
+                          "null",
+                          "\n    end"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "expression": {
+            "type": "Case",
+            "localId": "224",
+            "locator": "13:5-17:7",
+            "annotation": [],
+            "caseItem": [
+              {
+                "localId": "225",
+                "locator": "14:9-14:53",
+                "annotation": [],
+                "when": {
+                  "type": "Greater",
+                  "localId": "226",
+                  "locator": "14:14-14:43",
+                  "annotation": [],
+                  "signature": [],
+                  "operand": [
+                    {
+                      "type": "FunctionRef",
+                      "localId": "231",
+                      "name": "ToInteger",
+                      "libraryName": "FHIRHelpers",
+                      "annotation": [],
+                      "signature": [],
+                      "operand": [
+                        {
+                          "type": "As",
+                          "localId": "230",
+                          "asType": "{http://hl7.org/fhir}integer",
+                          "annotation": [],
+                          "signature": [],
+                          "operand": {
+                            "type": "Property",
+                            "localId": "228",
+                            "locator": "14:14-14:38",
+                            "path": "value",
+                            "annotation": [],
+                            "source": {
+                              "type": "ExpressionRef",
+                              "localId": "227",
+                              "locator": "14:14-14:32",
+                              "name": "First Observation",
+                              "annotation": []
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Literal",
+                      "localId": "229",
+                      "locator": "14:42-14:43",
+                      "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                      "value": "10",
+                      "annotation": []
+                    }
+                  ]
+                },
+                "then": {
+                  "type": "Literal",
+                  "localId": "232",
+                  "locator": "14:50-14:53",
+                  "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+                  "value": "true",
+                  "annotation": []
+                }
+              },
+              {
+                "localId": "233",
+                "locator": "15:9-15:54",
+                "annotation": [],
+                "when": {
+                  "type": "Less",
+                  "localId": "234",
+                  "locator": "15:14-15:43",
+                  "annotation": [],
+                  "signature": [],
+                  "operand": [
+                    {
+                      "type": "FunctionRef",
+                      "localId": "239",
+                      "name": "ToInteger",
+                      "libraryName": "FHIRHelpers",
+                      "annotation": [],
+                      "signature": [],
+                      "operand": [
+                        {
+                          "type": "As",
+                          "localId": "238",
+                          "asType": "{http://hl7.org/fhir}integer",
+                          "annotation": [],
+                          "signature": [],
+                          "operand": {
+                            "type": "Property",
+                            "localId": "236",
+                            "locator": "15:14-15:38",
+                            "path": "value",
+                            "annotation": [],
+                            "source": {
+                              "type": "ExpressionRef",
+                              "localId": "235",
+                              "locator": "15:14-15:32",
+                              "name": "First Observation",
+                              "annotation": []
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Literal",
+                      "localId": "237",
+                      "locator": "15:42-15:43",
+                      "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                      "value": "10",
+                      "annotation": []
+                    }
+                  ]
+                },
+                "then": {
+                  "type": "Literal",
+                  "localId": "240",
+                  "locator": "15:50-15:54",
+                  "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+                  "value": "false",
+                  "annotation": []
+                }
+              }
+            ],
+            "else": {
+              "type": "As",
+              "localId": "242",
+              "asType": "{urn:hl7-org:elm-types:r1}Boolean",
+              "annotation": [],
+              "signature": [],
+              "operand": {
+                "type": "Null",
+                "localId": "241",
+                "locator": "16:14-16:17",
+                "annotation": []
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
# Summary
This PR adds a base case to the `findAllLocalIdsInStatement` function in `ClauseResultsHelpers.ts` so that the localId object doesn't get overwritten when the statement JSON structure changes (this is something that occurs with measures translated using the 4.0.0-SNAPSHOT kotlin translator.

## New behavior
The order of the attributes in the ELM JSON structure will no longer matter, localId values will no longer get overwritten and calculation coverage and highlighting should be the same for measures translated with the kotlin 4.0.0-SNAPSHOT translator.

## Code changes
- `ClauseResultsHelpers.ts` - checks that the localIds[v] does not exist before setting it.
- `ClauseResultsHelper.test.ts` - adds a unit test for ELM JSON translated with the 4.0.0-SNAPSHOT translator.
- `CaseStatemeent-kotlin.json` - `CaseStatement.cql` translated to ELM JSON with the 4.0.0-SNAPSHOT translator for the unit test.

# Testing guidance
- `npm run check`
- Test with CMS130 retranslated with the kotlin translator (I will provide file): `npm run cli -- detailed -m <path to CMS130> --patients-directory <path to patients directory> --debug -s 2026-01-01 -e 2026-12-31`, the coverage percent should be 100% 
- NOTE: I have a branch of fqm-execution (https://github.com/projecttacoma/fqm-execution/tree/kotlin-translator-unit-tests) that retranslates all of the CQL fixtures using the 4.0.0-SNAPSHOT kotlin translator and updates the unit tests accordingly. I didn't include them in this PR because we didn't want to yet, but we have that branch for the future. Also, those tests passed as expected after updates so I didn't observe anything else that needed to be updated.