### PR TITLE
Default value constants

### DIFF
--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -42,6 +42,18 @@ import { clearElmInfoCache } from '../helpers/elm/ELMInfoCache';
 import _, { omit } from 'lodash';
 import { ELM } from '../types/ELMTypes';
 import { getReportBuilder } from '../helpers/ReportBuilderFactory';
+import {
+  DEFAULT_BUILD_STATEMENT_LEVEL_HTML,
+  DEFAULT_CALCULATE_CLAUSE_COVERAGE,
+  DEFAULT_CALCULATE_CLAUSE_UNCOVERAGE,
+  DEFAULT_CALCULATE_COVERAGE_DETAILS,
+  DEFAULT_CALCULATE_HTML,
+  DEFAULT_CALCULATE_RAVS,
+  DEFAULT_CALCULATE_SDES,
+  DEFAULT_DISABLE_HTML_ORDERING,
+  DEFAULT_TRUST_META_PROFILE,
+  DEFAULT_VERBOSE_CALCULATION_RESULTS
+} from '../constants';
 
 /**
  * Calculate measure against a set of patients. Returning detailed results for each patient and population group.
@@ -59,7 +71,7 @@ export async function calculate<T extends CalculationOptions>(
   valueSetCache: fhir4.ValueSet[] = []
 ): Promise<CalculationOutput<T>> {
   // Ensure verboseCalculationResults defaults to true when not provided in options
-  options.verboseCalculationResults = options.verboseCalculationResults ?? true;
+  options.verboseCalculationResults = options.verboseCalculationResults ?? DEFAULT_VERBOSE_CALCULATION_RESULTS;
 
   const debugObject: DebugOutput | undefined = options.enableDebugOutput ? <DebugOutput>{} : undefined;
 
@@ -68,14 +80,14 @@ export async function calculate<T extends CalculationOptions>(
   }
 
   // Ensure the CalculationOptions have sane defaults, only if they're not set
-  options.calculateHTML = options.calculateHTML ?? true;
-  options.calculateSDEs = options.calculateSDEs ?? true;
-  options.calculateRAVs = options.calculateRAVs ?? true;
-  options.calculateClauseCoverage = options.calculateClauseCoverage ?? true;
-  options.calculateClauseUncoverage = options.calculateClauseUncoverage ?? false;
-  options.calculateCoverageDetails = options.calculateCoverageDetails ?? false;
-  options.disableHTMLOrdering = options.disableHTMLOrdering ?? false;
-  options.buildStatementLevelHTML = options.buildStatementLevelHTML ?? false;
+  options.calculateHTML = options.calculateHTML ?? DEFAULT_CALCULATE_HTML;
+  options.calculateSDEs = options.calculateSDEs ?? DEFAULT_CALCULATE_SDES;
+  options.calculateRAVs = options.calculateRAVs ?? DEFAULT_CALCULATE_RAVS;
+  options.calculateClauseCoverage = options.calculateClauseCoverage ?? DEFAULT_CALCULATE_CLAUSE_COVERAGE;
+  options.calculateClauseUncoverage = options.calculateClauseUncoverage ?? DEFAULT_CALCULATE_CLAUSE_UNCOVERAGE;
+  options.calculateCoverageDetails = options.calculateCoverageDetails ?? DEFAULT_CALCULATE_COVERAGE_DETAILS;
+  options.disableHTMLOrdering = options.disableHTMLOrdering ?? DEFAULT_DISABLE_HTML_ORDERING;
+  options.buildStatementLevelHTML = options.buildStatementLevelHTML ?? DEFAULT_BUILD_STATEMENT_LEVEL_HTML;
 
   const compositeMeasureResource = MeasureBundleHelpers.extractCompositeMeasure(measureBundle);
 
@@ -790,7 +802,9 @@ function resolvePatientSource(patientBundles: fhir4.Bundle[], options: Calculati
     if (patientBundles.filter(pb => pb.entry?.length).length === 0) {
       throw new UnexpectedResource('No entries found in passed patient bundles');
     }
-    const patientSource = PatientSource.FHIRv401({ requireProfileTagging: options.trustMetaProfile ?? true });
+    const patientSource = PatientSource.FHIRv401({
+      requireProfileTagging: options.trustMetaProfile ?? DEFAULT_TRUST_META_PROFILE
+    });
     patientSource.loadBundles(patientBundles);
     return patientSource;
   }

--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -52,7 +52,8 @@ import {
   DEFAULT_CALCULATE_SDES,
   DEFAULT_DISABLE_HTML_ORDERING,
   DEFAULT_TRUST_META_PROFILE,
-  DEFAULT_VERBOSE_CALCULATION_RESULTS
+  DEFAULT_VERBOSE_CALCULATION_RESULTS,
+  UNKNOWN_GROUP_ID
 } from '../constants';
 
 /**
@@ -195,7 +196,7 @@ export async function calculate<T extends CalculationOptions>(
         }
 
         // fix groupId to an auto incremented if it was not found.
-        if (detailedGroupResult.groupId === 'unknown') {
+        if (detailedGroupResult.groupId === UNKNOWN_GROUP_ID) {
           detailedGroupResult.groupId = `population-group-${i++}`;
         }
 
@@ -213,8 +214,8 @@ export async function calculate<T extends CalculationOptions>(
           mainLibraryName,
           executedELM,
           group,
-          options.calculateSDEs ?? false,
-          options.calculateRAVs ?? false
+          options.calculateSDEs ?? DEFAULT_CALCULATE_SDES,
+          options.calculateRAVs ?? DEFAULT_CALCULATE_RAVS
         );
 
         // adds result information to the statement results and builds up clause results

--- a/src/calculation/CompositeReportBuilder.ts
+++ b/src/calculation/CompositeReportBuilder.ts
@@ -11,6 +11,7 @@ import {
 import { CompositeScoreType, PopulationType } from '../types/Enums';
 import { v4 as uuidv4 } from 'uuid';
 import { AbstractMeasureReportBuilder } from './AbstractMeasureReportBuilder';
+import { DEFAULT_MEASURE_URL_FOR_REPORT } from '../constants';
 
 export type CompositeMeasureReport = fhir4.MeasureReport & {
   group: (fhir4.MeasureReportGroup & {
@@ -163,7 +164,7 @@ export class CompositeReportBuilder<T extends PopulationGroupResult> extends Abs
           start: this.options.measurementPeriodStart,
           end: this.options.measurementPeriodEnd
         },
-        measure: compositeMeasure.url ?? 'UnknownMeasure',
+        measure: compositeMeasure.url ?? DEFAULT_MEASURE_URL_FOR_REPORT,
         group: groupsForMeasureReport,
         evaluatedResource: []
       };
@@ -198,7 +199,7 @@ export class CompositeReportBuilder<T extends PopulationGroupResult> extends Abs
           start: this.options.measurementPeriodStart,
           end: this.options.measurementPeriodEnd
         },
-        measure: compositeMeasure.url ?? 'UnknownMeasure',
+        measure: compositeMeasure.url ?? DEFAULT_MEASURE_URL_FOR_REPORT,
         group: [
           {
             population: [

--- a/src/calculation/DetailedResultsBuilder.ts
+++ b/src/calculation/DetailedResultsBuilder.ts
@@ -5,6 +5,7 @@ import { getResult, hasResult, setResult, createOrSetResult } from './ClauseResu
 import { ELM, ELMStatement } from '../types/ELMTypes';
 import { PopulationType } from '../types/Enums';
 import * as cql from '../types/CQLTypes';
+import { UNKNOWN_GROUP_ID } from '../constants';
 
 /**
  * Create population values (aka results) for all populations in the population group using the results from the
@@ -110,7 +111,7 @@ export function createPopulationValues(
     }
   }
   const detailedResult: DetailedPopulationGroupResult = {
-    groupId: populationGroup.id || 'unknown',
+    groupId: populationGroup.id || UNKNOWN_GROUP_ID,
     statementResults: [],
     populationResults: populationResults,
     episodeResults: episodeResults,

--- a/src/calculation/MeasureReportBuilder.ts
+++ b/src/calculation/MeasureReportBuilder.ts
@@ -16,6 +16,7 @@ import { UnexpectedProperty, UnsupportedProperty } from '../types/errors/CustomE
 import { isDetailedResult } from '../helpers/DetailedResultsHelpers';
 import { AbstractMeasureReportBuilder } from './AbstractMeasureReportBuilder';
 import { MeasureReportGroupStratifier } from 'fhir/r4';
+import { DEFAULT_IS_INDIVIDUAL_REPORT, DEFAULT_MEASURE_URL_FOR_REPORT } from '../constants';
 
 export default class MeasureReportBuilder<T extends PopulationGroupResult> extends AbstractMeasureReportBuilder<T> {
   report: fhir4.MeasureReport;
@@ -41,7 +42,7 @@ export default class MeasureReportBuilder<T extends PopulationGroupResult> exten
     if (this.options.reportType) {
       this.isIndividual = this.options.reportType === 'individual';
     } else {
-      this.isIndividual = true;
+      this.isIndividual = DEFAULT_IS_INDIVIDUAL_REPORT;
     }
 
     // determine if we should be calculating SDE, TODO: Support SDEs for summary/subject-list.
@@ -69,7 +70,7 @@ export default class MeasureReportBuilder<T extends PopulationGroupResult> exten
     this.report.type = this.isIndividual ? 'individual' : 'summary';
 
     // measure url from measure bundle
-    this.report.measure = this.measure.url || 'UnknownMeasure'; // or some other default?
+    this.report.measure = this.measure.url || DEFAULT_MEASURE_URL_FOR_REPORT;
     this.report.contained = [];
 
     // add narrative if specified

--- a/src/calculation/MeasureReportBuilder.ts
+++ b/src/calculation/MeasureReportBuilder.ts
@@ -16,7 +16,7 @@ import { UnexpectedProperty, UnsupportedProperty } from '../types/errors/CustomE
 import { isDetailedResult } from '../helpers/DetailedResultsHelpers';
 import { AbstractMeasureReportBuilder } from './AbstractMeasureReportBuilder';
 import { MeasureReportGroupStratifier } from 'fhir/r4';
-import { DEFAULT_IS_INDIVIDUAL_REPORT, DEFAULT_MEASURE_URL_FOR_REPORT } from '../constants';
+import { DEFAULT_MEASURE_URL_FOR_REPORT } from '../constants';
 
 export default class MeasureReportBuilder<T extends PopulationGroupResult> extends AbstractMeasureReportBuilder<T> {
   report: fhir4.MeasureReport;
@@ -42,7 +42,7 @@ export default class MeasureReportBuilder<T extends PopulationGroupResult> exten
     if (this.options.reportType) {
       this.isIndividual = this.options.reportType === 'individual';
     } else {
-      this.isIndividual = DEFAULT_IS_INDIVIDUAL_REPORT;
+      this.isIndividual = true;
     }
 
     // determine if we should be calculating SDE, TODO: Support SDEs for summary/subject-list.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,6 +16,7 @@ import { addValueSetsToMeasureBundle } from './helpers/MeasureBundleHelpers';
 import { clearDebugFolder, dumpCQLs, dumpELMJSONs, dumpHTMLs, dumpObject, dumpVSMap } from './helpers/DebugHelpers';
 import { CalculationOptions, CalculatorFunctionOutput } from './types/Calculator';
 import { PatientSource } from 'cql-exec-fhir';
+import { DEFAULT_OUTPUT_FILE_NAME } from './constants';
 
 program.command('detailed', { isDefault: true }).action(() => {
   program.outputType = 'detailed';
@@ -303,8 +304,8 @@ populatePatientBundles().then(async patientBundles => {
 
     // --out-file flag specified but no file path provided
     if (program.outFile === true || (!program.outFile && program.outputType === 'valueSets')) {
-      // use output.json (default file path) since no file path was provided
-      writeToFile('output.json', JSON.stringify(result?.results, null, 2));
+      // use default output filename defined in constants.ts
+      writeToFile(DEFAULT_OUTPUT_FILE_NAME, JSON.stringify(result?.results, null, 2));
       // --out-file flag specified with a file path
     } else if (program.outFile) {
       writeToFile(program.outFile, JSON.stringify(result?.results, null, 2));

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,7 +16,7 @@ import { addValueSetsToMeasureBundle } from './helpers/MeasureBundleHelpers';
 import { clearDebugFolder, dumpCQLs, dumpELMJSONs, dumpHTMLs, dumpObject, dumpVSMap } from './helpers/DebugHelpers';
 import { CalculationOptions, CalculatorFunctionOutput } from './types/Calculator';
 import { PatientSource } from 'cql-exec-fhir';
-import { DEFAULT_OUTPUT_FILE_NAME } from './constants';
+import { DEFAULT_OUTPUT_FILE_NAME, DEFAULT_REPORT_TYPE } from './constants';
 
 program.command('detailed', { isDefault: true }).action(() => {
   program.outputType = 'detailed';
@@ -128,7 +128,7 @@ async function calc(
     calcOptions.calculateCoverageDetails = true;
     result = await calculate(measureBundle, patientBundles, calcOptions, valueSetCache);
   } else if (program.outputType === 'reports') {
-    calcOptions.reportType = program.reportType || 'individual';
+    calcOptions.reportType = program.reportType || DEFAULT_REPORT_TYPE;
     result = await calculateMeasureReports(measureBundle, patientBundles, calcOptions, valueSetCache);
   } else if (program.outputType === 'gaps') {
     result = await calculateGapsInCare(measureBundle, patientBundles, calcOptions, valueSetCache);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,30 @@
+/**
+ * Measurement Period Dates
+ */
+export const DEFAULT_MEASUREMENT_PERIOD_START = '2019-01-01';
+export const DEFAULT_MEASUREMENT_PERIOD_END = '2019-12-31';
+
+/**
+ * Default Calculation Options for Calculator.ts
+ */
+export const DEFAULT_VERBOSE_CALCULATION_RESULTS = true;
+export const DEFAULT_CALCULATE_HTML = true;
+export const DEFAULT_CALCULATE_SDES = true;
+export const DEFAULT_CALCULATE_RAVS = true;
+export const DEFAULT_CALCULATE_CLAUSE_COVERAGE = true;
+export const DEFAULT_CALCULATE_CLAUSE_UNCOVERAGE = false;
+export const DEFAULT_CALCULATE_COVERAGE_DETAILS = false;
+export const DEFAULT_DISABLE_HTML_ORDERING = false;
+export const DEFAULT_BUILD_STATEMENT_LEVEL_HTML = false;
+export const DEFAULT_TRUST_META_PROFILE = true;
+
+/**
+ * MeasureReportBuilder.ts / CompositeReportBuilder.ts Defaults
+ */
+export const DEFAULT_IS_INDIVIDUAL_REPORT = true;
+export const DEFAULT_MEASURE_URL_FOR_REPORT = 'UnknownMeasure';
+
+/**
+ * cli.ts Defaults
+ */
+export const DEFAULT_OUTPUT_FILE_NAME = 'output.json';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -27,3 +27,4 @@ export const DEFAULT_MEASURE_URL_FOR_REPORT = 'UnknownMeasure';
  * cli.ts Defaults
  */
 export const DEFAULT_OUTPUT_FILE_NAME = 'output.json';
+export const DEFAULT_REPORT_TYPE = 'individual';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -21,7 +21,6 @@ export const DEFAULT_TRUST_META_PROFILE = true;
 /**
  * MeasureReportBuilder.ts / CompositeReportBuilder.ts Defaults
  */
-export const DEFAULT_IS_INDIVIDUAL_REPORT = true;
 export const DEFAULT_MEASURE_URL_FOR_REPORT = 'UnknownMeasure';
 
 /**

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -22,6 +22,7 @@ export const DEFAULT_TRUST_META_PROFILE = true;
  * MeasureReportBuilder.ts / CompositeReportBuilder.ts Defaults
  */
 export const DEFAULT_MEASURE_URL_FOR_REPORT = 'UnknownMeasure';
+export const DEFAULT_CQL_NAME = 'unknown library';
 
 /**
  * cli.ts Defaults

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -29,3 +29,8 @@ export const DEFAULT_CQL_NAME = 'unknown library';
  */
 export const DEFAULT_OUTPUT_FILE_NAME = 'output.json';
 export const DEFAULT_REPORT_TYPE = 'individual';
+
+/**
+ * DetailedResultsBuilder.ts Defaults
+ */
+export const UNKNOWN_GROUP_ID = 'unknown';

--- a/src/execution/Execution.ts
+++ b/src/execution/Execution.ts
@@ -5,6 +5,7 @@ import { ValueSetResolver } from './ValueSetResolver';
 import { UnexpectedResource } from '../types/errors/CustomErrors';
 import { retrieveELMInfo } from '../helpers/elm/ELMInfoCache';
 import { MeasureWithLibrary } from '../helpers/MeasureBundleHelpers';
+import { DEFAULT_MEASUREMENT_PERIOD_END, DEFAULT_MEASUREMENT_PERIOD_START } from '../constants';
 
 export async function execute(
   measure: MeasureWithLibrary,
@@ -117,12 +118,12 @@ export function getCQLIntervalEndpoints(options: CalculationOptions) {
   if (options.measurementPeriodStart) {
     start = parseTimeStringAsUTC(options.measurementPeriodStart);
   } else {
-    start = new Date('2019-01-01');
+    start = new Date(DEFAULT_MEASUREMENT_PERIOD_START);
   }
   if (options.measurementPeriodEnd) {
     end = parseTimeStringAsUTC(options.measurementPeriodEnd);
   } else {
-    end = new Date('2019-12-31');
+    end = new Date(DEFAULT_MEASUREMENT_PERIOD_END);
   }
   const startCql = DateTime.fromJSDate(start, 0); // No timezone offset for start
   const endCql = DateTime.fromJSDate(end, 0); // No timezone offset for stop

--- a/src/helpers/MeasureBundleHelpers.ts
+++ b/src/helpers/MeasureBundleHelpers.ts
@@ -5,7 +5,7 @@ import { UnexpectedProperty, UnexpectedResource } from '../types/errors/CustomEr
 import { getMissingDependentValuesets } from '../execution/ValueSetHelper';
 import { ValueSetResolver } from '../execution/ValueSetResolver';
 import { ExtractedLibrary } from '../types/CQLTypes';
-import { DEFAULT_MEASUREMENT_PERIOD_START, DEFAULT_MEASUREMENT_PERIOD_END } from '../constants';
+import { DEFAULT_MEASUREMENT_PERIOD_START, DEFAULT_MEASUREMENT_PERIOD_END, DEFAULT_CQL_NAME } from '../constants';
 
 /**
  * The extension that defines the population basis. This is used to determine if the measure is an episode of care or
@@ -569,7 +569,7 @@ export function extractLibrariesFromBundle(
         if (elmEncoded.data) {
           const decoded = Buffer.from(elmEncoded.data, 'base64').toString('binary');
           const cql = {
-            name: library.name || library.id || 'unknown library',
+            name: library.name || library.id || DEFAULT_CQL_NAME,
             cql: decoded
           };
           cqls.push(cql);

--- a/src/helpers/MeasureBundleHelpers.ts
+++ b/src/helpers/MeasureBundleHelpers.ts
@@ -5,6 +5,7 @@ import { UnexpectedProperty, UnexpectedResource } from '../types/errors/CustomEr
 import { getMissingDependentValuesets } from '../execution/ValueSetHelper';
 import { ValueSetResolver } from '../execution/ValueSetResolver';
 import { ExtractedLibrary } from '../types/CQLTypes';
+import { DEFAULT_MEASUREMENT_PERIOD_START, DEFAULT_MEASUREMENT_PERIOD_END } from '../constants';
 
 /**
  * The extension that defines the population basis. This is used to determine if the measure is an episode of care or
@@ -448,8 +449,6 @@ export function codeableConceptToPopulationType(concept: fhir4.CodeableConcept |
 
 /**
  * Pulls the measurement period out of the provided FHIR Measure resource, assuming one is set.
- * NOTE: the default start/end values are also set in Execution.ts
- * so if this date is changed from 2019 it must also be changed there
  *
  * @param measure FHIR Measure resource
  * @returns {CalculationOptions} object with only the measurement period start/end fields filled out,
@@ -457,8 +456,8 @@ export function codeableConceptToPopulationType(concept: fhir4.CodeableConcept |
  */
 export function extractMeasurementPeriod(measure: fhir4.Measure): CalculationOptions {
   return {
-    measurementPeriodStart: measure.effectivePeriod?.start || '2019-01-01',
-    measurementPeriodEnd: measure.effectivePeriod?.end || '2019-12-31'
+    measurementPeriodStart: measure.effectivePeriod?.start || DEFAULT_MEASUREMENT_PERIOD_START,
+    measurementPeriodEnd: measure.effectivePeriod?.end || DEFAULT_MEASUREMENT_PERIOD_END
   };
 }
 


### PR DESCRIPTION
# Summary
This PR uses constants for default values in the code as suggested by @cmoesel in his [fqm-analysis](https://github.com/projecttacoma/fqm-execution/commit/a89e1d208d0527e4813bfc4420fd09542c017902).

## New behavior
There should be no new behavior.

## Code changes
- `src/calculation/Calculator.ts` - use default constants from constants.ts for calculation option defaults
- `src/calculation/CompositeReportBuilder.ts` - use constant for 'UnknownMeasure' default value
- `src/calculation/MeasureReportBuilder.ts` - use constant for isIndividual true default value
- `src/cli.ts` - use constant for 'output.json' default value
- `src/constants.ts` - file for constants
- `src/execution/Execution.ts` / `src/helpers/MeasureBundleHelpers.ts` - use constants for default measurement period start and end date strings

# Testing guidance
- Look through the project to see if there are any other default values that could be defined as constants for clarity.
- `npm run check` sanity check
- `npm run test:integration` sanity check