### PR TITLE
Expanded code queries

### DIFF
--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -55,6 +55,8 @@ import {
   DEFAULT_VERBOSE_CALCULATION_RESULTS,
   UNKNOWN_GROUP_ID
 } from '../constants';
+import { getMissingDependentValuesets } from '../execution/ValueSetHelper';
+import { ValueSetResolver } from '../execution/ValueSetResolver';
 
 /**
  * Calculate measure against a set of patients. Returning detailed results for each patient and population group.
@@ -695,8 +697,10 @@ export async function calculateLibraryDataRequirements(
  */
 export async function calculateDataRequirements(
   measureBundle: fhir4.Bundle,
-  options: CalculationOptions = {}
+  options: CalculationOptions = {},
+  valueSetCache: fhir4.ValueSet[] = []
 ): Promise<DRCalculationOutput> {
+  let dataRequirements: DRCalculationOutput;
   // Extract the library ELM, and the id of the root library, from the measure bundle
   const measure = MeasureBundleHelpers.extractMeasureFromBundle(measureBundle);
   const effectivePeriod = measure.effectivePeriod;
@@ -704,13 +708,64 @@ export async function calculateDataRequirements(
     measureBundle,
     measure
   );
-  const dataRequirements = await DataRequirementHelpers.getDataRequirements(
-    cqls,
-    rootLibIdentifier,
-    elmJSONs,
-    options,
-    effectivePeriod
-  );
+  console.log(options);
+  console.log(options.useExpandedCodeQueries);
+
+  if (options.useExpandedCodeQueries) {
+    const valueSets: fhir4.ValueSet[] = [];
+    const newCache: fhir4.ValueSet[] = [];
+
+    // Pass in existing cache to attempt any missing resolutions
+    const missingVS = getMissingDependentValuesets(measureBundle, options.useEffectiveDataRequirements, [
+      ...valueSetCache
+    ]);
+
+    if (missingVS.length > 0) {
+      if (!options.vsAPIKey || options.vsAPIKey.length == 0) {
+        throw new UnexpectedResource(
+          `Missing the following valuesets: ${missingVS.join(', ')}, and no API key was provided to resolve them`
+        );
+      }
+      const vsr = new ValueSetResolver(options.vsAPIKey || '');
+      const [expansions, errorMessages] = await vsr.getExpansionForValuesetUrls(missingVS);
+
+      if (errorMessages.length > 0) {
+        throw new Error(errorMessages.join('\n'));
+      }
+
+      valueSets.push(...expansions);
+
+      // Update cache to include new expansions
+      if (options.useValueSetCaching) {
+        newCache.push(...expansions);
+      }
+    }
+
+    measureBundle.entry?.forEach(e => {
+      if (e.resource?.resourceType === 'ValueSet') {
+        valueSets.push(e.resource as fhir4.ValueSet);
+      }
+    });
+
+    valueSets.push(...valueSetCache);
+
+    dataRequirements = await DataRequirementHelpers.getDataRequirements(
+      cqls,
+      rootLibIdentifier,
+      elmJSONs,
+      options,
+      effectivePeriod,
+      valueSets
+    );
+  } else {
+    dataRequirements = await DataRequirementHelpers.getDataRequirements(
+      cqls,
+      rootLibIdentifier,
+      elmJSONs,
+      options,
+      effectivePeriod
+    );
+  }
   dataRequirements.results.relatedArtifact = DataRequirementHelpers.getFlattenedRelatedArtifacts(measureBundle);
   return dataRequirements;
 }

--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -708,9 +708,6 @@ export async function calculateDataRequirements(
     measureBundle,
     measure
   );
-  console.log(options);
-  console.log(options.useExpandedCodeQueries);
-
   if (options.useExpandedCodeQueries) {
     const valueSets: fhir4.ValueSet[] = [];
     const newCache: fhir4.ValueSet[] = [];

--- a/src/calculation/Calculator.ts
+++ b/src/calculation/Calculator.ts
@@ -692,6 +692,7 @@ export async function calculateLibraryDataRequirements(
  *
  * @param measureBundle Bundle with a MeasureResource and all necessary data for execution.
  * @param options Options for calculation.
+ * @param valueSetCache Cache of existing valuesets
  *
  * @returns FHIR Library of data requirements
  */

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -92,6 +92,11 @@ program
     "Uses the Measure's contained effective-data-requirements Library to find dependent ValueSets",
     false
   )
+  .option(
+    '--expanded-code-queries',
+    'Uses expanded code-based queries (code=value1,value2,value3... for all codes in vs) for data requirements calculation',
+    false
+  )
   .parse(process.argv);
 
 function parseBundle(filePath: string): fhir4.Bundle {
@@ -133,7 +138,7 @@ async function calc(
   } else if (program.outputType === 'gaps') {
     result = await calculateGapsInCare(measureBundle, patientBundles, calcOptions, valueSetCache);
   } else if (program.outputType === 'dataRequirements') {
-    result = calculateDataRequirements(measureBundle, calcOptions);
+    result = calculateDataRequirements(measureBundle, calcOptions, valueSetCache);
   } else if (program.outputType === 'libraryDataRequirements') {
     // in this case, measureBundle should be a library bundle
     result = calculateLibraryDataRequirements(measureBundle, calcOptions);
@@ -225,7 +230,8 @@ const calcOptions: CalculationOptions = {
   trustMetaProfile: parseTrustMetaProfile(program.trustMetaProfile),
   rootLibRef: program.rootLibRef,
   focusedStatement: program.focusedStatement,
-  useEffectiveDataRequirements: program.vsEffectiveDr
+  useEffectiveDataRequirements: program.vsEffectiveDr,
+  useExpandedCodeQueries: program.expandedCodeQueries
 };
 
 // Override the measurement period start/end in the options only if the user specified them

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,6 +17,7 @@ export const DEFAULT_CALCULATE_COVERAGE_DETAILS = false;
 export const DEFAULT_DISABLE_HTML_ORDERING = false;
 export const DEFAULT_BUILD_STATEMENT_LEVEL_HTML = false;
 export const DEFAULT_TRUST_META_PROFILE = true;
+export const DEFAULT_EXPANDED_CODE_QUERY_CHUNK_SIZE = 50;
 
 /**
  * MeasureReportBuilder.ts / CompositeReportBuilder.ts Defaults

--- a/src/helpers/DataRequirementHelpers.ts
+++ b/src/helpers/DataRequirementHelpers.ts
@@ -30,7 +30,8 @@ export async function getDataRequirements(
   rootLibIdentifier: ELMIdentifier,
   elmJSONs: ELM[],
   options: CalculationOptions = {},
-  effectivePeriod?: fhir4.Period
+  effectivePeriod?: fhir4.Period,
+  valueSets?: fhir4.ValueSet[]
 ): Promise<DRCalculationOutput> {
   const rootLib = elmJSONs.find(ej => ej.library.identifier == rootLibIdentifier);
 
@@ -80,7 +81,7 @@ export async function getDataRequirements(
     allRetrieves.map(retrieve => {
       const dr = generateDataRequirement(retrieve);
       addFiltersToDataRequirement(retrieve, dr, withErrors);
-      addFhirQueryPatternToDataRequirements(dr);
+      addFhirQueryPatternToDataRequirements(dr, options, valueSets);
       return dr;
     }),
     JSON.stringify
@@ -105,8 +106,18 @@ export async function getDataRequirements(
  * contains the query string.
  * @param dataRequirement  Data requirement to add FHIR Query Pattern to
  */
-export function addFhirQueryPatternToDataRequirements(dataRequirement: fhir4.DataRequirement) {
-  const query: codeFilterQuery = createQueryFromCodeFilter(dataRequirement.codeFilter, dataRequirement.type);
+export function addFhirQueryPatternToDataRequirements(
+  dataRequirement: fhir4.DataRequirement,
+  options: CalculationOptions = {},
+  valueSets?: fhir4.ValueSet[]
+) {
+  // add option for expanded
+  const query: codeFilterQuery = createQueryFromCodeFilter(
+    dataRequirement.codeFilter,
+    dataRequirement.type,
+    options,
+    valueSets
+  );
 
   // Configure query string from query object
   let queryString = `/${query.endpoint}?`;
@@ -179,7 +190,12 @@ export function addFhirQueryPatternToDataRequirements(dataRequirement: fhir4.Dat
  * @returns query object consisting of an endpoint and params object containing the code/valueSet
  * and value pairs
  */
-function createQueryFromCodeFilter(codeFilterArray: fhir4.DataRequirementCodeFilter[] | undefined, type: string) {
+function createQueryFromCodeFilter(
+  codeFilterArray: fhir4.DataRequirementCodeFilter[] | undefined,
+  type: string,
+  options: CalculationOptions = {},
+  valueSets?: fhir4.ValueSet[]
+) {
   const query: codeFilterQuery = { endpoint: type, params: {} };
 
   codeFilterArray?.map(codeFilter => {
@@ -187,7 +203,17 @@ function createQueryFromCodeFilter(codeFilterArray: fhir4.DataRequirementCodeFil
     if (codeFilter?.code) {
       query.params[`${codeFilter.path}`] = codeFilter.code[0].code;
     } else if (codeFilter?.valueSet) {
-      query.params[`${codeFilter.path}:in`] = codeFilter.valueSet;
+      // if expanded is true, we want to use expanded code-based queries (code=value1,value2,value3... for all values in VS)
+      if (options.useExpandedCodeQueries === true) {
+        // Get all codes in valueset
+        const valueSet = valueSets?.find(vs => vs.url === codeFilter.valueSet);
+        const codes = valueSet?.expansion?.contains?.flatMap(c => (c.code !== undefined ? [c.code] : [])) ?? [];
+        console.log(codes);
+        query.params[`${codeFilter.path}`] = codes?.join(',');
+      } else {
+        // if expanded is false, use valueset queries (code:in=vs) - does this matter for type:in=vs too?
+        query.params[`${codeFilter.path}:in`] = codeFilter.valueSet;
+      }
     }
   });
 

--- a/src/helpers/DataRequirementHelpers.ts
+++ b/src/helpers/DataRequirementHelpers.ts
@@ -20,6 +20,7 @@ import { uniqBy } from 'lodash';
 import { DateTime, Interval } from 'cql-execution';
 import { parseTimeStringAsUTC } from '../execution/ValueSetHelper';
 import * as MeasureBundleHelpers from './MeasureBundleHelpers';
+import { DEFAULT_EXPANDED_CODE_QUERY_CHUNK_SIZE } from '../constants';
 const FHIR_QUERY_PATTERN_URL = 'http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-fhirQueryPattern';
 
 /**
@@ -111,8 +112,7 @@ export function addFhirQueryPatternToDataRequirements(
   options: CalculationOptions = {},
   valueSets?: fhir4.ValueSet[]
 ) {
-  // add option for expanded
-  const query: codeFilterQuery = createQueryFromCodeFilter(
+  const queries: codeFilterQuery[] = createQueriesFromCodeFilter(
     dataRequirement.codeFilter,
     dataRequirement.type,
     options,
@@ -120,10 +120,13 @@ export function addFhirQueryPatternToDataRequirements(
   );
 
   // Configure query string from query object
-  let queryString = `/${query.endpoint}?`;
-  for (const [key, value] of Object.entries(query.params)) {
-    queryString = queryString.concat(`${key}=${value}&`);
-  }
+  let queryStrings = queries.map(query => {
+    let queryString = `/${query.endpoint}?`;
+    for (const [key, value] of Object.entries(query.params)) {
+      queryString = queryString.concat(`${key}=${value}&`);
+    }
+    return queryString;
+  });
 
   if (dataRequirement.dateFilter) {
     dataRequirement.dateFilter.forEach(dateFilter => {
@@ -145,16 +148,27 @@ export function addFhirQueryPatternToDataRequirements(
 
       if (foundParams.length === 1) {
         if (dateFilter.valueDateTime) {
-          queryString = queryString.concat(`${foundParams[0].resource.code}=${dateFilter.valueDateTime}&`);
+          const valueDateTime = dateFilter.valueDateTime;
+          queryStrings = queryStrings.map(queryString =>
+            queryString.concat(`${foundParams[0].resource.code}=${valueDateTime}&`)
+          );
         } else if (dateFilter.valuePeriod) {
-          if (dateFilter.valuePeriod.start) {
-            queryString = queryString.concat(`${foundParams[0].resource.code}=ge${dateFilter.valuePeriod.start}&`);
+          const valuePeriod = dateFilter.valuePeriod;
+          if (valuePeriod.start) {
+            queryStrings = queryStrings.map(queryString =>
+              queryString.concat(`${foundParams[0].resource.code}=ge${valuePeriod.start}&`)
+            );
           }
-          if (dateFilter.valuePeriod.end) {
-            queryString = queryString.concat(`${foundParams[0].resource.code}=le${dateFilter.valuePeriod.end}&`);
+          if (valuePeriod.end) {
+            queryStrings = queryStrings.map(queryString =>
+              queryString.concat(`${foundParams[0].resource.code}=le${valuePeriod.end}&`)
+            );
           }
         } else if (dateFilter.valueDuration) {
-          queryString = queryString.concat(`${foundParams[0].resource.code}=${dateFilter.valueDuration.value}&`);
+          const valueDuration = dateFilter.valueDuration;
+          queryStrings = queryStrings.map(queryString =>
+            queryString.concat(`${foundParams[0].resource.code}=${valueDuration.value}&`)
+          );
         }
       } else if (foundParams.length > 1) {
         // assumed that multiple foundParams matches is an unexpected result
@@ -167,18 +181,20 @@ export function addFhirQueryPatternToDataRequirements(
   }
 
   // Create an extension for each way that exists for referencing the patient
-  (<any>patientSearchParameters)[dataRequirement.type]?.forEach((patientContext: string) => {
-    const fhirPathExtension: Extension = {
-      url: FHIR_QUERY_PATTERN_URL,
-      valueString: queryString.concat(`${patientContext}=Patient/{{context.patientId}}`)
-    };
+  queryStrings.forEach(queryString => {
+    (<any>patientSearchParameters)[dataRequirement.type]?.forEach((patientContext: string) => {
+      const fhirPathExtension: Extension = {
+        url: FHIR_QUERY_PATTERN_URL,
+        valueString: queryString.concat(`${patientContext}=Patient/{{context.patientId}}`)
+      };
 
-    // Add query to data requirement
-    if (dataRequirement.extension) {
-      dataRequirement.extension.push(fhirPathExtension);
-    } else {
-      dataRequirement.extension = [fhirPathExtension];
-    }
+      // Add query to data requirement
+      if (dataRequirement.extension) {
+        dataRequirement.extension.push(fhirPathExtension);
+      } else {
+        dataRequirement.extension = [fhirPathExtension];
+      }
+    });
   });
 }
 
@@ -190,34 +206,57 @@ export function addFhirQueryPatternToDataRequirements(
  * @returns query object consisting of an endpoint and params object containing the code/valueSet
  * and value pairs
  */
-function createQueryFromCodeFilter(
+function createQueriesFromCodeFilter(
   codeFilterArray: fhir4.DataRequirementCodeFilter[] | undefined,
   type: string,
   options: CalculationOptions = {},
   valueSets?: fhir4.ValueSet[]
 ) {
-  const query: codeFilterQuery = { endpoint: type, params: {} };
+  let queries: codeFilterQuery[] = [{ endpoint: type, params: {} }];
 
   codeFilterArray?.map(codeFilter => {
     // Prefer specific code filter over valueSet
     if (codeFilter?.code) {
-      query.params[`${codeFilter.path}`] = codeFilter.code[0].code;
+      queries = queries.map(query => ({
+        endpoint: query.endpoint,
+        params: { ...query.params, [`${codeFilter.path}`]: codeFilter.code?.[0].code }
+      }));
     } else if (codeFilter?.valueSet) {
       // if expanded is true, we want to use expanded code-based queries (code=value1,value2,value3... for all values in VS)
       if (options.useExpandedCodeQueries === true) {
         // Get all codes in valueset
         const valueSet = valueSets?.find(vs => vs.url === codeFilter.valueSet);
         const codes = valueSet?.expansion?.contains?.flatMap(c => (c.code !== undefined ? [c.code] : [])) ?? [];
-        console.log(codes);
-        query.params[`${codeFilter.path}`] = codes?.join(',');
+        const codeChunks = chunkArray(codes, DEFAULT_EXPANDED_CODE_QUERY_CHUNK_SIZE);
+        queries = queries.flatMap(query =>
+          codeChunks.map(codeChunk => ({
+            endpoint: query.endpoint,
+            params: { ...query.params, [`${codeFilter.path}`]: codeChunk.join(',') }
+          }))
+        );
       } else {
         // if expanded is false, use valueset queries (code:in=vs) - does this matter for type:in=vs too?
-        query.params[`${codeFilter.path}:in`] = codeFilter.valueSet;
+        queries = queries.map(query => ({
+          endpoint: query.endpoint,
+          params: { ...query.params, [`${codeFilter.path}:in`]: codeFilter.valueSet }
+        }));
       }
     }
   });
 
-  return query;
+  return queries;
+}
+
+function chunkArray<T>(values: T[], chunkSize: number): T[][] {
+  if (values.length === 0) {
+    return [[]];
+  }
+
+  const chunks: T[][] = [];
+  for (let startIndex = 0; startIndex < values.length; startIndex += chunkSize) {
+    chunks.push(values.slice(startIndex, startIndex + chunkSize));
+  }
+  return chunks;
 }
 
 /**

--- a/src/helpers/DataRequirementHelpers.ts
+++ b/src/helpers/DataRequirementHelpers.ts
@@ -106,6 +106,8 @@ export async function getDataRequirements(
  * the specified endpoint, and adds a fhirQueryPattern extension to the data requirement that
  * contains the query string.
  * @param dataRequirement  Data requirement to add FHIR Query Pattern to
+ * @param options Options for calculation.
+ * @param valueSetCache Cache of existing valuesets
  */
 export function addFhirQueryPatternToDataRequirements(
   dataRequirement: fhir4.DataRequirement,
@@ -203,6 +205,9 @@ export function addFhirQueryPatternToDataRequirements(
  * query object containing each code/valueSet and corresponding value.
  * @param codeFilterArray codeFilter array from DataRequirement
  * @param type dataRequirement type
+ * @param options Options for calculation
+ * @param valueSetCache Cache of existing valuesets
+ *
  * @returns query object consisting of an endpoint and params object containing the code/valueSet
  * and value pairs
  */

--- a/src/helpers/DataRequirementHelpers.ts
+++ b/src/helpers/DataRequirementHelpers.ts
@@ -219,13 +219,12 @@ function createQueriesFromCodeFilter(
 ) {
   let queries: codeFilterQuery[] = [{ endpoint: type, params: {} }];
 
-  codeFilterArray?.map(codeFilter => {
+  codeFilterArray?.forEach(codeFilter => {
     // Prefer specific code filter over valueSet
     if (codeFilter?.code) {
-      queries = queries.map(query => ({
-        endpoint: query.endpoint,
-        params: { ...query.params, [`${codeFilter.path}`]: codeFilter.code?.[0].code }
-      }));
+      queries.forEach(query => {
+        query.params[`${codeFilter.path}`] = codeFilter.code?.[0].code;
+      });
     } else if (codeFilter?.valueSet) {
       // if expanded is true, we want to use expanded code-based queries (code=value1,value2,value3... for all values in VS)
       if (options.useExpandedCodeQueries === true) {
@@ -241,10 +240,9 @@ function createQueriesFromCodeFilter(
         );
       } else {
         // if expanded is false, use valueset queries (code:in=vs) - does this matter for type:in=vs too?
-        queries = queries.map(query => ({
-          endpoint: query.endpoint,
-          params: { ...query.params, [`${codeFilter.path}:in`]: codeFilter.valueSet }
-        }));
+        queries.forEach(query => {
+          query.params[`${codeFilter.path}:in`] = codeFilter.valueSet;
+        });
       }
     }
   });

--- a/src/helpers/DataRequirementHelpers.ts
+++ b/src/helpers/DataRequirementHelpers.ts
@@ -104,10 +104,11 @@ export async function getDataRequirements(
 /**
  * Creates query string for the data requirement using either the code filter code or valueSet and
  * the specified endpoint, and adds a fhirQueryPattern extension to the data requirement that
- * contains the query string.
+ * contains the query string. Uses expanded valuesets to get all of the codes in a valueset if the
+ * useExpandedCodeQueries option is set to true.
  * @param dataRequirement  Data requirement to add FHIR Query Pattern to
  * @param options Options for calculation.
- * @param valueSetCache Cache of existing valuesets
+ * @param valueSets Cache of existing valuesets
  */
 export function addFhirQueryPatternToDataRequirements(
   dataRequirement: fhir4.DataRequirement,
@@ -202,11 +203,12 @@ export function addFhirQueryPatternToDataRequirements(
 
 /**
  * Parses each element of codeFilter array for either the code or valueSet key, and creates
- * query object containing each code/valueSet and corresponding value.
+ * query object containing each code/valueSet and corresponding value. Uses expanded valuesets
+ * to get all of the codes in a valueset if the useExpandedCodeQueries option is set to true.
  * @param codeFilterArray codeFilter array from DataRequirement
  * @param type dataRequirement type
  * @param options Options for calculation
- * @param valueSetCache Cache of existing valuesets
+ * @param valueSets Cache of existing valuesets
  *
  * @returns query object consisting of an endpoint and params object containing the code/valueSet
  * and value pairs

--- a/src/types/Calculator.ts
+++ b/src/types/Calculator.ts
@@ -59,6 +59,8 @@ export interface CalculationOptions {
   focusedStatement?: string;
   /** Uses the Measure's contained effective-data-requirements Library to find dependent ValueSets */
   useEffectiveDataRequirements?: boolean;
+  /** if true, uses expanded code-based queries in data requirements calculation */
+  useExpandedCodeQueries?: boolean;
 }
 
 /**

--- a/test/unit/DataRequirementHelpers.test.ts
+++ b/test/unit/DataRequirementHelpers.test.ts
@@ -3,6 +3,7 @@ import * as DataRequirementHelpers from '../../src/helpers/DataRequirementHelper
 import { CalculationOptions, DataTypeQuery } from '../../src/types/Calculator';
 import { DataRequirement } from 'fhir/r4';
 import { DateTime, Interval } from 'cql-execution';
+import { DEFAULT_EXPANDED_CODE_QUERY_CHUNK_SIZE } from '../../src/constants';
 import moment from 'moment';
 
 describe('DataRequirementHelpers', () => {
@@ -150,6 +151,44 @@ describe('DataRequirementHelpers', () => {
           '/Procedure?code=value1,value2,value3&status=completed&performer=Patient/{{context.patientId}}'
         );
       }
+    });
+
+    test('chunks expanded code queries when valueset has more codes than the default chunk size', () => {
+      const testDataReq: DataRequirement = {
+        type: 'Procedure',
+        codeFilter: [
+          {
+            path: 'code',
+            valueSet: 'http://example.com'
+          }
+        ]
+      };
+      const expandedCodes = Array.from({ length: DEFAULT_EXPANDED_CODE_QUERY_CHUNK_SIZE + 1 }, (_, index) => ({
+        code: `value${index + 1}`
+      }));
+      const valueSet = {
+        resourceType: 'ValueSet',
+        url: 'http://example.com',
+        expansion: {
+          contains: expandedCodes
+        }
+      } as fhir4.ValueSet;
+      const firstCodeChunk = expandedCodes
+        .slice(0, DEFAULT_EXPANDED_CODE_QUERY_CHUNK_SIZE)
+        .map(({ code }) => code)
+        .join(',');
+      const secondCodeChunk = expandedCodes[DEFAULT_EXPANDED_CODE_QUERY_CHUNK_SIZE].code;
+
+      DataRequirementHelpers.addFhirQueryPatternToDataRequirements(testDataReq, { useExpandedCodeQueries: true }, [
+        valueSet
+      ]);
+
+      expect(testDataReq.extension?.map(extension => extension.valueString)).toEqual([
+        `/Procedure?code=${firstCodeChunk}&patient=Patient/{{context.patientId}}`,
+        `/Procedure?code=${firstCodeChunk}&performer=Patient/{{context.patientId}}`,
+        `/Procedure?code=${secondCodeChunk}&patient=Patient/{{context.patientId}}`,
+        `/Procedure?code=${secondCodeChunk}&performer=Patient/{{context.patientId}}`
+      ]);
     });
 
     test('add fhirQueryPattern extension with CodeFilter codes and valueSets, and date filters', () => {

--- a/test/unit/DataRequirementHelpers.test.ts
+++ b/test/unit/DataRequirementHelpers.test.ts
@@ -110,6 +110,48 @@ describe('DataRequirementHelpers', () => {
       }
     });
 
+    test('uses expanded code queries when option is set to true', () => {
+      const testDataReq: DataRequirement = {
+        type: 'Procedure',
+        codeFilter: [
+          {
+            path: 'code',
+            valueSet: 'http://example.com'
+          },
+          {
+            path: 'status',
+            code: [
+              {
+                code: 'completed',
+                system: 'http://hl7.org/fhir/event-status'
+              }
+            ]
+          }
+        ]
+      };
+      const valueSet = {
+        resourceType: 'ValueSet',
+        url: 'http://example.com',
+        expansion: {
+          contains: [{ code: 'value1' }, { code: 'value2' }, { code: 'value3' }]
+        }
+      } as fhir4.ValueSet;
+
+      DataRequirementHelpers.addFhirQueryPatternToDataRequirements(testDataReq, { useExpandedCodeQueries: true }, [
+        valueSet
+      ]);
+
+      expect(testDataReq.extension?.length).toEqual(2);
+      if (testDataReq.extension) {
+        expect(testDataReq.extension[0].valueString).toEqual(
+          '/Procedure?code=value1,value2,value3&status=completed&patient=Patient/{{context.patientId}}'
+        );
+        expect(testDataReq.extension[1].valueString).toEqual(
+          '/Procedure?code=value1,value2,value3&status=completed&performer=Patient/{{context.patientId}}'
+        );
+      }
+    });
+
     test('add fhirQueryPattern extension with CodeFilter codes and valueSets, and date filters', () => {
       const testDataReqWithDateFilter: DataRequirement = {
         type: 'ServiceRequest',


### PR DESCRIPTION
# Summary
This PR adds an option to `calculateDataRequirements` to return expanded code-based queries (code=value1,value2,value3...for all values in vs) in the `cqfm-fhirQueryPattern` extension on data requirements instead of the valueset queries (code:in=vs).

## New behavior
Data Requirements calculation uses expanded code-based queries when the `useExpandedCodeQueries` option is set to `true`.

## Code changes
- `src/calculation/Calculator.ts` - passes `valueSetCache` into `calculateDataRequirements` now that we will have to resolve ValueSets if the `useExpandedCodeQueries` option is set to true
- `src/cli.ts` - add cli option for `useExpandedCodeQueries` and pass `valueSetCache` into `calculateDataRequirements`
- `src/constants.ts` - default for the code query chunk size. I could also make this a user option to input but I am not totally sure how necessary that is?
- `src/helpers/DataRequirementsHelpers.ts` - main changes, handles `useExpandedCodeQueries`
- `src/types/Calculator.ts` - adds Calculation option type
- `test/unit/DataRequirementsHelpers.test.ts` - associated unit test

# Testing guidance
- `npm run test:plus`
- `npm run cli -- dataRequirements <path-to-some-measure-bundle> --expanded-code-queries true -o` and inspect the output in `output.json`