### PR TITLE
cql-execution 3.3.2 bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "commander": "^6.1.0",
         "core-js": "^3.49.0",
         "cql-exec-fhir": "^2.1.6",
-        "cql-execution": "^3.3.1",
+        "cql-execution": "^3.3.2",
         "fhir-spec-tools": "^0.4.0",
         "handlebars": "^4.7.7",
         "lodash": "^4.17.21",
@@ -2804,9 +2804,9 @@
       }
     },
     "node_modules/cql-execution": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.3.1.tgz",
-      "integrity": "sha512-YofAny7/AIJGGMi9LPDnyoenD+mgM2O4gTs/nc0G+Eqx2F0GnjHtDdAF9QoryOR6rSj+S207fEa+nMYs1Fg/3w==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.3.2.tgz",
+      "integrity": "sha512-ljV+vvsk8aefwJzQRDD66exTce+LJ8h6+tzWNwEI+0357ZFoVnAs+M5p6PdgWiSIuhg4ywl/H5l+N7WoQL+ogg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@lhncbc/ucum-lhc": "^7.1.6",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "commander": "^6.1.0",
     "core-js": "^3.49.0",
     "cql-exec-fhir": "^2.1.6",
-    "cql-execution": "^3.3.1",
+    "cql-execution": "^3.3.2",
     "fhir-spec-tools": "^0.4.0",
     "handlebars": "^4.7.7",
     "lodash": "^4.17.21",


### PR DESCRIPTION
# Summary
Updates to [cql-execution 3.3.2](https://github.com/cqframework/cql-execution/releases/tag/v3.3.2).

## New behavior
- There should be no new behavior except no more errors from cql-execution when pulled into browser-based applications.

## Code changes
- Upgrades cql-execution to 3.3.2.

# Testing guidance
- `npm run test:plus`
- Run regression tests